### PR TITLE
fix(hub): prepareConnector finds SKILL.md in bundled 2.x layout (2.1.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "narai-primitives",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Read-only connectors + planning hub + connector framework + credential resolution, in one package. Bundles what was @narai/connector-toolkit, @narai/connector-config, @narai/connector-hub, the seven @narai/<svc>-agent-connector packages, and @narai/credential-providers.",
   "type": "module",
   "main": "./dist/hub/index.js",

--- a/src/hub/index.ts
+++ b/src/hub/index.ts
@@ -45,10 +45,31 @@ function shortName(skill: string): string {
   return skill.replace(/-agent-connector$/, "");
 }
 
-/** Walk up from a `dist/cli.js` path to the package root. */
+/** Walk up from a connector CLI path to the narai-primitives package root.
+ *
+ * Two layouts to handle:
+ *   - Bundled 2.x: `<root>/dist/connectors/<name>/cli.js` (walk up 4)
+ *   - Legacy:     `<root>/dist/cli.js` (walk up 2 — pre-2.0 per-connector packages)
+ */
 function packageRootFromCli(cliPath: string): string {
+  const parts = cliPath.split(path.sep);
+  const distIdx = parts.lastIndexOf("dist");
+  if (distIdx > 0 && parts[distIdx + 1] === "connectors") {
+    // <root>/dist/connectors/<name>/cli.js → <root>
+    return parts.slice(0, distIdx).join(path.sep);
+  }
   // <root>/dist/cli.js → <root>
   return path.dirname(path.dirname(cliPath));
+}
+
+/** Candidate SKILL.md paths under a package root, in preference order. */
+function skillMdCandidates(root: string, name: string): string[] {
+  return [
+    // Bundled 2.x: plugins/<name>-agent/skills/<name>-agent/SKILL.md
+    path.join(root, "plugins", `${name}-agent`, "skills", `${name}-agent`, "SKILL.md"),
+    // Legacy: plugin/skills/<name>-agent/SKILL.md (pre-2.0 per-connector packages)
+    path.join(root, "plugin", "skills", `${name}-agent`, "SKILL.md"),
+  ];
 }
 
 /** Read a file synchronously, returning null on failure. */
@@ -116,13 +137,20 @@ function prepareConnector(
     };
   }
   const root = packageRootFromCli(resolved.resolvedPath);
-  const skillFile = path.join(root, "plugin", "skills", `${name}-agent`, "SKILL.md");
-  const skillContent = tryRead(skillFile);
+  const candidates = skillMdCandidates(root, name);
+  let skillContent: string | null = null;
+  for (const candidate of candidates) {
+    const content = tryRead(candidate);
+    if (content !== null) {
+      skillContent = content;
+      break;
+    }
+  }
   if (skillContent === null) {
     return {
       error: {
         code: "SKILL_NOT_FOUND",
-        message: `SKILL.md not found at ${skillFile}`,
+        message: `SKILL.md not found at any of: ${candidates.join(", ")}`,
       },
     };
   }

--- a/tests/hub/gather.test.ts
+++ b/tests/hub/gather.test.ts
@@ -33,7 +33,7 @@ afterEach(() => {
 
 /** Build a fake `<root>/<name>-agent-connector/{dist/cli.js, plugin/skills/<name>-agent/SKILL.md}`
  *  layout under tmpDir. Returns the absolute cli path so the test can register
- *  it with the injected `cliResolver`. */
+ *  it with the injected `cliResolver`. This is the LEGACY pre-2.0 layout. */
 function setupFakeConnector(
   root: string,
   name: string,
@@ -51,6 +51,34 @@ function setupFakeConnector(
   fs.writeFileSync(
     path.join(pkgRoot, "plugin", "skills", `${name}-agent`, "SKILL.md"),
     opts.skill ?? `# ${name} skill body`,
+  );
+  return cliPath;
+}
+
+/** Build a fake bundled-2.x layout under `<root>/narai-primitives/`:
+ *   - dist/connectors/<name>/cli.js
+ *   - plugins/<name>-agent/skills/<name>-agent/SKILL.md
+ *  Returns the cli path so a test can register it with the cliResolver. */
+function setupBundledConnector(
+  root: string,
+  name: string,
+  opts: { cliBody?: string; skill?: string } = {},
+): string {
+  const pkgRoot = path.join(root, "narai-primitives");
+  fs.mkdirSync(path.join(pkgRoot, "dist", "connectors", name), { recursive: true });
+  fs.mkdirSync(
+    path.join(pkgRoot, "plugins", `${name}-agent`, "skills", `${name}-agent`),
+    { recursive: true },
+  );
+  const cliPath = path.join(pkgRoot, "dist", "connectors", name, "cli.js");
+  fs.writeFileSync(
+    cliPath,
+    opts.cliBody ??
+      `process.stdout.write(JSON.stringify({status:"success",action:"x",data:{name:"${name}"}}));\n`,
+  );
+  fs.writeFileSync(
+    path.join(pkgRoot, "plugins", `${name}-agent`, "skills", `${name}-agent`, "SKILL.md"),
+    opts.skill ?? `# ${name} skill body (bundled)`,
   );
   return cliPath;
 }
@@ -128,6 +156,69 @@ describe("gather end-to-end with stubs", () => {
       data: { name: "aws" },
     });
     expect(out.results[0]?.error).toBeUndefined();
+  });
+
+  it("loads SKILL.md from the bundled 2.x layout (plugins/<name>-agent/skills/<name>-agent/SKILL.md)", async () => {
+    // The bundled 2.x narai-primitives layout puts the connector CLI at
+    // <root>/dist/connectors/<name>/cli.js and the skill at
+    // <root>/plugins/<name>-agent/skills/<name>-agent/SKILL.md.
+    // Both paths must resolve correctly from `prepareConnector`.
+    //
+    // We verify by capturing the planner's systemPrompt — buildSystemPrompt
+    // concatenates each connector's skillContent verbatim, so finding the
+    // bundled-skill marker in the prompt proves the bundled SKILL.md was
+    // read successfully.
+    const cli = setupBundledConnector(tmpDir, "aws", {
+      skill: "# aws bundled skill — only this body proves bundled SKILL.md loaded",
+    });
+    let capturedSystemPrompt = "";
+    const planner: Planner = {
+      plan: async (systemPrompt) => {
+        capturedSystemPrompt = systemPrompt;
+        return JSON.stringify([{ connector: "aws", action: "x", params: {} }]);
+      },
+    };
+    const loader = stubLoader({ aws: { skill: "aws-agent-connector" } });
+    const cliResolver: CliResolver = (name) =>
+      name === "aws"
+        ? { command: "node", args: [cli], source: "bundled-self", resolvedPath: cli }
+        : null;
+    const out = await gather(
+      { prompt: "?" },
+      { planner, configLoader: loader, cliResolver },
+    );
+    // No prep error — SKILL.md was found at one of the candidate paths.
+    expect(
+      out.results.every((r) => r.error?.code !== "SKILL_NOT_FOUND"),
+    ).toBe(true);
+    // The bundled-skill marker must appear in the system prompt — proves
+    // the bundled candidate path was the one that resolved.
+    expect(capturedSystemPrompt).toContain("aws bundled skill");
+  });
+
+  it("falls back to the legacy plugin/skills/<name>-agent/SKILL.md layout when the bundled path is absent", async () => {
+    // Existing pre-2.0 packages still ship the legacy `plugin/skills/...`
+    // path. The hub must keep finding SKILL.md there too.
+    const cli = setupFakeConnector(tmpDir, "jira", {
+      skill: "# jira legacy skill body — only the legacy path can produce this",
+    });
+    let capturedSystemPrompt = "";
+    const planner: Planner = {
+      plan: async (systemPrompt) => {
+        capturedSystemPrompt = systemPrompt;
+        return JSON.stringify([{ connector: "jira", action: "x", params: {} }]);
+      },
+    };
+    const loader = stubLoader({ jira: { skill: "jira-agent-connector" } });
+    const cliResolver = stubCliResolver({ jira: cli });
+    const out = await gather(
+      { prompt: "?" },
+      { planner, configLoader: loader, cliResolver },
+    );
+    expect(
+      out.results.every((r) => r.error?.code !== "SKILL_NOT_FOUND"),
+    ).toBe(true);
+    expect(capturedSystemPrompt).toContain("jira legacy skill body");
   });
 
   it("returns plan: [] and PLANNER_INVALID when planner output is unparsable", async () => {


### PR DESCRIPTION
## Summary

Companion to 2.1.1's \`resolveAgentCli\` fix. The CLI resolver now finds the bundled CLI at \`<root>/dist/connectors/<name>/cli.js\`, but the hub's \`prepareConnector\` still derived the package root and SKILL.md path using pre-2.0 arithmetic — so every bundled connector still failed with \`SKILL_NOT_FOUND\` before reaching the connector subprocess.

This was surfaced by re-running doc-wiki's eval-14 (\`wiki-gather-credential-boundary\`) against the freshly-published 2.1.1 with no workarounds: 5/9 expectations passed, 4 failed because every dispatch returned \`SKILL_NOT_FOUND\` before the connector subprocess could spawn. The credential-resolution boundary the eval is built to verify was unreachable.

## Two issues fixed in src/hub/index.ts

1. **packageRootFromCli**: walked up only 2 dirs from the CLI path, which is correct for the legacy \`<root>/dist/cli.js\` layout but wrong for \`<root>/dist/connectors/<name>/cli.js\` (needs 4 levels up). Now detects the bundled layout by checking for \`dist/connectors/\` in the CLI path and walks the right number of levels.

2. **SKILL.md location**: was hardcoded to \`<root>/plugin/skills/<name>-agent/SKILL.md\` (singular \`plugin\`). The bundled layout puts it at \`<root>/plugins/<name>-agent/skills/<name>-agent/SKILL.md\` (plural \`plugins\`, plus an extra \`<name>-agent\` dir nesting). Now tries the bundled candidate first, then falls back to the legacy path so pre-2.0 packages still work. The \`SKILL_NOT_FOUND\` error message lists both tried paths so failures are diagnosable.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run build\` succeeds
- [x] \`npm test\` — **1572 passed** (was 1570 + 2 new gather-test cases for bundled and legacy SKILL.md paths), 26 skipped, 0 failures

The two new tests use a capturing planner to verify the loaded SKILL.md content reaches the planner's \`systemPrompt\` verbatim — \`buildSystemPrompt\` concatenates each connector's \`skillContent\`, so finding the marker text in the prompt proves the right candidate path resolved.

## Version bump

Patch — \`2.1.1 → 2.1.2\`. No API change; completes the 2.1.1 bundled-layout fix.

## What this unblocks

After 2.1.2 publishes, \`gather()\` against any bundled connector actually dispatches to the connector subprocess instead of bailing at SKILL_NOT_FOUND. doc-wiki's \`/doc-wiki:ingest <url>\` now reaches the credential-resolution boundary in production for the first time.