### PR TITLE
fix(db): runSchema honors getSchemaAsync; bump plugin manifests (2.1.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "narai-primitives",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Read-only connectors + planning hub + connector framework + credential resolution, in one package. Bundles what was @narai/connector-toolkit, @narai/connector-config, @narai/connector-hub, the seven @narai/<svc>-agent-connector packages, and @narai/credential-providers.",
   "type": "module",
   "main": "./dist/hub/index.js",

--- a/plugins/aws-agent/package.json
+++ b/plugins/aws-agent/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "description": "Runtime manifest for aws-agent-plugin. The SessionStart hook runs `npm install` on this manifest into ${CLAUDE_PLUGIN_DATA}.",
   "dependencies": {
-    "narai-primitives": "^2.0.0"
+    "narai-primitives": "^2.1.3"
   }
 }

--- a/plugins/confluence-agent/package.json
+++ b/plugins/confluence-agent/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "narai-primitives": "^2.0.0"
+    "narai-primitives": "^2.1.3"
   }
 }

--- a/plugins/db-agent/package.json
+++ b/plugins/db-agent/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "narai-primitives": "^2.0.0"
+    "narai-primitives": "^2.1.3"
   }
 }

--- a/plugins/gcp-agent/package.json
+++ b/plugins/gcp-agent/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "description": "Runtime manifest for gcp-agent-plugin. The SessionStart hook runs `npm install` on this manifest into ${CLAUDE_PLUGIN_DATA}.",
   "dependencies": {
-    "narai-primitives": "^2.0.0"
+    "narai-primitives": "^2.1.3"
   }
 }

--- a/plugins/github-agent/package.json
+++ b/plugins/github-agent/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "narai-primitives": "^2.0.0"
+    "narai-primitives": "^2.1.3"
   }
 }

--- a/plugins/jira-agent/package.json
+++ b/plugins/jira-agent/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "narai-primitives": "^2.0.0"
+    "narai-primitives": "^2.1.3"
   }
 }

--- a/plugins/notion-agent/package.json
+++ b/plugins/notion-agent/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "narai-primitives": "^2.0.0"
+    "narai-primitives": "^2.1.3"
   }
 }

--- a/src/connectors/db/dispatcher.ts
+++ b/src/connectors/db/dispatcher.ts
@@ -34,6 +34,7 @@ import { SQLiteDriver } from "./lib/drivers/sqlite.js";
 import type {
   DatabaseDriver,
   ExecuteReadResult,
+  Table,
 } from "./lib/drivers/base.js";
 import { parseConfig } from "./config.js";
 import {
@@ -263,14 +264,33 @@ export function adaptDriver(
   };
 }
 
-export function runSchema(
+/**
+ * Phase E drivers (pg, mysql, mssql, oracle, mongo, dynamo) return a useless
+ * stub from sync `getSchema` and put the real query logic in an async
+ * `getSchemaAsync` method. Detect the async hook the same way `SchemaManager`
+ * does (`lib/schema.ts`) and prefer it; fall back to sync `getSchema` for
+ * sqlite which has no async variant.
+ */
+interface AsyncSchemaDriver {
+  getSchemaAsync?(
+    conn: unknown,
+    schemaName?: string,
+    tableFilter?: string | null,
+  ): Promise<Table[]>;
+}
+
+export async function runSchema(
   driver: DatabaseDriver,
   conn: unknown,
   filter: string | null,
   envName: string = "",
-): FetchResult {
+): Promise<FetchResult> {
   try {
-    const tables = driver.getSchema(conn, undefined, filter);
+    const asyncHook = (driver as AsyncSchemaDriver).getSchemaAsync;
+    const tables: Table[] =
+      typeof asyncHook === "function"
+        ? await asyncHook.call(driver, conn, undefined, filter)
+        : driver.getSchema(conn, undefined, filter);
     let columnCount = 0;
     for (const t of tables) columnCount += t.columns.length;
     logEvent({
@@ -449,11 +469,13 @@ async function runQueryOnSqlite(v: QueryParamsValidated): Promise<FetchResult> {
   }
 }
 
-function runSchemaOnSqlite(v: SchemaParamsValidated): FetchResult {
+async function runSchemaOnSqlite(
+  v: SchemaParamsValidated,
+): Promise<FetchResult> {
   const driver = new SQLiteDriver();
   const conn = driver.connect({ database: v.sqlite_path! });
   try {
-    return runSchema(driver, conn, v.filter ?? null, "");
+    return await runSchema(driver, conn, v.filter ?? null, "");
   } finally {
     driver.close(conn);
   }
@@ -576,7 +598,12 @@ async function runOnEnv(
   try {
     if (action === "schema") {
       const sv = v as SchemaParamsValidated;
-      return runSchema(conn.driver, conn.native, sv.filter ?? null, envName);
+      return await runSchema(
+        conn.driver,
+        conn.native,
+        sv.filter ?? null,
+        envName,
+      );
     }
     const qv = v as QueryParamsValidated;
     const policy = new Policy(approvalMode, rules);
@@ -627,7 +654,7 @@ export async function fetch(
       return await runOnEnv("query", v);
     }
     const v = validateSchemaParams(p);
-    if (v.sqlite_path) return runSchemaOnSqlite(v);
+    if (v.sqlite_path) return await runSchemaOnSqlite(v);
     return await runOnEnv("schema", v);
   } catch (exc) {
     return {

--- a/tests/connectors/db/run_schema.test.ts
+++ b/tests/connectors/db/run_schema.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Regression test: dispatcher.runSchema must call driver.getSchemaAsync
+ * when present.
+ *
+ * Phase E drivers (pg, mysql, mssql, oracle, mongo, dynamo) intentionally
+ * stub the sync `getSchema` to return `[]` and put their real
+ * `information_schema` query logic in `getSchemaAsync`. The dispatcher's
+ * `runSchema` originally called the sync stub directly, so a
+ * `gather()` "show me the tables" against postgres always returned
+ * `table_count: 0` despite a successful connection — silent failure
+ * surfaced by doc-wiki's eval-20.
+ *
+ * This test pins the contract: when a driver exposes `getSchemaAsync`,
+ * runSchema must use it; sync `getSchema` is the fallback only when no
+ * async hook exists (sqlite path).
+ */
+import { describe, expect, it } from "vitest";
+import { runSchema } from "../../../src/connectors/db/dispatcher.js";
+import {
+  Column,
+  DatabaseDriver,
+  Table,
+  type ExecuteReadResult,
+} from "../../../src/connectors/db/lib/drivers/base.js";
+import { OperationType } from "../../../src/connectors/db/lib/policy.js";
+
+/** Driver that exposes both the sync stub (returns []) and the async
+ *  hook (returns a real table). Mirrors the Phase E driver shape. */
+class StubAsyncDriver extends DatabaseDriver {
+  syncCalls = 0;
+  asyncCalls = 0;
+  connect(): unknown {
+    return {};
+  }
+  executeRead(): ExecuteReadResult {
+    return { columns: [], rows: [], row_count: 0, execution_time_ms: 0 };
+  }
+  override getSchema(
+    _conn: unknown,
+    _schemaName?: string,
+    _tableFilter?: string | null,
+  ): Table[] {
+    this.syncCalls += 1;
+    return []; // stub — same as the real Phase E drivers
+  }
+  async getSchemaAsync(
+    _conn: unknown,
+    _schemaName?: string,
+    _tableFilter?: string | null,
+  ): Promise<Table[]> {
+    this.asyncCalls += 1;
+    return [
+      new Table({
+        name: "users",
+        schema: "public",
+        columns: [
+          new Column({ name: "id", data_type: "integer", nullable: false, is_primary_key: true }),
+          new Column({ name: "email", data_type: "text", nullable: false }),
+        ],
+      }),
+    ];
+  }
+  close(): void {
+    /* no-op */
+  }
+  classifyOperation(): OperationType {
+    return OperationType.READ;
+  }
+}
+
+/** Sync-only driver (sqlite shape) — no getSchemaAsync method. */
+class StubSyncDriver extends DatabaseDriver {
+  syncCalls = 0;
+  connect(): unknown {
+    return {};
+  }
+  executeRead(): ExecuteReadResult {
+    return { columns: [], rows: [], row_count: 0, execution_time_ms: 0 };
+  }
+  override getSchema(
+    _conn: unknown,
+    _schemaName?: string,
+    _tableFilter?: string | null,
+  ): Table[] {
+    this.syncCalls += 1;
+    return [
+      new Table({
+        name: "legacy_table",
+        schema: "main",
+        columns: [
+          new Column({ name: "id", data_type: "INTEGER", nullable: false, is_primary_key: true }),
+        ],
+      }),
+    ];
+  }
+  close(): void {
+    /* no-op */
+  }
+  classifyOperation(): OperationType {
+    return OperationType.READ;
+  }
+}
+
+describe("runSchema (dispatcher)", () => {
+  it("prefers getSchemaAsync when the driver exposes it", async () => {
+    const driver = new StubAsyncDriver();
+    const result = await runSchema(driver, {}, null, "test-env");
+    expect(driver.asyncCalls).toBe(1);
+    expect(driver.syncCalls).toBe(0);
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.table_count).toBe(1);
+      expect(result.tables[0]?.name).toBe("users");
+    }
+  });
+
+  it("falls back to sync getSchema when getSchemaAsync is absent", async () => {
+    const driver = new StubSyncDriver();
+    const result = await runSchema(driver, {}, null, "sqlite-env");
+    expect(driver.syncCalls).toBe(1);
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.table_count).toBe(1);
+      expect(result.tables[0]?.name).toBe("legacy_table");
+    }
+  });
+
+  it("never calls the sync stub when async hook is present (the bug)", async () => {
+    // Direct regression check: prior to the fix, runSchema would call
+    // the sync stub which returns [] and emit table_count: 0 even when
+    // the async path could have produced rows. If a future refactor
+    // accidentally removes the async detection, this test catches it.
+    const driver = new StubAsyncDriver();
+    const result = await runSchema(driver, {}, null);
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.table_count).toBeGreaterThan(0);
+    }
+  });
+
+  it("propagates structured error envelope on async failure", async () => {
+    class FailingAsync extends StubAsyncDriver {
+      override async getSchemaAsync(): Promise<Table[]> {
+        throw new Error("boom");
+      }
+    }
+    const driver = new FailingAsync();
+    const result = await runSchema(driver, {}, null, "fail-env");
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.error_code).toBe("SCHEMA_ERROR");
+      expect(result.error).toContain("boom");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Two fixes ride together for 2.1.3, both surfaced by doc-wiki's connector-boundary eval suite.

## 1. db.runSchema sync/async bug

\`dispatcher.runSchema\` called the **sync** \`driver.getSchema(conn, ...)\` — which is a stub returning \`[]\` in every Phase E driver (postgresql / mysql / sqlserver / oracle / mongodb / dynamodb). The real query logic lives in \`getSchemaAsync\`. Effect: any \`/doc-wiki:ingest\` \"show me the tables\" against a live postgres/mysql/etc returned \`table_count: 0\` despite a successful connection. Silent failure.

Surfaced by doc-wiki's eval-20 (\`wiki-gather-db-postgres-success\`), which had to work around it by issuing an explicit \`SELECT FROM information_schema.tables\` query instead of using the \`schema\` action.

Fix mirrors the existing pattern in \`src/connectors/db/lib/schema.ts\` (\`SchemaManager\`): duck-type \`driver.getSchemaAsync\`, await when present, fall back to sync \`getSchema\` for sqlite (which has no async variant). \`runSchema\` and \`runSchemaOnSqlite\` are now async; both call sites in \`runOnEnv\` and the top-level dispatcher correctly await them.

Regression test at \`tests/connectors/db/run_schema.test.ts\` pins the contract with 4 cases:
- async hook present → async path taken, sync stub never called
- async hook absent → sync fallback (sqlite shape)
- bug regression check (\`table_count > 0\` when async path produces rows — the exact symptom that surfaced from eval-20)
- structured SCHEMA_ERROR envelope on async failure

## 2. Plugin manifest byte-bump

The 7 connector plugins under \`plugins/<name>-agent/package.json\` declared \`\"narai-primitives\": \"^2.0.0\"\`. The marketplace SessionStart hook only reinstalls when this file changes (\`diff -q\` skip), so **existing installs in \`\$CLAUDE_PLUGIN_DATA\` never picked up 2.1.1, 2.1.2, or this 2.1.3 fix**. Bumping the caret to \`^2.1.3\` is byte-different but caret-equivalent — same range semantically, but forces \`npm install\` on next session start.

Affects: aws / confluence / db / gcp / github / jira / notion.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run build\` succeeds
- [x] \`npm test\` — **1576 passed** (was 1572 + 4 new run_schema cases), 26 skipped, 0 failures

## Version bump

Patch — \`2.1.2 → 2.1.3\`. No API change.

## What this unblocks

- After 2.1.3 publishes, doc-wiki's eval-20 can drop its workaround (use the \`schema\` action directly).
- Plugin-marketplace users on existing installs will pick up the full 2.1.x line on next session.