### PR TITLE
feat(toolkit+config): remove "present" leak from base; add hub-side policy validator

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -23,6 +23,13 @@ export {
 } from "./secrets.js";
 
 export {
+  validatePolicies,
+  assertValidPolicies,
+  type PolicyIssue,
+  type ValidationOptions,
+} from "./policy_validation.js";
+
+export {
   loadConnectorEnvironment,
   type LoadConnectorEnvironmentOptions,
 } from "./bootstrap.js";

--- a/src/config/policy_validation.ts
+++ b/src/config/policy_validation.ts
@@ -1,0 +1,125 @@
+/**
+ * Hub-level validator for `~/.connectors/config.yaml` policy blocks.
+ *
+ * The base `PolicyDecision` set is `"allow" | "escalate" | "deny"`; each
+ * connector may register extras (e.g. db-agent's `"present"`) via the
+ * `policyExtras` field on `createConnector`. This module is the **runtime
+ * IoC complement** to that type-level surface — it validates resolved
+ * config values against `PolicyDecision ∪ per-connector extras` so a
+ * typo'd `write: "esclate"` fails at config-load instead of at first call.
+ *
+ * The validator is intentionally non-throwing by default: callers receive
+ * a list of issues and decide whether to log, warn, or hard-fail. An
+ * `assertValidPolicies` helper throws when any issue is found.
+ *
+ * Where to wire it up:
+ *  - The hub (planner) can call `assertValidPolicies(resolved, { connectorExtras })`
+ *    after `loadResolvedConfig`, with `connectorExtras` populated from each
+ *    builtin connector's exported vocabulary (e.g. `DB_POLICY_EXTRAS`).
+ *  - Custom connectors loaded via `~/.connectors/connectors/<name>/` should
+ *    expose their own vocabulary the same way; the hub merges it into the
+ *    `connectorExtras` map before validating.
+ */
+import type { PolicyDecision, PolicyMap, ResolvedConfig } from "./types.js";
+
+/** The five canonical action keys validated as typed slots. */
+const TYPED_ACTIONS = ["read", "write", "delete", "admin", "privilege"] as const;
+type TypedAction = (typeof TYPED_ACTIONS)[number];
+
+/** Universal decision set, kept in lockstep with the `PolicyDecision` type. */
+const BASE_DECISIONS: readonly PolicyDecision[] = [
+  "allow",
+  "escalate",
+  "deny",
+];
+
+/** A single offending policy value, with enough context to surface to operators. */
+export interface PolicyIssue {
+  /** Connector name, or `null` when the issue is on the top-level `policy:`. */
+  connector: string | null;
+  /** Which typed action slot was offending (always one of the TYPED_ACTIONS). */
+  action: TypedAction;
+  /** The actual (offending) value found in config. */
+  value: string;
+  /** What the validator expected — base decisions ∪ this connector's extras. */
+  expected: readonly string[];
+}
+
+/** Options forwarded to `validatePolicies` / `assertValidPolicies`. */
+export interface ValidationOptions {
+  /**
+   * Per-connector extra-decision vocabulary. Keyed by connector name as it
+   * appears in the resolved config. Connectors absent from this map are
+   * validated against `PolicyDecision` only — which is correct behavior
+   * for connectors that don't widen the decision set.
+   *
+   * For builtin connectors, prefer importing the connector's own constant
+   * (e.g. `DB_POLICY_EXTRAS` from `narai-primitives/db/plugin-config`) so
+   * the runtime list and the type-level `TExtra` parameter stay in lockstep.
+   */
+  connectorExtras?: Readonly<Record<string, readonly string[]>>;
+}
+
+/**
+ * Validate every typed action slot in a resolved config against the
+ * appropriate vocabulary. Returns the list of issues (empty ⇒ valid).
+ *
+ * Top-level `policy` is validated against the base `PolicyDecision` set
+ * with no extras — extras only have meaning at the connector level.
+ *
+ * Free-form aspect keys (e.g. db's `unbounded_select`) are not validated
+ * here: they flow through the `[extra: string]` index signature on
+ * `PolicyMap`, and each connector validates its own extras at the
+ * connector boundary (with full knowledge of its valid set).
+ */
+export function validatePolicies(
+  config: ResolvedConfig,
+  opts: ValidationOptions = {},
+): PolicyIssue[] {
+  const issues: PolicyIssue[] = [];
+  const connectorExtras = opts.connectorExtras ?? {};
+
+  validatePolicyMap(config.policy, [], null, issues);
+
+  for (const [name, slice] of Object.entries(config.connectors)) {
+    const extras = connectorExtras[name] ?? [];
+    validatePolicyMap(slice.policy, extras, name, issues);
+  }
+
+  return issues;
+}
+
+/** Throwing variant. Composes with `validatePolicies` — same options, same checks. */
+export function assertValidPolicies(
+  config: ResolvedConfig,
+  opts: ValidationOptions = {},
+): void {
+  const issues = validatePolicies(config, opts);
+  if (issues.length === 0) return;
+  const lines = issues.map((i) => {
+    const where = i.connector === null ? "<top-level>" : `connectors.${i.connector}`;
+    return `  ${where}.policy.${i.action} = ${JSON.stringify(i.value)} ` +
+      `(expected one of ${JSON.stringify(i.expected)})`;
+  });
+  throw new Error(`Invalid policy values:\n${lines.join("\n")}`);
+}
+
+function validatePolicyMap(
+  policy: PolicyMap,
+  knownExtras: readonly string[],
+  connector: string | null,
+  out: PolicyIssue[],
+): void {
+  const allowed: readonly string[] = [...BASE_DECISIONS, ...knownExtras];
+  for (const action of TYPED_ACTIONS) {
+    const value = (policy as Record<string, unknown>)[action];
+    if (value === undefined) continue;
+    if (typeof value !== "string") {
+      out.push({ connector, action, value: String(value), expected: allowed });
+      continue;
+    }
+    if (!allowed.includes(value)) {
+      out.push({ connector, action, value, expected: allowed });
+    }
+  }
+}

--- a/src/toolkit/policy/config.ts
+++ b/src/toolkit/policy/config.ts
@@ -26,7 +26,6 @@ import {
 
 const VALID_RULES: ReadonlySet<Rule> = new Set([
   "success",
-  "present",
   "escalate",
   "denied",
 ]);
@@ -128,7 +127,7 @@ function validateRule(
 ): Rule {
   if (typeof value !== "string" || !VALID_RULES.has(value as Rule)) {
     throw new Error(
-      `${field}: expected one of [success, present, escalate, denied], got: ${JSON.stringify(
+      `${field}: expected one of [success, escalate, denied], got: ${JSON.stringify(
         value,
       )}`,
     );

--- a/src/toolkit/policy/gate.ts
+++ b/src/toolkit/policy/gate.ts
@@ -3,10 +3,12 @@
  * `./approval.ts` (the factory wires it up per connector invocation).
  *
  * Rule combination: kind rule is the base; each aspect rule (if declared)
- * applies on top via Rule strictness (denied > escalate > present > success).
- * Note: Rule "present" collapses to Decision "escalate" — extendDecision
- * hooks intercept escalate to emit ExtendedEnvelope.
- * Ties go to the first offender so the `reason` message is predictable.
+ * applies on top via Rule strictness (denied > escalate > success). Ties
+ * go to the first offender so the `reason` message is predictable.
+ *
+ * Connectors with custom rule values (e.g. db-agent's `"present"`) must
+ * translate them to base values before invoking `checkPolicy` — the gate
+ * is exhaustive over the base 3-rule set only.
  */
 import type {
   ApprovalMode,
@@ -20,9 +22,8 @@ import { DECISION_RANK } from "./types.js";
 /** Strictness rank for combining Rule values (same order as DECISION_RANK). */
 const RULE_RANK: Record<Rule, number> = {
   success: 0,
-  present: 1,
-  escalate: 2,
-  denied: 3,
+  escalate: 1,
+  denied: 2,
 };
 
 /** Minimal state needed for approval-mode resolution. Pure-data. */
@@ -38,7 +39,7 @@ export interface ApprovalState {
  */
 export function checkPolicy(
   classification: Classification,
-  rules: PolicyRules,
+  rules: PolicyRules<never>,
   approvalMode: ApprovalMode,
   approvalState: ApprovalState,
 ): Decision {
@@ -71,11 +72,6 @@ export function checkPolicy(
         status: "escalate",
         reason: escalateReason(kind, strictestReasonSource, offendingAspect),
       };
-    // Rule "present" collapses to Decision "escalate" in toolkit 3.0;
-    // extendDecision hooks (e.g. db-agent) intercept escalate to emit
-    // a connector-specific ExtendedEnvelope.
-    case "present":
-      return { status: "escalate", reason: presentReason(kind, strictestReasonSource, offendingAspect) };
     case "success":
       // A "success" rule for reads still has to pass the approval mode gate.
       if (kind === "read") {
@@ -164,15 +160,4 @@ function escalateReason(
     return `${aspect} aspect requires approval`;
   }
   return `${kind} requires approval`;
-}
-
-function presentReason(
-  kind: string,
-  source: "kind" | "aspect",
-  aspect: string | null,
-): string {
-  if (source === "aspect" && aspect !== null) {
-    return `${aspect} aspect is displayed but not executed`;
-  }
-  return `${kind} is displayed but not executed`;
 }

--- a/src/toolkit/policy/types.ts
+++ b/src/toolkit/policy/types.ts
@@ -29,18 +29,34 @@ export interface Classification {
 // Rules — operator-configured actions per kind / aspect.
 // ───────────────────────────────────────────────────────────────────────────
 
-/** Wire rules operators set per classification. */
-export type Rule = "success" | "present" | "escalate" | "denied";
+/**
+ * Wire rules operators set per classification. The toolkit-level base set
+ * holds only `success | escalate | denied`. Connectors that need a custom
+ * rule (e.g. db-agent's `"present"` rule, which means "displayed but not
+ * executed") declare it locally and translate to a base rule at their own
+ * boundary before invoking `checkPolicy`. The wire envelope (`status` is
+ * `string`) and the `extendDecision` hook still let those connectors emit
+ * connector-specific outcomes.
+ */
+export type Rule = "success" | "escalate" | "denied";
 
 /** Rule without `"success"` — used for safety-floor slots (admin, ddl, privilege). */
 export type RestrictedRule = Exclude<Rule, "success">;
 
-export interface PolicyRules {
-  read: Rule;
-  write: Rule;
-  admin: RestrictedRule;
+/**
+ * The toolkit-level rules shape, keyed by classification kind. `TExtra`
+ * mirrors `PolicyMap`'s parameter, but the default is `never` (not `string`):
+ * the toolkit gate is the strict checkpoint, so unspecialized `PolicyRules`
+ * means "base rules only". Connectors with extra rule values declare them
+ * explicitly via `PolicyRules<"present">` etc., and translate to base
+ * before invoking `checkPolicy`.
+ */
+export interface PolicyRules<TExtra extends string = never> {
+  read: Rule | TExtra;
+  write: Rule | TExtra;
+  admin: RestrictedRule | TExtra;
   /** Per-aspect rule map. Absent aspects fall through to the kind's rule. */
-  aspects?: Record<string, Rule>;
+  aspects?: Record<string, Rule | TExtra>;
 }
 
 export type ApprovalMode =
@@ -49,10 +65,16 @@ export type ApprovalMode =
   | "confirm_each"
   | "grant_required";
 
-/** Defaults matching db-agent's historical behavior, generalized to CRUD. */
+/**
+ * Connector-agnostic default rules. Writes escalate by default (operators
+ * may downgrade to `success` per connector); admin is the safety-floor
+ * default-deny. Connectors that historically used `"present"` for write
+ * (e.g. db-agent's "displayed but not executed") declare it in their own
+ * defaults and translate to `"escalate"` before reaching the toolkit gate.
+ */
 export const DEFAULT_POLICY: PolicyRules = {
   read: "success",
-  write: "present",
+  write: "escalate",
   admin: "denied",
   aspects: {},
 };

--- a/tests/config/policy_validation.test.ts
+++ b/tests/config/policy_validation.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Hub-side validation of policy values against `PolicyDecision ∪ extras`.
+ *
+ * These tests pin the runtime IoC complement to the type-level generic:
+ * the resolve layer accepts any string in policy slots (so the hub stays
+ * connector-agnostic), but consumers can call `validatePolicies` with a
+ * per-connector vocabulary registry to fail config-load on bad values.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  validatePolicies,
+  assertValidPolicies,
+} from "../../src/config/policy_validation.js";
+import { DB_POLICY_EXTRAS } from "../../src/connectors/db/lib/plugin_config.js";
+import type { ResolvedConfig } from "../../src/config/types.js";
+
+function buildConfig(
+  overrides: Partial<ResolvedConfig> = {},
+): ResolvedConfig {
+  return {
+    hub: { model: null, max_tokens: null },
+    policy: {},
+    enforce_hooks: true,
+    model: null,
+    environment: null,
+    consumer: null,
+    connectors: {},
+    ...overrides,
+  };
+}
+
+describe("validatePolicies — base decisions only", () => {
+  it("accepts allow / escalate / deny in every typed slot", () => {
+    const cfg = buildConfig({
+      policy: { read: "allow", write: "escalate", delete: "deny", admin: "deny", privilege: "deny" },
+      connectors: {
+        github: {
+          name: "github", enabled: true, skill: "github-agent-connector",
+          model: null, enforce_hooks: true,
+          policy: { read: "allow", write: "escalate" },
+          options: {},
+        },
+      },
+    });
+    expect(validatePolicies(cfg)).toEqual([]);
+  });
+
+  it("rejects connector-specific extras when no extras registered", () => {
+    const cfg = buildConfig({
+      connectors: {
+        db: {
+          name: "db", enabled: true, skill: "db-agent-connector",
+          model: null, enforce_hooks: true,
+          policy: { write: "present" },
+          options: {},
+        },
+      },
+    });
+    const issues = validatePolicies(cfg);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      connector: "db",
+      action: "write",
+      value: "present",
+    });
+    expect(issues[0]?.expected).toEqual(["allow", "escalate", "deny"]);
+  });
+
+  it("rejects nonsense values (typos)", () => {
+    const cfg = buildConfig({
+      connectors: {
+        github: {
+          name: "github", enabled: true, skill: "github-agent-connector",
+          model: null, enforce_hooks: true,
+          policy: { read: "esclate" },
+          options: {},
+        },
+      },
+    });
+    const issues = validatePolicies(cfg);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.value).toBe("esclate");
+  });
+});
+
+describe("validatePolicies — with per-connector extras", () => {
+  it("accepts db's 'present' when DB_POLICY_EXTRAS is registered", () => {
+    const cfg = buildConfig({
+      connectors: {
+        db: {
+          name: "db", enabled: true, skill: "db-agent-connector",
+          model: null, enforce_hooks: true,
+          policy: { write: "present", admin: "present" },
+          options: {},
+        },
+      },
+    });
+    const issues = validatePolicies(cfg, {
+      connectorExtras: { db: DB_POLICY_EXTRAS },
+    });
+    expect(issues).toEqual([]);
+  });
+
+  it("rejects extras belonging to a different connector", () => {
+    const cfg = buildConfig({
+      connectors: {
+        github: {
+          name: "github", enabled: true, skill: "github-agent-connector",
+          model: null, enforce_hooks: true,
+          policy: { write: "present" },
+          options: {},
+        },
+      },
+    });
+    // db's vocabulary is registered, but github isn't — github gets base only.
+    const issues = validatePolicies(cfg, {
+      connectorExtras: { db: DB_POLICY_EXTRAS },
+    });
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.connector).toBe("github");
+  });
+
+  it("does not validate top-level policy against connector extras", () => {
+    const cfg = buildConfig({
+      policy: { write: "present" },  // top-level — only base decisions allowed
+      connectors: {
+        db: {
+          name: "db", enabled: true, skill: "db-agent-connector",
+          model: null, enforce_hooks: true,
+          policy: { write: "present" },
+          options: {},
+        },
+      },
+    });
+    const issues = validatePolicies(cfg, {
+      connectorExtras: { db: DB_POLICY_EXTRAS },
+    });
+    // db's per-connector slice is OK; top-level "present" is rejected.
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.connector).toBeNull();
+  });
+
+  it("ignores undefined slots and free-form extra keys", () => {
+    const cfg = buildConfig({
+      connectors: {
+        db: {
+          name: "db", enabled: true, skill: "db-agent-connector",
+          model: null, enforce_hooks: true,
+          // unbounded_select is a connector-specific *aspect* (not a typed action),
+          // so the validator skips it — db's own validator handles it.
+          policy: { read: "allow", unbounded_select: "escalate" } as never,
+          options: {},
+        },
+      },
+    });
+    expect(validatePolicies(cfg, { connectorExtras: { db: DB_POLICY_EXTRAS } }))
+      .toEqual([]);
+  });
+});
+
+describe("assertValidPolicies", () => {
+  it("returns silently when every slot is valid", () => {
+    const cfg = buildConfig({
+      policy: { read: "allow" },
+    });
+    expect(() => assertValidPolicies(cfg)).not.toThrow();
+  });
+
+  it("throws an aggregated error citing every offender", () => {
+    const cfg = buildConfig({
+      policy: { read: "wat" },
+      connectors: {
+        github: {
+          name: "github", enabled: true, skill: "github-agent-connector",
+          model: null, enforce_hooks: true,
+          policy: { write: "yolo", admin: "free-for-all" },
+          options: {},
+        },
+      },
+    });
+    expect(() => assertValidPolicies(cfg)).toThrowError(/Invalid policy values/);
+    try {
+      assertValidPolicies(cfg);
+    } catch (e) {
+      const msg = (e as Error).message;
+      expect(msg).toContain("<top-level>");
+      expect(msg).toContain("connectors.github.policy.write");
+      expect(msg).toContain("connectors.github.policy.admin");
+    }
+  });
+});

--- a/tests/toolkit/policy_gate.test.ts
+++ b/tests/toolkit/policy_gate.test.ts
@@ -12,7 +12,7 @@ describe("checkPolicy — kind rules", () => {
     expect(d.reason).toBe("auto-approved");
   });
 
-  it("write with default policy (=present) returns escalate", () => {
+  it("write with default policy (=escalate) returns escalate", () => {
     const d = checkPolicy({ kind: "write" }, DEFAULT_POLICY, "auto", noApproval);
     expect(d.status).toBe("escalate");
   });
@@ -93,7 +93,7 @@ describe("checkPolicy — approval_mode state machine", () => {
   });
 
   it("approval_mode does not apply to write/admin", () => {
-    // Write rule = present → escalate regardless of approval_mode.
+    // Write rule = escalate regardless of approval_mode.
     const d = checkPolicy(
       { kind: "write" },
       DEFAULT_POLICY,


### PR DESCRIPTION
## Summary

Two follow-ups that pair with the merged [#5](https://github.com/narailabs/narai-primitives/pull/5) (typesafe-IoC at the config layer):

### Round 1 — toolkit-layer "present" leak

The same `"present"` leak existed in parallel at the toolkit layer (`src/toolkit/policy/types.ts`):

- `Rule = "success" | "present" | "escalate" | "denied"` baked db's term into the universal toolkit type.
- `DEFAULT_POLICY.write = "present"` made every connector's default db-flavoured.
- `gate.ts` special-cased `case "present"` to collapse to `"escalate"`.

Fixed:

- `Rule = "success" | "escalate" | "denied"` (no `"present"`).
- `DEFAULT_POLICY.write = "escalate"` (was `"present"`).
- `PolicyRules<TExtra extends string = never>` parameterized for connectors that want custom rule values; `checkPolicy` accepts `PolicyRules<never>` only.
- Drop `case "present"` collapse and `presentReason` helper from `gate.ts`.
- Drop `"present"` from `VALID_RULES` in `config.ts`.

The default for `PolicyRules<TExtra>` is `never` (strict — gate is the strict checkpoint), distinct from `PolicyMap<TExtra = string>` (config layer, hub-agnostic). That asymmetry is intentional: the gate enforces, the config-resolve layer doesn't.

Connectors that historically used `"present"` (only db) are unaffected at runtime — db sets `disablePolicyDiscovery: true` and runs its own SQL-aware policy gate. Other connectors' default behaviour stays identical (write was already collapsing to escalate via the rule→decision mapping; now it escalates directly without the alias).

### Round 2 — hub-side runtime validation

The runtime IoC complement to PR #5's type-level generic. New module `src/config/policy_validation.ts`:

- `validatePolicies(config, { connectorExtras }): PolicyIssue[]` — non-throwing, returns offending values with action+connector context.
- `assertValidPolicies(config, { connectorExtras }): void` — throws an aggregated error citing every offender.

Top-level `policy:` is validated against `PolicyDecision` only; per-connector slices may include that connector's registered extras (e.g. `DB_POLICY_EXTRAS`). Hub planners can call this after `loadResolvedConfig` to fail config-load on typos and unknown decisions instead of waiting for first connector dispatch.

## Why

PR #5 closed the config-layer leak but the parallel toolkit-layer leak in `Rule`/`DEFAULT_POLICY` remained. Future connectors wanting their own rule outcomes had no typesafe place to land at the toolkit gate. And the type-level IoC needed a runtime-validation complement so operator config typos (`"esclate"`, `"presnt"`) fail fast at config-load, not at first dispatch.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 1420 passed + 26 skipped (was 1411 + 26; +9 new policy_validation tests)
- [x] `policy_gate.test.ts` updated to reflect the dropped `"present"` rule
- [x] `policy_validation.test.ts` covers: base-only acceptance, typo rejection, per-connector extras (db's `"present"` accepted with `DB_POLICY_EXTRAS`), top-level policy stays base-only

## Breaking change

Toolkit `Rule` no longer includes `"present"`. Operator configs with `write: "present"` etc. now fail validation at the toolkit layer. Mitigation: db doesn't go through this validator (it has `disablePolicyDiscovery: true`); other connectors used base values already. Bump major or include in the existing `^2.0.0-rc` series.