### PR TITLE
feat(config): typesafe IoC for PolicyDecision via generic PolicyMap<TExtra>

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,18 @@
       "types": "./dist/connectors/db/index.d.ts",
       "import": "./dist/connectors/db/index.js"
     },
+    "./db/policy": {
+      "types": "./dist/connectors/db/lib/policy.d.ts",
+      "import": "./dist/connectors/db/lib/policy.js"
+    },
+    "./db/schema": {
+      "types": "./dist/connectors/db/lib/schema.d.ts",
+      "import": "./dist/connectors/db/lib/schema.js"
+    },
+    "./db/plugin-config": {
+      "types": "./dist/connectors/db/lib/plugin_config.d.ts",
+      "import": "./dist/connectors/db/lib/plugin_config.js"
+    },
     "./gcp": {
       "types": "./dist/connectors/gcp/index.d.ts",
       "import": "./dist/connectors/gcp/index.js"

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -11,23 +11,34 @@
 /** The five canonical policy actions every connector understands. */
 export type PolicyAction = "read" | "write" | "delete" | "admin" | "privilege";
 
-/** The base policy decisions. db-agent extends this with `present`. */
-export type PolicyDecision = "allow" | "escalate" | "deny" | "present";
+/**
+ * The base policy decisions every connector understands. Connectors with
+ * outcomes beyond this (e.g. db's `present`) declare them locally and
+ * specialize `PolicyMap` / `ResolvedConnector` via the `TExtra` parameter.
+ */
+export type PolicyDecision = "allow" | "escalate" | "deny";
 
 /**
- * A policy block. Universal actions (read/write/...) take a PolicyDecision;
- * connector-specific extras (e.g. `unbounded_select` for db-agent) may take
- * any string value. The library does not interpret extras — the connector
+ * A policy block. Universal actions (read/write/...) take a `PolicyDecision`,
+ * optionally widened by a connector-specific `TExtra` string union (e.g.
+ * `PolicyMap<"present">` for db-agent). Connector-specific extra *actions*
+ * (e.g. `unbounded_select` for db-agent) flow through the index signature
+ * with no constraint — the library does not interpret them; the connector
  * does.
+ *
+ * Default `TExtra = string` keeps the type connector-agnostic (any string
+ * value is admitted) so the hub and resolve layer can pass policy blocks
+ * around without knowing which connector they target. Code that wants
+ * strict typing — db-agent, custom connectors — specializes.
  */
-export interface PolicyMap {
-  read?: PolicyDecision;
-  write?: PolicyDecision;
-  delete?: PolicyDecision;
-  admin?: PolicyDecision;
-  privilege?: PolicyDecision;
+export interface PolicyMap<TExtra extends string = string> {
+  read?: PolicyDecision | TExtra;
+  write?: PolicyDecision | TExtra;
+  delete?: PolicyDecision | TExtra;
+  admin?: PolicyDecision | TExtra;
+  privilege?: PolicyDecision | TExtra;
   /** Connector-specific extras (e.g. `unbounded_select`). */
-  [extra: string]: PolicyDecision | string | undefined;
+  [extra: string]: PolicyDecision | TExtra | string | undefined;
 }
 
 /**
@@ -54,9 +65,11 @@ export interface ResolveOptions {
 
 /**
  * The fully-resolved view of one connector's effective config for a given
- * (consumer, environment) pair.
+ * (consumer, environment) pair. `TExtra` mirrors `PolicyMap`'s parameter so
+ * a connector that defines extra decision values (e.g. db's `"present"`)
+ * can specialize once and have its policy slot strictly typed throughout.
  */
-export interface ResolvedConnector {
+export interface ResolvedConnector<TExtra extends string = string> {
   /** Connector name, matching its key under `connectors:` in the config. */
   name: string;
   /**
@@ -80,7 +93,7 @@ export interface ResolvedConnector {
   /** Whether this connector's guardrail rules participate in the unified hook. */
   enforce_hooks: boolean;
   /** Effective policy after base+env+consumer merge. */
-  policy: PolicyMap;
+  policy: PolicyMap<TExtra>;
   /**
    * All connector-specific extras (`audit`, `servers`, `atlassian-api-key`,
    * etc.). Secrets like `env:NAME` are passed through unresolved so each
@@ -89,15 +102,20 @@ export interface ResolvedConnector {
   options: Record<string, unknown>;
 }
 
-/** The fully-resolved view of the whole config for a given call. */
-export interface ResolvedConfig {
+/**
+ * The fully-resolved view of the whole config for a given call. `TExtra`
+ * widens the policy decision union for both the top-level `policy` and
+ * every connector slice; the hub keeps the default `string` so it doesn't
+ * have to know what extras any individual connector contributes.
+ */
+export interface ResolvedConfig<TExtra extends string = string> {
   /** Hub-specific settings. Read by `@narai/connector-hub`. */
   hub: {
     model: string | null;
     max_tokens: number | null;
   };
   /** Top-level policy defaults (apply unless a connector overrides). */
-  policy: PolicyMap;
+  policy: PolicyMap<TExtra>;
   /** Top-level enforce_hooks default. */
   enforce_hooks: boolean;
   /** Top-level model default; null means inherit from the active session. */
@@ -107,5 +125,5 @@ export interface ResolvedConfig {
   /** Resolved consumer name, or null if none was provided. */
   consumer: string | null;
   /** Per-connector resolved views. */
-  connectors: Record<string, ResolvedConnector>;
+  connectors: Record<string, ResolvedConnector<TExtra>>;
 }

--- a/src/connectors/db/connector.ts
+++ b/src/connectors/db/connector.ts
@@ -24,6 +24,7 @@
 import { createConnector, EnvelopeOverride, type Connector, type ExtendedEnvelope } from "narai-primitives/toolkit";
 import { z } from "zod";
 import { fetch as dispatcherFetch, type FetchResult } from "./dispatcher.js";
+import { DB_POLICY_EXTRAS } from "./lib/plugin_config.js";
 
 // ───────────────────────────────────────────────────────────────────────────
 // Param schemas
@@ -132,6 +133,9 @@ export function buildDbConnector(overrides: BuildOptions = {}): Connector {
     // toolkit's YAML discovery — the dispatcher loads and gates against
     // the resolved config internally.
     disablePolicyDiscovery: true,
+    // Declare the extra decision values db understands beyond the
+    // universal PolicyDecision set. Mirrors `DbExtraDecision` at runtime.
+    policyExtras: DB_POLICY_EXTRAS,
     credentials: async () => ({}),
     // No SDK to preload — drivers are lazy-loaded via `getConnection` inside
     // the dispatcher on the allow path only.

--- a/src/connectors/db/lib/plugin_config.ts
+++ b/src/connectors/db/lib/plugin_config.ts
@@ -21,10 +21,46 @@
 import * as fs from "node:fs";
 import * as yaml from "js-yaml";
 
+import type {
+  PolicyDecision,
+  PolicyMap,
+  ResolvedConnector,
+} from "narai-primitives/config";
+
 import type { OperationType } from "./policy.js";
 
-export type PolicyRule = "allow" | "present" | "escalate" | "deny";
+/**
+ * The extra decision value db-agent contributes on top of the universal
+ * `PolicyDecision` set. Exported so `PolicyMap<DbExtraDecision>` can be
+ * built by consumers that want strict typing on db's policy block.
+ */
+export type DbExtraDecision = "present";
+
+/**
+ * The full set of policy rules valid in a db-agent config. Composed from
+ * the universal `PolicyDecision` (`"allow" | "escalate" | "deny"`) plus
+ * db's local `"present"`. Stated this way rather than re-listing the four
+ * literals so the base set has exactly one source of truth.
+ */
+export type PolicyRule = PolicyDecision | DbExtraDecision;
 export type RestrictedPolicyRule = Exclude<PolicyRule, "allow">;
+
+/**
+ * `PolicyMap` specialized to db-agent's decision vocabulary. Use this in
+ * db-internal code that wants `policy.read = "present"` to typecheck while
+ * `policy.read = "anything-else"` does not.
+ */
+export type DbPolicyMap = PolicyMap<DbExtraDecision>;
+
+/** `ResolvedConnector` specialized to db-agent's decision vocabulary. */
+export type DbResolvedConnector = ResolvedConnector<DbExtraDecision>;
+
+/**
+ * Tuple-typed vocabulary suitable for `createConnector`'s `policyExtras`
+ * field. Kept as a single source of truth so the type-level extras and the
+ * runtime declaration stay in lockstep.
+ */
+export const DB_POLICY_EXTRAS = ["present"] as const satisfies readonly DbExtraDecision[];
 
 export type UnboundedSelectMode = "escalate" | "allow";
 

--- a/src/connectors/db/lib/policy.ts
+++ b/src/connectors/db/lib/policy.ts
@@ -22,12 +22,20 @@
  * accepts an optional driver and dispatches accordingly.
  */
 import { performance } from "node:perf_hooks";
+import type { PolicyDecision } from "narai-primitives/config";
 import type { DatabaseDriver } from "./drivers/base.js";
 import { logEvent, scrubSqlSecrets } from "./audit.js";
 import { DEFAULT_POLICY, type PolicyRules } from "./plugin_config.js";
 
-/** Possible outcomes of a policy check (wire format = lowercase string). */
-export type Decision = "allow" | "deny" | "escalate" | "present_only";
+/**
+ * Possible outcomes of a db-internal policy check (wire format = lowercase
+ * string). Composed from the universal `PolicyDecision` plus db's local
+ * `"present_only"` so the base set has a single source of truth. Note that
+ * `"present_only"` is a *runtime* spelling distinct from the *config-level*
+ * `"present"` rule (the latter is the operator-facing token in YAML; this
+ * one is the wire status emitted in the envelope after rule translation).
+ */
+export type Decision = PolicyDecision | "present_only";
 
 /** Namespace providing Python-style attribute access (`Decision.ALLOW`). */
 export const Decision = {

--- a/src/toolkit/connector.ts
+++ b/src/toolkit/connector.ts
@@ -143,6 +143,17 @@ export interface ConnectorConfig<TSdk = unknown> {
   policyConfigPath?: string;
   /** Aspects that cannot be downgraded to `"success"` in operator config. */
   policyFloorAspects?: readonly string[];
+  /**
+   * Decision strings this connector recognizes beyond the universal
+   * `PolicyDecision` set (`"allow" | "escalate" | "deny"`). Declaring this
+   * is the runtime complement to specializing `PolicyMap<TExtra>` at the
+   * type level: the hub may use it to validate operator-supplied
+   * `~/.connectors/config.yaml` values, and tooling can introspect a
+   * connector's policy vocabulary without parsing its source. Example:
+   * db-agent declares `policyExtras: ["present"] as const` to register
+   * its `"present"` rule.
+   */
+  readonly policyExtras?: readonly string[];
   /** Default rules when no config is found. Defaults to `DEFAULT_POLICY`. */
   defaultPolicy?: PolicyRules;
   /**

--- a/tests/config/types_ioc.test.ts
+++ b/tests/config/types_ioc.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Type-level inversion-of-control assertions for `PolicyMap` and friends.
+ *
+ * These tests validate the generic `PolicyMap<TExtra>` behaviour — that
+ * specializing widens the accepted decision set without polluting the base
+ * universal `PolicyDecision`. The runtime body is a thin sanity check; the
+ * actual contract lives in the `// @ts-expect-error` comments, which the
+ * project's `tsc --noEmit` step verifies.
+ *
+ * If a `@ts-expect-error` comment ends up over a line that no longer fails
+ * typing, tsc will report it as an unused suppression — meaning the type
+ * IoC has weakened and a connector-specific decision has leaked into the
+ * base set.
+ */
+import { describe, it, expect } from "vitest";
+
+import type {
+  PolicyDecision,
+  PolicyMap,
+  ResolvedConnector,
+  ResolvedConfig,
+} from "../../src/config/types.js";
+import type {
+  DbExtraDecision,
+  DbPolicyMap,
+  DbResolvedConnector,
+} from "../../src/connectors/db/lib/plugin_config.js";
+
+// ───────────────────────────────────────────────────────────────────────────
+// Helpers — make assignability checks read like assertions.
+// ───────────────────────────────────────────────────────────────────────────
+
+function expectAssignable<T>(_value: T): void {
+  /* compile-time only */
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Base type: PolicyDecision must NOT include connector-specific extras.
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("PolicyDecision (base)", () => {
+  it("admits exactly allow / escalate / deny", () => {
+    expectAssignable<PolicyDecision>("allow");
+    expectAssignable<PolicyDecision>("escalate");
+    expectAssignable<PolicyDecision>("deny");
+
+    // @ts-expect-error — "present" is db-agent's, not part of the universal set.
+    expectAssignable<PolicyDecision>("present");
+    // @ts-expect-error — present_only is db's runtime spelling, not config-level.
+    expectAssignable<PolicyDecision>("present_only");
+    // @ts-expect-error — arbitrary strings are not PolicyDecision.
+    expectAssignable<PolicyDecision>("anything-else");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// PolicyMap: connector-agnostic by default, strict when narrowed, widenable.
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("PolicyMap<TExtra>", () => {
+  it("default (TExtra = string) is connector-agnostic and admits any string", () => {
+    // Hub-style code annotates without specializing — anything string-shaped
+    // flows through. This is the runtime today, type-encoded.
+    const policy: PolicyMap = { read: "allow", write: "anything-goes", delete: "present" };
+    expect(policy.read).toBe("allow");
+  });
+
+  it("PolicyMap<never> is the strictest specialization (only base PolicyDecision)", () => {
+    const strict: PolicyMap<never> = { read: "allow", write: "escalate", delete: "deny" };
+    expect(strict.read).toBe("allow");
+
+    // @ts-expect-error — "present" is not in PolicyDecision and TExtra=never.
+    const _bad1: PolicyMap<never> = { read: "present" };
+    // @ts-expect-error — db's wire spelling has no place at the config level.
+    const _bad2: PolicyMap<never> = { write: "present_only" };
+    void _bad1; void _bad2;
+  });
+
+  it("PolicyMap<\"present\"> admits 'present' but rejects unrelated extras", () => {
+    const dbish: PolicyMap<"present"> = { read: "present", write: "allow", delete: "deny" };
+    expect(dbish.read).toBe("present");
+
+    // @ts-expect-error — only "present" is widened; other extras still rejected.
+    const _bad: PolicyMap<"present"> = { read: "sandbox" };
+    void _bad;
+  });
+
+  it("future connectors can declare their own without touching the base", () => {
+    // Imagine a hypothetical "sandbox" connector — no narai-primitives change required.
+    type SandboxPolicyMap = PolicyMap<"sandbox" | "queue">;
+    const sandboxPolicy: SandboxPolicyMap = { write: "sandbox", delete: "queue" };
+    expect(sandboxPolicy.write).toBe("sandbox");
+
+    // @ts-expect-error — db's "present" doesn't belong in this connector's vocabulary.
+    const _bad: SandboxPolicyMap = { write: "present" };
+    void _bad;
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// ResolvedConnector / ResolvedConfig propagate TExtra through.
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("ResolvedConnector / ResolvedConfig propagation", () => {
+  it("ResolvedConnector<TExtra> threads the parameter into policy", () => {
+    const slice: ResolvedConnector<"present"> = {
+      name: "db",
+      enabled: true,
+      skill: "db-agent-connector",
+      model: null,
+      enforce_hooks: true,
+      policy: { read: "allow", write: "present", delete: "present" },
+      options: {},
+    };
+    expect(slice.policy.write).toBe("present");
+
+    // @ts-expect-error — even on a specialized slice, unknown extras are rejected.
+    const _bad: ResolvedConnector<"present"> = {
+      name: "db", enabled: true, skill: "x", model: null, enforce_hooks: false,
+      policy: { read: "sandbox" }, options: {},
+    };
+    void _bad;
+  });
+
+  it("ResolvedConfig<TExtra> uniformly widens both top-level and per-connector policy", () => {
+    const cfg: ResolvedConfig<"present"> = {
+      hub: { model: null, max_tokens: null },
+      policy: { read: "present" },
+      enforce_hooks: false,
+      model: null,
+      environment: null,
+      consumer: null,
+      connectors: {
+        db: {
+          name: "db", enabled: true, skill: "db-agent-connector", model: null,
+          enforce_hooks: false,
+          policy: { read: "present" },
+          options: {},
+        },
+      },
+    };
+    expect(cfg.connectors.db?.policy.read).toBe("present");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// db-agent specialization: the typed exports route to the right widening.
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("db-agent typed exports", () => {
+  it("DbExtraDecision is exactly 'present' (no leakage of present_only or others)", () => {
+    expectAssignable<DbExtraDecision>("present");
+
+    // @ts-expect-error — present_only is the runtime/wire form, not a config rule.
+    expectAssignable<DbExtraDecision>("present_only");
+    // @ts-expect-error — db's vocabulary doesn't include arbitrary strings.
+    expectAssignable<DbExtraDecision>("escalate-but-also-publish");
+  });
+
+  it("DbPolicyMap = PolicyMap<DbExtraDecision> accepts the four db-config values", () => {
+    const p: DbPolicyMap = {
+      read: "allow",
+      write: "present",
+      delete: "escalate",
+      admin: "deny",
+    };
+    expect(p.read).toBe("allow");
+
+    // @ts-expect-error — anything outside the four-value set still rejected.
+    const _bad: DbPolicyMap = { read: "queue" };
+    void _bad;
+  });
+
+  it("DbResolvedConnector exposes the same widening at the slice level", () => {
+    const slice: DbResolvedConnector = {
+      name: "db", enabled: true, skill: "db-agent-connector",
+      model: null, enforce_hooks: true,
+      policy: { read: "allow", write: "present" },
+      options: {},
+    };
+    expect(slice.policy.write).toBe("present");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// policyExtras: the runtime IoC complement is declared, accessible, and typed.
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("ConnectorConfig.policyExtras (runtime vocabulary)", () => {
+  it("the db connector declares ['present'] at runtime", async () => {
+    // Live import — exercises the export wiring end-to-end.
+    const { default: dbConnector } = await import("../../src/connectors/db/index.js");
+    // The `policyExtras` field lives on the ConnectorConfig that built the
+    // connector; the public Connector interface doesn't re-expose it. So we
+    // assert the underlying constant matches what the connector ships.
+    const { DB_POLICY_EXTRAS } = await import("../../src/connectors/db/lib/plugin_config.js");
+    expect(DB_POLICY_EXTRAS).toEqual(["present"]);
+    expect(dbConnector.name).toBe("db");
+  });
+});


### PR DESCRIPTION
## Summary

Three rounds of cleanup, all aimed at making the policy/decision vocabulary connector-extensible and typesafe:

### Round 1 — config-layer IoC (commit `ce04913`)

- Narrow universal `PolicyDecision` to `"allow" | "escalate" | "deny"` and parameterize `PolicyMap`/`ResolvedConnector`/`ResolvedConfig` over `TExtra extends string = string`. Connector-specific decisions (e.g. db's `"present"`) declare locally via specialization: `type DbPolicyMap = PolicyMap<"present">`.
- Add `ConnectorConfig.policyExtras: readonly string[]` so connectors register their extra-decision vocabulary at runtime; db ships `["present"] as const`.
- Recompose db's internal `PolicyRule` and `Decision` from upstream `PolicyDecision` rather than re-listing literals — single source of truth for the base set.
- Expose `./db/policy`, `./db/schema`, `./db/plugin-config` subpath exports so consumers (e.g. doc-wiki's `wiki_db`) can import canonical types without pulling the full `./db` barrel.
- New `tests/config/types_ioc.test.ts` pins the type contract via `// @ts-expect-error`; `tsc --noEmit` validates the assertions.

### Round 2 — toolkit-layer leak (commit `52a6340`)

The same `"present"` leak existed in parallel at the toolkit layer (`src/toolkit/policy/types.ts`):
- `Rule = "success" | "present" | "escalate" | "denied"` baked db's term into the universal toolkit type.
- `DEFAULT_POLICY.write = "present"` made every connector's default db-flavoured.
- The gate special-cased `case "present"` to collapse to `"escalate"`.

Fixed:
- `Rule = "success" | "escalate" | "denied"` (no `"present"`).
- `DEFAULT_POLICY.write = "escalate"` (was `"present"`).
- `PolicyRules<TExtra extends string = never>` parameterized for connectors that want custom rule values; `checkPolicy` accepts `PolicyRules<never>` only.
- Drop `case "present"` collapse and `presentReason` helper from `gate.ts`.
- Drop `"present"` from `VALID_RULES` in `config.ts`.

Connectors that historically used `"present"` (only db) are unaffected at runtime — db sets `disablePolicyDiscovery: true` and runs its own SQL-aware policy gate. Other connectors' default behaviour stays identical (write was already collapsing to escalate via the rule→decision mapping; now it escalates directly without the alias).

### Round 3 — hub-side runtime validation (commit `52a6340`)

The runtime IoC complement to Round 1's type-level generic. New module `src/config/policy_validation.ts`:

- `validatePolicies(config, { connectorExtras }): PolicyIssue[]` — non-throwing, returns offending values with action+connector context.
- `assertValidPolicies(config, { connectorExtras }): void` — throws an aggregated error citing every offender.

Top-level `policy:` is validated against `PolicyDecision` only; per-connector slices may include that connector's registered extras (e.g. `DB_POLICY_EXTRAS`). Hub planners can call this after `loadResolvedConfig` to fail config-load on typos and unknown decisions instead of waiting for first connector dispatch.

## Why

`PolicyDecision` previously baked db's `"present"` into the universal config-level type (with a comment that even acknowledged the leak), and the toolkit layer had the parallel leak in `Rule`/`DEFAULT_POLICY`. Any future connector wanting its own outcome (`"sandbox"`, `"queue"`, `"redact"`, ...) had no typesafe place to land. The `extendDecision` hook + open-string `ExtendedEnvelope.status` already gave runtime/wire IoC; the type system was the only closed layer. This PR closes the gap at both layers and adds a runtime validator so operators get fast feedback on config typos.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 1420 passed + 26 skipped (was 1400 + 26; +20 new tests across types_ioc and policy_validation)
- [x] `node -e 'import("narai-primitives/db/policy")...'` resolves new subpaths
- [x] db connector still emits `present_only` envelopes verbatim
- [x] Default `TExtra` choices: `PolicyMap<TExtra = string>` (config layer, hub-agnostic) vs `PolicyRules<TExtra = never>` (toolkit layer, gate is strict checkpoint)
- [x] Type-level: `PolicyMap<never>` rejects `"present"`; `DbPolicyMap` accepts it; `PolicyMap<"sandbox">` admits sandbox-but-not-present (verified by `@ts-expect-error` in `types_ioc.test.ts`)
- [x] Runtime: `validatePolicies(cfg, { connectorExtras: { db: DB_POLICY_EXTRAS }})` accepts db's `"present"`; rejects it on github's slice; rejects typos like `"esclate"`

## Breaking changes

- `PolicyDecision` no longer includes `"present"`. External consumers using `"present"` as a `PolicyDecision` value get a compile error. Mitigation: db-agent's vocabulary lives in `DbExtraDecision` / `DbPolicyMap` (exported from `narai-primitives/db`).
- Toolkit `Rule` no longer includes `"present"`. Operator configs with `write: "present"` etc. now fail validation at the toolkit layer. Mitigation: db doesn't go through this validator (it has its own); other connectors used base values already.

Bump major or include in the existing `^2.0.0-rc` series.