### PR TITLE
fix(toolkit): resolveAgentCli finds bundled connector CLIs (2.1.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "narai-primitives",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Read-only connectors + planning hub + connector framework + credential resolution, in one package. Bundles what was @narai/connector-toolkit, @narai/connector-config, @narai/connector-hub, the seven @narai/<svc>-agent-connector packages, and @narai/credential-providers.",
   "type": "module",
   "main": "./dist/hub/index.js",

--- a/src/toolkit/agent_resolver.ts
+++ b/src/toolkit/agent_resolver.ts
@@ -1,14 +1,21 @@
 /**
  * agent_resolver — locate a connector's CLI on disk via the canonical
- * 4-step fallback every consumer (the hub, doc-wiki's wrappers, etc.) needs:
+ * 5-step fallback every consumer (the hub, doc-wiki's wrappers, etc.) needs:
  *
  *   1. `<NAME>_AGENT_CLI` env var (operator escape hatch).
- *   2. `~/.claude/plugins/cache/<name>-agent-plugin*` — populated by Claude
+ *   2. **Bundled-self** — when narai-primitives is installed (npm install,
+ *      npm link, or running from its own source tree), the canonical 2.x
+ *      layout ships every connector CLI at
+ *      `<narai-primitives root>/dist/connectors/<name>/cli.js`. The
+ *      resolver derives that root from its own file path via
+ *      `import.meta.url`, so the lookup works regardless of install layout.
+ *   3. `~/.claude/plugins/cache/<name>-agent-plugin*` — populated by Claude
  *      Code's plugin manager.
- *   3. `${CLAUDE_PLUGIN_DATA}/node_modules/<package>/<cliRelativePath>` —
+ *   4. `${CLAUDE_PLUGIN_DATA}/node_modules/<package>/<cliRelativePath>` —
  *      where the connector's `SessionStart` hook installs it.
- *   4. `~/src/connectors/<name>-agent-connector/<cliRelativePath>` — the
- *      developer-machine fallback.
+ *   5. `~/src/connectors/<name>-agent-connector/<cliRelativePath>` — the
+ *      legacy developer-machine fallback (kept for backward compat with
+ *      pre-2.0 layouts).
  *
  * Returns null if no candidate exists, so callers can fail with a clear
  * message instead of crashing on `spawn`.
@@ -17,6 +24,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 
 export interface ResolveAgentCliOptions {
   /** Connector short name (e.g. `"confluence"`, `"db"`, `"aws"`). */
@@ -31,6 +39,15 @@ export interface ResolveAgentCliOptions {
   cliRelativePath?: string;
   /** Dev-fallback root. Default: `~/src/connectors/`. */
   devRoot?: string;
+  /**
+   * Override the bundled-self search root. The default is computed from
+   * `import.meta.url` (the resolver's own file location) so the lookup
+   * works in any install layout. Pass `null` (explicit) to skip the
+   * bundled-self check entirely — useful for unit tests that want to
+   * exercise the lower fallback paths without colliding with the real
+   * bundled connector CLIs that ship next to this file.
+   */
+  bundledSelfRoot?: string | null;
   /** Override for `process.env`. Used by tests; production callers leave it alone. */
   envOverride?: NodeJS.ProcessEnv;
   /** Override for `os.homedir()`. Used by tests. */
@@ -39,6 +56,7 @@ export interface ResolveAgentCliOptions {
 
 export type ResolutionSource =
   | "env"
+  | "bundled-self"
   | "plugin-cache"
   | "claude-plugin-data"
   | "dev-fallback";
@@ -70,6 +88,25 @@ function defaultDevRoot(home: string): string {
   return path.join(home, "src", "connectors");
 }
 
+/**
+ * Derive narai-primitives' own package root from this file's location.
+ *
+ * Layout after build: `<package root>/dist/toolkit/agent_resolver.js`. Walking
+ * up two directories from `import.meta.url` lands on the package root in
+ * every install scenario (npm install, npm link, source dir).
+ *
+ * Returns `null` when the file URL can't be parsed — defensive only;
+ * shouldn't happen in any standard ESM runtime.
+ */
+function defaultBundledSelfRoot(): string | null {
+  try {
+    const here = fileURLToPath(import.meta.url);
+    return path.resolve(path.dirname(here), "..", "..");
+  } catch {
+    return null;
+  }
+}
+
 export function resolveAgentCli(opts: ResolveAgentCliOptions): ResolvedAgentCli | null {
   const env = opts.envOverride ?? process.env;
   const home = opts.homeOverride ?? os.homedir();
@@ -78,6 +115,10 @@ export function resolveAgentCli(opts: ResolveAgentCliOptions): ResolvedAgentCli 
   const packageName = opts.packageName ?? defaultPackageName(opts.name);
   const cliRelative = opts.cliRelativePath ?? "dist/cli.js";
   const devRoot = opts.devRoot ?? defaultDevRoot(home);
+  const bundledSelfRoot =
+    opts.bundledSelfRoot === null
+      ? null
+      : (opts.bundledSelfRoot ?? defaultBundledSelfRoot());
 
   // 1. Explicit env-var override.
   const envPath = env[envVar];
@@ -85,7 +126,29 @@ export function resolveAgentCli(opts: ResolveAgentCliOptions): ResolvedAgentCli 
     return { command: "node", args: [envPath], source: "env", resolvedPath: envPath };
   }
 
-  // 2. Plugin cache lookup.
+  // 2. Bundled-self: the canonical 2.x layout ships every connector CLI at
+  //    `<narai-primitives root>/dist/connectors/<name>/cli.js`. This is the
+  //    primary path for any caller that has narai-primitives installed —
+  //    npm install, npm link, or a source checkout all flow through here.
+  if (bundledSelfRoot !== null) {
+    const bundledCli = path.join(
+      bundledSelfRoot,
+      "dist",
+      "connectors",
+      opts.name,
+      "cli.js",
+    );
+    if (fs.existsSync(bundledCli)) {
+      return {
+        command: "node",
+        args: [bundledCli],
+        source: "bundled-self",
+        resolvedPath: bundledCli,
+      };
+    }
+  }
+
+  // 3. Plugin cache lookup.
   const pluginCache = path.join(home, ".claude", "plugins", "cache");
   if (fs.existsSync(pluginCache)) {
     let entries: string[];
@@ -103,7 +166,7 @@ export function resolveAgentCli(opts: ResolveAgentCliOptions): ResolvedAgentCli 
     }
   }
 
-  // 3. CLAUDE_PLUGIN_DATA install location.
+  // 4. CLAUDE_PLUGIN_DATA install location.
   const pluginData = env["CLAUDE_PLUGIN_DATA"];
   if (typeof pluginData === "string" && pluginData !== "") {
     const candidate = path.join(pluginData, "node_modules", packageName, cliRelative);
@@ -112,7 +175,7 @@ export function resolveAgentCli(opts: ResolveAgentCliOptions): ResolvedAgentCli 
     }
   }
 
-  // 4. Dev fallback.
+  // 5. Dev fallback (legacy ~/src/connectors/<name>-agent-connector layout).
   const devCandidate = path.join(devRoot, `${opts.name}-agent-connector`, cliRelative);
   if (fs.existsSync(devCandidate)) {
     return { command: "node", args: [devCandidate], source: "dev-fallback", resolvedPath: devCandidate };

--- a/tests/toolkit/agent_resolver.test.ts
+++ b/tests/toolkit/agent_resolver.test.ts
@@ -25,6 +25,7 @@ describe("resolveAgentCli", () => {
       name: "fake",
       homeOverride: fakeHome,
       envOverride: {},
+      bundledSelfRoot: null,
     });
     expect(result).toBeNull();
   });
@@ -37,6 +38,7 @@ describe("resolveAgentCli", () => {
       name: "jira",
       homeOverride: fakeHome,
       envOverride: { JIRA_AGENT_CLI: customCli },
+      bundledSelfRoot: null,
     });
     expect(result).not.toBeNull();
     expect(result?.source).toBe("env");
@@ -54,6 +56,7 @@ describe("resolveAgentCli", () => {
       name: "db",
       homeOverride: fakeHome,
       envOverride: { DB_AGENT_CLI: customCli },
+      bundledSelfRoot: null,
     });
     expect(result?.source).toBe("env");
   });
@@ -63,6 +66,7 @@ describe("resolveAgentCli", () => {
       name: "jira",
       homeOverride: fakeHome,
       envOverride: { JIRA_AGENT_CLI: path.join(fakeHome, "nope") },
+      bundledSelfRoot: null,
     });
     expect(result).toBeNull();
   });
@@ -79,6 +83,7 @@ describe("resolveAgentCli", () => {
       name: "jira",
       homeOverride: fakeHome,
       envOverride: {},
+      bundledSelfRoot: null,
     });
     expect(result?.source).toBe("plugin-cache");
     expect(result?.resolvedPath).toBe(cliPath);
@@ -93,6 +98,7 @@ describe("resolveAgentCli", () => {
         name: "jira",
         homeOverride: fakeHome,
         envOverride: { CLAUDE_PLUGIN_DATA: pluginData },
+        bundledSelfRoot: null,
       });
       expect(result?.source).toBe("claude-plugin-data");
       expect(result?.resolvedPath).toBe(cliPath);
@@ -108,6 +114,7 @@ describe("resolveAgentCli", () => {
       name: "jira",
       homeOverride: fakeHome,
       envOverride: {},
+      bundledSelfRoot: null,
     });
     expect(result?.source).toBe("dev-fallback");
     expect(result?.resolvedPath).toBe(cliPath);
@@ -122,6 +129,7 @@ describe("resolveAgentCli", () => {
       homeOverride: fakeHome,
       envOverride: {},
       devRoot: customRoot,
+      bundledSelfRoot: null,
     });
     expect(result?.resolvedPath).toBe(cliPath);
   });
@@ -143,9 +151,134 @@ describe("resolveAgentCli", () => {
       pluginNameContains: "myorg-thing-plugin",
       packageName: "@myorg/thing",
       cliRelativePath: "build/main.js",
+      bundledSelfRoot: null,
     });
     expect(result?.source).toBe("plugin-cache");
     expect(result?.resolvedPath).toBe(cliPath);
+  });
+
+  it("bundled-self resolves a CLI inside narai-primitives' own dist tree", () => {
+    // Simulate the canonical 2.x bundled layout: narai-primitives' package
+    // root contains dist/connectors/<name>/cli.js for every connector.
+    const bundledRoot = fs.mkdtempSync(path.join(os.tmpdir(), "np-bundled-"));
+    try {
+      const cliPath = path.join(
+        bundledRoot,
+        "dist",
+        "connectors",
+        "github",
+        "cli.js",
+      );
+      fs.mkdirSync(path.dirname(cliPath), { recursive: true });
+      fs.writeFileSync(cliPath, "#!/usr/bin/env node\n");
+      const result = resolveAgentCli({
+        name: "github",
+        homeOverride: fakeHome,
+        envOverride: {},
+        bundledSelfRoot: bundledRoot,
+      });
+      expect(result?.source).toBe("bundled-self");
+      expect(result?.command).toBe("node");
+      expect(result?.resolvedPath).toBe(cliPath);
+    } finally {
+      fs.rmSync(bundledRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("bundled-self is preferred over plugin-cache when both exist", () => {
+    // The bundled CLI ships with the package; plugin-cache is a legacy
+    // fallback. When narai-primitives is installed normally, bundled-self
+    // is the right answer.
+    const bundledRoot = fs.mkdtempSync(path.join(os.tmpdir(), "np-bundled-"));
+    try {
+      const bundledCli = path.join(
+        bundledRoot,
+        "dist",
+        "connectors",
+        "jira",
+        "cli.js",
+      );
+      fs.mkdirSync(path.dirname(bundledCli), { recursive: true });
+      fs.writeFileSync(bundledCli, "");
+
+      // Also set up a plugin-cache entry for the legacy package layout.
+      const pluginDir = path.join(
+        fakeHome,
+        ".claude", "plugins", "cache",
+        "jira-agent-plugin",
+        "node_modules", "@narai", "jira-agent-connector",
+      );
+      touchPackageCli(pluginDir);
+
+      const result = resolveAgentCli({
+        name: "jira",
+        homeOverride: fakeHome,
+        envOverride: {},
+        bundledSelfRoot: bundledRoot,
+      });
+      expect(result?.source).toBe("bundled-self");
+      expect(result?.resolvedPath).toBe(bundledCli);
+    } finally {
+      fs.rmSync(bundledRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("env-var override still wins over bundled-self", () => {
+    // Operators must always be able to override with NAME_AGENT_CLI even
+    // when narai-primitives' own bundled CLI is available.
+    const bundledRoot = fs.mkdtempSync(path.join(os.tmpdir(), "np-bundled-"));
+    try {
+      const bundledCli = path.join(
+        bundledRoot,
+        "dist",
+        "connectors",
+        "jira",
+        "cli.js",
+      );
+      fs.mkdirSync(path.dirname(bundledCli), { recursive: true });
+      fs.writeFileSync(bundledCli, "");
+
+      const customCli = path.join(fakeHome, "custom", "cli.js");
+      fs.mkdirSync(path.dirname(customCli), { recursive: true });
+      fs.writeFileSync(customCli, "");
+
+      const result = resolveAgentCli({
+        name: "jira",
+        homeOverride: fakeHome,
+        envOverride: { JIRA_AGENT_CLI: customCli },
+        bundledSelfRoot: bundledRoot,
+      });
+      expect(result?.source).toBe("env");
+      expect(result?.resolvedPath).toBe(customCli);
+    } finally {
+      fs.rmSync(bundledRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("bundled-self gracefully degrades when the connector is not bundled", () => {
+    // A name that has no built CLI under bundledSelfRoot should fall
+    // through to the lower fallbacks instead of erroring.
+    const bundledRoot = fs.mkdtempSync(path.join(os.tmpdir(), "np-bundled-empty-"));
+    try {
+      // Empty bundled root — no dist/connectors/<name>/cli.js inside.
+      const pluginDir = path.join(
+        fakeHome,
+        ".claude", "plugins", "cache",
+        "jira-agent-plugin",
+        "node_modules", "@narai", "jira-agent-connector",
+      );
+      const pluginCli = touchPackageCli(pluginDir);
+      const result = resolveAgentCli({
+        name: "jira",
+        homeOverride: fakeHome,
+        envOverride: {},
+        bundledSelfRoot: bundledRoot,
+      });
+      expect(result?.source).toBe("plugin-cache");
+      expect(result?.resolvedPath).toBe(pluginCli);
+    } finally {
+      fs.rmSync(bundledRoot, { recursive: true, force: true });
+    }
   });
 
   it("plugin cache is preferred over CLAUDE_PLUGIN_DATA when both exist", () => {
@@ -165,6 +298,7 @@ describe("resolveAgentCli", () => {
         name: "jira",
         homeOverride: fakeHome,
         envOverride: { CLAUDE_PLUGIN_DATA: pluginData },
+        bundledSelfRoot: null,
       });
       expect(result?.source).toBe("plugin-cache");
       expect(result?.resolvedPath).toBe(pluginCli);


### PR DESCRIPTION
## Summary

Fixes a real runtime regression uncovered by the doc-wiki gather()-boundary eval. \`resolveAgentCli({name: \"github\"})\` was returning \`null\` even when narai-primitives is correctly installed and the bundled CLI exists at \`node_modules/narai-primitives/dist/connectors/github/cli.js\`. The resolver's four fallback steps (env-var override, plugin-cache, CLAUDE_PLUGIN_DATA, dev-fallback) all assumed the pre-2.0 layout where each connector shipped as \`@narai/<name>-agent-connector\` with \`dist/cli.js\`. **None of them checked the canonical 2.x bundled layout.**

## Production impact (silent before this fix)

Any caller using the resolver's default defaults — including the hub's own \`defaultCliResolver\` at \`src/hub/index.ts:64\` — hit \`CLI_NOT_FOUND\` on every dispatch. The unit tests and doc-wiki test suite never caught this because nothing actually exercised \`gather()\` against the bundled connectors end-to-end. The bug was hiding because the only test that does that — eval id 14 in doc-wiki — was added literally in the same session that surfaced this fix, and the runner had to inject a custom \`cliResolver\` workaround to get past the silent failure.

After this fix lands and 2.1.1 publishes, doc-wiki's \`/doc-wiki:ingest <github-url>\` (and every other gather() consumer) actually dispatches against the bundled connector subprocess instead of silently returning a CLI_NOT_FOUND step.

## What changed

Added a new \"bundled-self\" resolution step after the env-var override and before the legacy fallbacks. It derives narai-primitives' own package root from \`import.meta.url\` (\`<root>/dist/toolkit/agent_resolver.js\` → walk up two dirs) and looks for \`<root>/dist/connectors/<name>/cli.js\`. Works in every install layout: \`npm install\`, \`npm link\`, source checkout.

Order is now:
1. \`<NAME>_AGENT_CLI\` env var (operator escape hatch)
2. **Bundled-self** (NEW — canonical 2.x location)
3. Plugin cache (legacy)
4. CLAUDE_PLUGIN_DATA (legacy)
5. Dev fallback (legacy ~/src/connectors/...)

The legacy steps stay for backward compatibility with pre-2.0 install layouts. Tests can pass \`bundledSelfRoot: null\` to exercise the lower fallbacks without the real bundled CLIs colliding.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run build\` succeeds
- [x] \`npm test\` — **1570 passed** (was 1566 + 4 new resolver tests), 26 skipped, 0 failures
- [x] Manual end-to-end check: \`import('narai-primitives/toolkit').resolveAgentCli({name:'github'})\` against a normal \`npm install narai-primitives\` install resolves the bundled CLI under \`node_modules/narai-primitives/dist/connectors/github/cli.js\` (was: \`null\`).

## Version bump

Patch — \`2.1.0 → 2.1.1\`. No API change; \`ResolveAgentCliOptions\` adds an optional \`bundledSelfRoot\` field, additive.