### PR TITLE
fix(plugins): repoint runtime to narai-primitives

### DIFF
--- a/plugins/aws-agent/.claude-plugin/plugin.json
+++ b/plugins/aws-agent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-agent-plugin",
-  "version": "1.0.0",
-  "description": "Read-only AWS connector for Claude Code. Wraps @narai/aws-agent-connector. Lambda, RDS, S3, CloudWatch.",
+  "version": "1.1.0",
+  "description": "Read-only AWS connector for Claude Code. Built on narai-primitives (subpath ./aws). Lambda, RDS, S3, CloudWatch.",
   "author": "narai"
 }

--- a/plugins/aws-agent/README.md
+++ b/plugins/aws-agent/README.md
@@ -1,6 +1,6 @@
 # aws-agent-plugin
 
-Claude Code plugin that wraps [`@narai/aws-agent-connector`](https://www.npmjs.com/package/@narai/aws-agent-connector) as a read-only AWS skill and slash command.
+Claude Code plugin that wraps [`narai-primitives/aws`](https://www.npmjs.com/package/narai-primitives) as a read-only AWS skill and slash command.
 
 ## What it adds
 
@@ -21,7 +21,7 @@ hook in `hooks/hooks.json`:
    next session.
 
 After a successful install,
-`${CLAUDE_PLUGIN_DATA}/node_modules/@narai/aws-agent-connector/dist/cli.js`
+`${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/dist/connectors/aws/cli.js`
 exists and `bin/aws-agent` can exec it.
 
 ## Usage

--- a/plugins/aws-agent/bin/aws-agent
+++ b/plugins/aws-agent/bin/aws-agent
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# aws-agent — thin shim over @narai/aws-agent-connector.
+# aws-agent — thin shim over narai-primitives (CLI at dist/connectors/aws).
 #
 # The SessionStart hook in hooks/hooks.json installs the npm package into
 # ${CLAUDE_PLUGIN_DATA}/node_modules on first session. This shim exec's
@@ -11,7 +11,7 @@ if [ -z "${CLAUDE_PLUGIN_DATA:-}" ]; then
   exit 2
 fi
 
-CLI="${CLAUDE_PLUGIN_DATA}/node_modules/@narai/aws-agent-connector/dist/cli.js"
+CLI="${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/dist/connectors/aws/cli.js"
 
 if [ ! -f "$CLI" ]; then
   echo "aws-agent: connector CLI not found at $CLI" >&2

--- a/plugins/aws-agent/hooks/hooks.json
+++ b/plugins/aws-agent/hooks/hooks.json
@@ -9,11 +9,11 @@
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/plugin/hooks/reminder.mjs\" 2>/dev/null || true"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/reminder.mjs\" 2>/dev/null || true"
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/@narai/connector-toolkit/plugin-hooks/stale-summarize.mjs\" 2>/dev/null || true",
+            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/stale-summarize.mjs\" 2>/dev/null || true",
             "env": { "USAGE_CONNECTOR_NAME": "aws" }
           }
         ]
@@ -25,10 +25,10 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/@narai/connector-toolkit/plugin-hooks/usage-record.mjs\" 2>/dev/null || true",
+            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/usage-record.mjs\" 2>/dev/null || true",
             "env": {
               "USAGE_CONNECTOR_NAME": "aws",
-              "USAGE_BIN_HINT": "@narai/aws-agent-connector"
+              "USAGE_BIN_HINT": "narai-primitives/dist/connectors/aws"
             }
           }
         ]
@@ -39,7 +39,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/@narai/connector-toolkit/plugin-hooks/session-summary.mjs\" 2>/dev/null || true",
+            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/session-summary.mjs\" 2>/dev/null || true",
             "env": { "USAGE_CONNECTOR_NAME": "aws" }
           }
         ]

--- a/plugins/aws-agent/hooks/reminder.mjs
+++ b/plugins/aws-agent/hooks/reminder.mjs
@@ -5,7 +5,7 @@
 try {
   const data = process.env.CLAUDE_PLUGIN_DATA;
   if (!data) process.exit(0);
-  const toolkitEntry = `${data}/node_modules/@narai/connector-toolkit/dist/plugin/reminder.js`;
+  const toolkitEntry = `${data}/node_modules/narai-primitives/dist/toolkit/plugin/reminder.js`;
   const mod = await import(toolkitEntry);
   const decision = mod.evaluateNudge({ connectors: ["aws"] });
   if (decision.nudge) {

--- a/plugins/aws-agent/package.json
+++ b/plugins/aws-agent/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "description": "Runtime manifest for aws-agent-plugin. The SessionStart hook runs `npm install` on this manifest into ${CLAUDE_PLUGIN_DATA}.",
   "dependencies": {
-    "@narai/aws-agent-connector": "file:.."
+    "narai-primitives": "^2.0.0"
   }
 }

--- a/plugins/aws-agent/skills/aws-agent/SKILL.md
+++ b/plugins/aws-agent/skills/aws-agent/SKILL.md
@@ -11,7 +11,7 @@ context: fork
 # AWS Agent
 
 Answer the user's question by invoking the `aws-agent` binary exposed by
-this plugin. It delegates to `@narai/aws-agent-connector`, which speaks to
+this plugin. It delegates to `narai-primitives/aws`, which speaks to
 AWS via the read-only SDK v3 surface.
 
 ## Invocation

--- a/plugins/confluence-agent/.claude-plugin/plugin.json
+++ b/plugins/confluence-agent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "confluence-agent-plugin",
-  "version": "1.0.0",
-  "description": "Read-only Confluence connector for Claude Code. Wraps @narai/confluence-agent-connector.",
+  "version": "1.1.0",
+  "description": "Read-only Confluence connector for Claude Code. Built on narai-primitives (subpath ./confluence).",
   "author": "narai"
 }

--- a/plugins/confluence-agent/README.md
+++ b/plugins/confluence-agent/README.md
@@ -1,6 +1,6 @@
 # confluence-agent-plugin
 
-Claude Code plugin that wraps `@narai/confluence-agent-connector` as a read-only Confluence skill and slash command. Same layout as aws/gcp/notion-agent-plugin.
+Claude Code plugin that wraps `narai-primitives/confluence` as a read-only Confluence skill and slash command. Same layout as aws/gcp/notion-agent-plugin.
 
 ## Credentials
 

--- a/plugins/confluence-agent/bin/confluence-agent
+++ b/plugins/confluence-agent/bin/confluence-agent
@@ -6,7 +6,7 @@ if [ -z "${CLAUDE_PLUGIN_DATA:-}" ]; then
   exit 2
 fi
 
-CLI="${CLAUDE_PLUGIN_DATA}/node_modules/@narai/confluence-agent-connector/dist/cli.js"
+CLI="${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/dist/connectors/confluence/cli.js"
 
 if [ ! -f "$CLI" ]; then
   echo "confluence-agent: connector CLI not found at $CLI" >&2

--- a/plugins/confluence-agent/hooks/hooks.json
+++ b/plugins/confluence-agent/hooks/hooks.json
@@ -9,11 +9,11 @@
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/plugin/hooks/reminder.mjs\" 2>/dev/null || true"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/reminder.mjs\" 2>/dev/null || true"
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/@narai/connector-toolkit/plugin-hooks/stale-summarize.mjs\" 2>/dev/null || true",
+            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/stale-summarize.mjs\" 2>/dev/null || true",
             "env": { "USAGE_CONNECTOR_NAME": "confluence" }
           }
         ]
@@ -25,10 +25,10 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/@narai/connector-toolkit/plugin-hooks/usage-record.mjs\" 2>/dev/null || true",
+            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/usage-record.mjs\" 2>/dev/null || true",
             "env": {
               "USAGE_CONNECTOR_NAME": "confluence",
-              "USAGE_BIN_HINT": "@narai/confluence-agent-connector"
+              "USAGE_BIN_HINT": "narai-primitives/dist/connectors/confluence"
             }
           }
         ]
@@ -39,7 +39,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/@narai/connector-toolkit/plugin-hooks/session-summary.mjs\" 2>/dev/null || true",
+            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/session-summary.mjs\" 2>/dev/null || true",
             "env": { "USAGE_CONNECTOR_NAME": "confluence" }
           }
         ]

--- a/plugins/confluence-agent/hooks/reminder.mjs
+++ b/plugins/confluence-agent/hooks/reminder.mjs
@@ -14,7 +14,7 @@
 try {
   const data = process.env.CLAUDE_PLUGIN_DATA;
   if (!data) process.exit(0);
-  const toolkitEntry = `${data}/node_modules/@narai/connector-toolkit/dist/plugin/reminder.js`;
+  const toolkitEntry = `${data}/node_modules/narai-primitives/dist/toolkit/plugin/reminder.js`;
   const mod = await import(toolkitEntry);
   const decision = mod.evaluateNudge({ connectors: ["confluence"] });
   if (decision.nudge) {

--- a/plugins/confluence-agent/package.json
+++ b/plugins/confluence-agent/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@narai/confluence-agent-connector": "file:.."
+    "narai-primitives": "^2.0.0"
   }
 }

--- a/plugins/confluence-agent/skills/confluence-agent/SKILL.md
+++ b/plugins/confluence-agent/skills/confluence-agent/SKILL.md
@@ -11,7 +11,7 @@ context: fork
 
 Answer the user's question by invoking the `confluence-agent` binary
 exposed by this plugin. It delegates to
-`@narai/confluence-agent-connector` via Atlassian's Confluence REST v1.
+`narai-primitives/confluence` via Atlassian's Confluence REST v1.
 
 ## Invocation
 

--- a/plugins/db-agent/.claude-plugin/plugin.json
+++ b/plugins/db-agent/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "db-agent-plugin",
-  "version": "1.0.0",
-  "description": "Safe, read-only database query agent for Claude Code. Wraps @narai/db-agent-connector. Every statement passes the policy gate before any driver loads or any connection is opened.",
+  "version": "1.1.0",
+  "description": "Safe, read-only database query agent for Claude Code. Built on narai-primitives (subpath ./db). Every statement passes the policy gate before any driver loads or any connection is opened.",
   "author": {
     "name": "Narai Labs",
     "url": "https://github.com/narailabs"
   },
-  "homepage": "https://github.com/narailabs/db-agent-connector",
-  "repository": "https://github.com/narailabs/db-agent-connector",
+  "homepage": "https://github.com/narailabs/narai-primitives/tree/main/plugins/db-agent",
+  "repository": "https://github.com/narailabs/narai-primitives",
   "license": "MIT",
   "keywords": ["database", "sql", "postgresql", "mysql", "sqlite", "policy-gate"],
   "userConfig": {

--- a/plugins/db-agent/README.md
+++ b/plugins/db-agent/README.md
@@ -1,6 +1,6 @@
 # db-agent-plugin
 
-Claude Code plugin that wraps [`@narai/db-agent-connector`](https://www.npmjs.com/package/@narai/db-agent-connector).
+Claude Code plugin that wraps [`narai-primitives/db`](https://www.npmjs.com/package/narai-primitives).
 
 Exposes the `db-agent` skill. Every query passes through the policy gate before any driver loads or any connection opens. V2.0 vocab and defaults:
 
@@ -10,4 +10,4 @@ Exposes the `db-agent` skill. Every query passes through the policy gate before 
 - `admin` (CREATE/DROP/ALTER/RENAME) → returned as formatted SQL, never executed
 - `privilege` (GRANT/REVOKE) → hard-denied
 
-Install via Claude Code's plugin marketplace. The `SessionStart` hook installs `@narai/db-agent-connector` into the plugin's data directory on first use.
+Install via Claude Code's plugin marketplace. The `SessionStart` hook installs `narai-primitives` into the plugin's data directory on first use.

--- a/plugins/db-agent/bin/db-agent
+++ b/plugins/db-agent/bin/db-agent
@@ -6,7 +6,7 @@ if [ -z "${CLAUDE_PLUGIN_DATA:-}" ]; then
   exit 2
 fi
 
-CLI="${CLAUDE_PLUGIN_DATA}/node_modules/@narai/db-agent-connector/dist/cli.js"
+CLI="${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/dist/connectors/db/cli.js"
 
 if [ ! -f "$CLI" ]; then
   echo "db-agent: connector CLI not found at $CLI" >&2

--- a/plugins/db-agent/hooks/hooks.json
+++ b/plugins/db-agent/hooks/hooks.json
@@ -8,11 +8,11 @@
         },
         {
           "type": "command",
-          "command": "node \"${CLAUDE_PLUGIN_ROOT}/plugin/hooks/reminder.mjs\" 2>/dev/null || true"
+          "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/reminder.mjs\" 2>/dev/null || true"
         },
         {
           "type": "command",
-          "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/@narai/connector-toolkit/plugin-hooks/stale-summarize.mjs\" 2>/dev/null || true",
+          "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/stale-summarize.mjs\" 2>/dev/null || true",
           "env": { "USAGE_CONNECTOR_NAME": "db" }
         }
       ]
@@ -24,7 +24,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "node ${CLAUDE_PLUGIN_ROOT}/plugin/hooks/db-guard.mjs",
+          "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/db-guard.mjs",
           "env": {
             "DB_AGENT_GUARDRAILS": "${user_config.install_guardrails}"
           }
@@ -38,10 +38,10 @@
       "hooks": [
         {
           "type": "command",
-          "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/@narai/connector-toolkit/plugin-hooks/usage-record.mjs\" 2>/dev/null || true",
+          "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/usage-record.mjs\" 2>/dev/null || true",
           "env": {
             "USAGE_CONNECTOR_NAME": "db",
-            "USAGE_BIN_HINT": "@narai/db-agent-connector"
+            "USAGE_BIN_HINT": "narai-primitives/dist/connectors/db"
           }
         }
       ]
@@ -52,7 +52,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/@narai/connector-toolkit/plugin-hooks/session-summary.mjs\" 2>/dev/null || true",
+          "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/session-summary.mjs\" 2>/dev/null || true",
           "env": { "USAGE_CONNECTOR_NAME": "db" }
         }
       ]

--- a/plugins/db-agent/hooks/reminder.mjs
+++ b/plugins/db-agent/hooks/reminder.mjs
@@ -5,7 +5,7 @@
 try {
   const data = process.env.CLAUDE_PLUGIN_DATA;
   if (!data) process.exit(0);
-  const toolkitEntry = `${data}/node_modules/@narai/connector-toolkit/dist/plugin/reminder.js`;
+  const toolkitEntry = `${data}/node_modules/narai-primitives/dist/toolkit/plugin/reminder.js`;
   const mod = await import(toolkitEntry);
   const decision = mod.evaluateNudge({ connectors: ["db"] });
   if (decision.nudge) {

--- a/plugins/db-agent/package.json
+++ b/plugins/db-agent/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@narai/db-agent-connector": "file:.."
+    "narai-primitives": "^2.0.0"
   }
 }

--- a/plugins/db-agent/skills/db-agent/SKILL.md
+++ b/plugins/db-agent/skills/db-agent/SKILL.md
@@ -14,7 +14,7 @@ context: fork
 # Database Agent
 
 Answer the user's question by invoking the `db-agent` binary exposed by this
-plugin. It delegates to `@narai/db-agent-connector`, which enforces the
+plugin. It delegates to `narai-primitives/db`, which enforces the
 policy gate before any backend is touched.
 
 ## Invocation

--- a/plugins/gcp-agent/.claude-plugin/plugin.json
+++ b/plugins/gcp-agent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gcp-agent-plugin",
-  "version": "1.0.0",
-  "description": "Read-only GCP connector for Claude Code. Wraps @narai/gcp-agent-connector. Cloud Run, Cloud SQL, Pub/Sub, Cloud Logging.",
+  "version": "1.1.0",
+  "description": "Read-only GCP connector for Claude Code. Built on narai-primitives (subpath ./gcp). Cloud Run, Cloud SQL, Pub/Sub, Cloud Logging.",
   "author": "narai"
 }

--- a/plugins/gcp-agent/README.md
+++ b/plugins/gcp-agent/README.md
@@ -1,6 +1,6 @@
 # gcp-agent-plugin
 
-Claude Code plugin that wraps [`@narai/gcp-agent-connector`](https://www.npmjs.com/package/@narai/gcp-agent-connector) as a read-only GCP skill and slash command.
+Claude Code plugin that wraps [`narai-primitives/gcp`](https://www.npmjs.com/package/narai-primitives) as a read-only GCP skill and slash command.
 
 - **Skill** `gcp-agent` — automatic invocation for Cloud Run / Cloud SQL / Pub/Sub / Cloud Logging questions.
 - **Slash command** `/gcp-agent <action> <params-json>`.
@@ -15,7 +15,7 @@ On first `SessionStart` the hook in `hooks/hooks.json`:
 3. if the install fails, removes the stale copy so the hook re-runs next session.
 
 After install,
-`${CLAUDE_PLUGIN_DATA}/node_modules/@narai/gcp-agent-connector/dist/cli.js`
+`${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/dist/connectors/gcp/cli.js`
 exists and `bin/gcp-agent` exec's it.
 
 ## Credentials

--- a/plugins/gcp-agent/bin/gcp-agent
+++ b/plugins/gcp-agent/bin/gcp-agent
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# gcp-agent — thin shim over @narai/gcp-agent-connector.
+# gcp-agent — thin shim over narai-primitives (CLI at dist/connectors/gcp).
 set -euo pipefail
 
 if [ -z "${CLAUDE_PLUGIN_DATA:-}" ]; then
@@ -7,7 +7,7 @@ if [ -z "${CLAUDE_PLUGIN_DATA:-}" ]; then
   exit 2
 fi
 
-CLI="${CLAUDE_PLUGIN_DATA}/node_modules/@narai/gcp-agent-connector/dist/cli.js"
+CLI="${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/dist/connectors/gcp/cli.js"
 
 if [ ! -f "$CLI" ]; then
   echo "gcp-agent: connector CLI not found at $CLI" >&2

--- a/plugins/gcp-agent/hooks/hooks.json
+++ b/plugins/gcp-agent/hooks/hooks.json
@@ -9,11 +9,11 @@
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/plugin/hooks/reminder.mjs\" 2>/dev/null || true"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/reminder.mjs\" 2>/dev/null || true"
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/@narai/connector-toolkit/plugin-hooks/stale-summarize.mjs\" 2>/dev/null || true",
+            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/stale-summarize.mjs\" 2>/dev/null || true",
             "env": { "USAGE_CONNECTOR_NAME": "gcp" }
           }
         ]
@@ -25,10 +25,10 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/@narai/connector-toolkit/plugin-hooks/usage-record.mjs\" 2>/dev/null || true",
+            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/usage-record.mjs\" 2>/dev/null || true",
             "env": {
               "USAGE_CONNECTOR_NAME": "gcp",
-              "USAGE_BIN_HINT": "@narai/gcp-agent-connector"
+              "USAGE_BIN_HINT": "narai-primitives/dist/connectors/gcp"
             }
           }
         ]
@@ -39,7 +39,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/@narai/connector-toolkit/plugin-hooks/session-summary.mjs\" 2>/dev/null || true",
+            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/session-summary.mjs\" 2>/dev/null || true",
             "env": { "USAGE_CONNECTOR_NAME": "gcp" }
           }
         ]

--- a/plugins/gcp-agent/hooks/reminder.mjs
+++ b/plugins/gcp-agent/hooks/reminder.mjs
@@ -5,7 +5,7 @@
 try {
   const data = process.env.CLAUDE_PLUGIN_DATA;
   if (!data) process.exit(0);
-  const toolkitEntry = `${data}/node_modules/@narai/connector-toolkit/dist/plugin/reminder.js`;
+  const toolkitEntry = `${data}/node_modules/narai-primitives/dist/toolkit/plugin/reminder.js`;
   const mod = await import(toolkitEntry);
   const decision = mod.evaluateNudge({ connectors: ["gcp"] });
   if (decision.nudge) {

--- a/plugins/gcp-agent/package.json
+++ b/plugins/gcp-agent/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "description": "Runtime manifest for gcp-agent-plugin. The SessionStart hook runs `npm install` on this manifest into ${CLAUDE_PLUGIN_DATA}.",
   "dependencies": {
-    "@narai/gcp-agent-connector": "file:.."
+    "narai-primitives": "^2.0.0"
   }
 }

--- a/plugins/gcp-agent/skills/gcp-agent/SKILL.md
+++ b/plugins/gcp-agent/skills/gcp-agent/SKILL.md
@@ -10,7 +10,7 @@ context: fork
 # GCP Agent
 
 Answer the user's question by invoking the `gcp-agent` binary exposed by
-this plugin. It delegates to `@narai/gcp-agent-connector`, which speaks to
+this plugin. It delegates to `narai-primitives/gcp`, which speaks to
 GCP by shelling out to `gcloud` / `bq` with Application Default Credentials.
 
 ## Invocation

--- a/plugins/github-agent/.claude-plugin/plugin.json
+++ b/plugins/github-agent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-agent-plugin",
-  "version": "1.0.0",
-  "description": "Read-only GitHub connector for Claude Code. Wraps @narai/github-agent-connector.",
+  "version": "1.1.0",
+  "description": "Read-only GitHub connector for Claude Code. Built on narai-primitives (subpath ./github).",
   "author": "narai"
 }

--- a/plugins/github-agent/README.md
+++ b/plugins/github-agent/README.md
@@ -1,6 +1,6 @@
 # github-agent-plugin
 
-Claude Code plugin wrapping `@narai/github-agent-connector`. Same layout as the other platform plugins.
+Claude Code plugin wrapping `narai-primitives/github`. Same layout as the other platform plugins.
 
 ## Credentials
 

--- a/plugins/github-agent/bin/github-agent
+++ b/plugins/github-agent/bin/github-agent
@@ -6,7 +6,7 @@ if [ -z "${CLAUDE_PLUGIN_DATA:-}" ]; then
   exit 2
 fi
 
-CLI="${CLAUDE_PLUGIN_DATA}/node_modules/@narai/github-agent-connector/dist/cli.js"
+CLI="${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/dist/connectors/github/cli.js"
 
 if [ ! -f "$CLI" ]; then
   echo "github-agent: connector CLI not found at $CLI" >&2

--- a/plugins/github-agent/hooks/hooks.json
+++ b/plugins/github-agent/hooks/hooks.json
@@ -9,11 +9,11 @@
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/plugin/hooks/reminder.mjs\" 2>/dev/null || true"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/reminder.mjs\" 2>/dev/null || true"
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/@narai/connector-toolkit/plugin-hooks/stale-summarize.mjs\" 2>/dev/null || true",
+            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/stale-summarize.mjs\" 2>/dev/null || true",
             "env": { "USAGE_CONNECTOR_NAME": "github" }
           }
         ]
@@ -25,10 +25,10 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/@narai/connector-toolkit/plugin-hooks/usage-record.mjs\" 2>/dev/null || true",
+            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/usage-record.mjs\" 2>/dev/null || true",
             "env": {
               "USAGE_CONNECTOR_NAME": "github",
-              "USAGE_BIN_HINT": "@narai/github-agent-connector"
+              "USAGE_BIN_HINT": "narai-primitives/dist/connectors/github"
             }
           }
         ]
@@ -39,7 +39,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/@narai/connector-toolkit/plugin-hooks/session-summary.mjs\" 2>/dev/null || true",
+            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/session-summary.mjs\" 2>/dev/null || true",
             "env": { "USAGE_CONNECTOR_NAME": "github" }
           }
         ]

--- a/plugins/github-agent/hooks/reminder.mjs
+++ b/plugins/github-agent/hooks/reminder.mjs
@@ -5,7 +5,7 @@
 try {
   const data = process.env.CLAUDE_PLUGIN_DATA;
   if (!data) process.exit(0);
-  const toolkitEntry = `${data}/node_modules/@narai/connector-toolkit/dist/plugin/reminder.js`;
+  const toolkitEntry = `${data}/node_modules/narai-primitives/dist/toolkit/plugin/reminder.js`;
   const mod = await import(toolkitEntry);
   const decision = mod.evaluateNudge({ connectors: ["github"] });
   if (decision.nudge) {

--- a/plugins/github-agent/package.json
+++ b/plugins/github-agent/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@narai/github-agent-connector": "file:.."
+    "narai-primitives": "^2.0.0"
   }
 }

--- a/plugins/github-agent/skills/github-agent/SKILL.md
+++ b/plugins/github-agent/skills/github-agent/SKILL.md
@@ -11,7 +11,7 @@ context: fork
 
 Answer the user's question by invoking the `github-agent` binary
 exposed by this plugin. It delegates to
-`@narai/github-agent-connector` via GitHub's REST v3 + GraphQL APIs.
+`narai-primitives/github` via GitHub's REST v3 + GraphQL APIs.
 
 ## Invocation
 

--- a/plugins/jira-agent/.claude-plugin/plugin.json
+++ b/plugins/jira-agent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-agent-plugin",
-  "version": "1.0.0",
-  "description": "Read-only Jira connector for Claude Code. Wraps @narai/jira-agent-connector.",
+  "version": "1.1.0",
+  "description": "Read-only Jira connector for Claude Code. Built on narai-primitives (subpath ./jira).",
   "author": "narai"
 }

--- a/plugins/jira-agent/README.md
+++ b/plugins/jira-agent/README.md
@@ -1,6 +1,6 @@
 # jira-agent-plugin
 
-Claude Code plugin wrapping `@narai/jira-agent-connector`. Same layout as the other platform plugins.
+Claude Code plugin wrapping `narai-primitives/jira`. Same layout as the other platform plugins.
 
 ## Credentials
 

--- a/plugins/jira-agent/bin/jira-agent
+++ b/plugins/jira-agent/bin/jira-agent
@@ -6,7 +6,7 @@ if [ -z "${CLAUDE_PLUGIN_DATA:-}" ]; then
   exit 2
 fi
 
-CLI="${CLAUDE_PLUGIN_DATA}/node_modules/@narai/jira-agent-connector/dist/cli.js"
+CLI="${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/dist/connectors/jira/cli.js"
 
 if [ ! -f "$CLI" ]; then
   echo "jira-agent: connector CLI not found at $CLI" >&2

--- a/plugins/jira-agent/hooks/hooks.json
+++ b/plugins/jira-agent/hooks/hooks.json
@@ -9,11 +9,11 @@
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/plugin/hooks/reminder.mjs\" 2>/dev/null || true"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/reminder.mjs\" 2>/dev/null || true"
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/@narai/connector-toolkit/plugin-hooks/stale-summarize.mjs\" 2>/dev/null || true",
+            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/stale-summarize.mjs\" 2>/dev/null || true",
             "env": { "USAGE_CONNECTOR_NAME": "jira" }
           }
         ]
@@ -25,10 +25,10 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/@narai/connector-toolkit/plugin-hooks/usage-record.mjs\" 2>/dev/null || true",
+            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/usage-record.mjs\" 2>/dev/null || true",
             "env": {
               "USAGE_CONNECTOR_NAME": "jira",
-              "USAGE_BIN_HINT": "@narai/jira-agent-connector"
+              "USAGE_BIN_HINT": "narai-primitives/dist/connectors/jira"
             }
           }
         ]
@@ -39,7 +39,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/@narai/connector-toolkit/plugin-hooks/session-summary.mjs\" 2>/dev/null || true",
+            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/session-summary.mjs\" 2>/dev/null || true",
             "env": { "USAGE_CONNECTOR_NAME": "jira" }
           }
         ]

--- a/plugins/jira-agent/hooks/reminder.mjs
+++ b/plugins/jira-agent/hooks/reminder.mjs
@@ -5,7 +5,7 @@
 try {
   const data = process.env.CLAUDE_PLUGIN_DATA;
   if (!data) process.exit(0);
-  const toolkitEntry = `${data}/node_modules/@narai/connector-toolkit/dist/plugin/reminder.js`;
+  const toolkitEntry = `${data}/node_modules/narai-primitives/dist/toolkit/plugin/reminder.js`;
   const mod = await import(toolkitEntry);
   const decision = mod.evaluateNudge({ connectors: ["jira"] });
   if (decision.nudge) {

--- a/plugins/jira-agent/package.json
+++ b/plugins/jira-agent/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@narai/jira-agent-connector": "file:.."
+    "narai-primitives": "^2.0.0"
   }
 }

--- a/plugins/jira-agent/skills/jira-agent/SKILL.md
+++ b/plugins/jira-agent/skills/jira-agent/SKILL.md
@@ -9,7 +9,7 @@ context: fork
 # Jira Agent
 
 Answer the user's question by invoking the `jira-agent` binary exposed
-by this plugin. It delegates to `@narai/jira-agent-connector` via
+by this plugin. It delegates to `narai-primitives/jira` via
 Atlassian's Jira REST v3.
 
 ## Invocation

--- a/plugins/notion-agent/.claude-plugin/plugin.json
+++ b/plugins/notion-agent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-agent-plugin",
-  "version": "1.0.0",
-  "description": "Read-only Notion connector for Claude Code. Wraps @narai/notion-agent-connector.",
+  "version": "1.1.0",
+  "description": "Read-only Notion connector for Claude Code. Built on narai-primitives (subpath ./notion).",
   "author": "narai"
 }

--- a/plugins/notion-agent/README.md
+++ b/plugins/notion-agent/README.md
@@ -1,6 +1,6 @@
 # notion-agent-plugin
 
-Claude Code plugin that wraps `@narai/notion-agent-connector` as a read-only Notion skill and slash command.
+Claude Code plugin that wraps `narai-primitives/notion` as a read-only Notion skill and slash command.
 
 - Skill `notion-agent` — automatic invocation for Notion workspace questions.
 - Slash command `/notion-agent <action> <params-json>`.
@@ -10,7 +10,7 @@ Claude Code plugin that wraps `@narai/notion-agent-connector` as a read-only Not
 
 On first `SessionStart` the hook copies `package.json` into
 `${CLAUDE_PLUGIN_DATA}` and runs `npm install --no-audit --no-fund` there
-once. After that, `${CLAUDE_PLUGIN_DATA}/node_modules/@narai/notion-agent-connector/dist/cli.js`
+once. After that, `${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/dist/connectors/notion/cli.js`
 exists and `bin/notion-agent` exec's it.
 
 ## Credentials

--- a/plugins/notion-agent/bin/notion-agent
+++ b/plugins/notion-agent/bin/notion-agent
@@ -6,7 +6,7 @@ if [ -z "${CLAUDE_PLUGIN_DATA:-}" ]; then
   exit 2
 fi
 
-CLI="${CLAUDE_PLUGIN_DATA}/node_modules/@narai/notion-agent-connector/dist/cli.js"
+CLI="${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/dist/connectors/notion/cli.js"
 
 if [ ! -f "$CLI" ]; then
   echo "notion-agent: connector CLI not found at $CLI" >&2

--- a/plugins/notion-agent/hooks/hooks.json
+++ b/plugins/notion-agent/hooks/hooks.json
@@ -9,11 +9,11 @@
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/plugin/hooks/reminder.mjs\" 2>/dev/null || true"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/reminder.mjs\" 2>/dev/null || true"
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/@narai/connector-toolkit/plugin-hooks/stale-summarize.mjs\" 2>/dev/null || true",
+            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/stale-summarize.mjs\" 2>/dev/null || true",
             "env": { "USAGE_CONNECTOR_NAME": "notion" }
           }
         ]
@@ -25,10 +25,10 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/@narai/connector-toolkit/plugin-hooks/usage-record.mjs\" 2>/dev/null || true",
+            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/usage-record.mjs\" 2>/dev/null || true",
             "env": {
               "USAGE_CONNECTOR_NAME": "notion",
-              "USAGE_BIN_HINT": "@narai/notion-agent-connector"
+              "USAGE_BIN_HINT": "narai-primitives/dist/connectors/notion"
             }
           }
         ]
@@ -39,7 +39,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/@narai/connector-toolkit/plugin-hooks/session-summary.mjs\" 2>/dev/null || true",
+            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/session-summary.mjs\" 2>/dev/null || true",
             "env": { "USAGE_CONNECTOR_NAME": "notion" }
           }
         ]

--- a/plugins/notion-agent/hooks/reminder.mjs
+++ b/plugins/notion-agent/hooks/reminder.mjs
@@ -6,7 +6,7 @@
 try {
   const data = process.env.CLAUDE_PLUGIN_DATA;
   if (!data) process.exit(0);
-  const toolkitEntry = `${data}/node_modules/@narai/connector-toolkit/dist/plugin/reminder.js`;
+  const toolkitEntry = `${data}/node_modules/narai-primitives/dist/toolkit/plugin/reminder.js`;
   const mod = await import(toolkitEntry);
   const decision = mod.evaluateNudge({ connectors: ["notion"] });
   if (decision.nudge) {

--- a/plugins/notion-agent/package.json
+++ b/plugins/notion-agent/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@narai/notion-agent-connector": "file:.."
+    "narai-primitives": "^2.0.0"
   }
 }

--- a/plugins/notion-agent/skills/notion-agent/SKILL.md
+++ b/plugins/notion-agent/skills/notion-agent/SKILL.md
@@ -9,7 +9,7 @@ context: fork
 # Notion Agent
 
 Answer the user's question by invoking the `notion-agent` binary exposed
-by this plugin. It delegates to `@narai/notion-agent-connector`, which
+by this plugin. It delegates to `narai-primitives/notion`, which
 speaks to the Notion Public API with a `NOTION_TOKEN` integration secret.
 
 ## Invocation


### PR DESCRIPTION
## Summary

The 7 connector plugins (`aws/confluence/db/gcp/github/jira/notion-agent`) were still installing the deprecated `@narai/<svc>-agent-connector` packages on SessionStart and exec'ing CLIs from those package paths. This PR repoints them at the bundled `narai-primitives` (now at `2.0.0`).

Also fixes a latent bug: `hooks.json` referenced `\${CLAUDE_PLUGIN_ROOT}/plugin/hooks/*` paths that don't exist — leftover from the old per-package layout where the plugin sat under a `plugin/` subdir. The plugins inside `narai-primitives/plugins/<svc>-agent/` are flat, so the path is `\${CLAUDE_PLUGIN_ROOT}/hooks/*`.

### Per-plugin diff (×7, uniform)

- `package.json` runtime dep: `@narai/<svc>-agent-connector` (deprecated) → `narai-primitives@^2.0.0`
- `bin/<svc>-agent`: CLI path → `node_modules/narai-primitives/dist/connectors/<svc>/cli.js`
- `hooks/hooks.json`:
  - `node_modules/@narai/connector-toolkit/plugin-hooks/*` → `node_modules/narai-primitives/plugin-hooks/*`
  - `\${CLAUDE_PLUGIN_ROOT}/plugin/hooks/reminder.mjs` → `\${CLAUDE_PLUGIN_ROOT}/hooks/reminder.mjs`
  - `USAGE_BIN_HINT` updated from deprecated package name to match new CLI path
- `hooks/reminder.mjs`: toolkit reminder import → `narai-primitives/dist/toolkit/plugin/reminder.js`
- `.claude-plugin/plugin.json`: description rewritten ("Built on narai-primitives (subpath ./<svc>)"); version `1.0.0 → 1.1.0`
- `README.md` + `SKILL.md`: prose references updated

`db-agent/.claude-plugin/plugin.json` additionally has its `homepage`/`repository` repointed from archived `narailabs/db-agent-connector` to `narailabs/narai-primitives`.

Plugin versions bump 1.0.0 → 1.1.0 (minor — runtime-dependency change). A follow-up PR will bump matching marketplace catalog entries.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 1400 passed, 26 skipped (live-DB only, env-gated)
- [x] **Smoke test**: copied `plugins/jira-agent/package.json` to a temp dir, ran `npm install`, confirmed `node_modules/narai-primitives/dist/connectors/jira/cli.js` exists, ran `node $CLI --action jql_search --params '...'` — got the expected `{"status":"error","error_code":"CONFIG_ERROR",...}` envelope without credentials configured (correct shape).
- [ ] Marketplace follow-up PR (separate)