### PR TITLE
chore(ci): bump actions/checkout and actions/setup-node to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ["20", "22"]
+        node: ["22", "24"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Set up Node 20
-        uses: actions/setup-node@v4
+      - name: Set up Node 22
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: npm
 


### PR DESCRIPTION
## Summary

- Bump `actions/checkout` v4 -> v6 and `actions/setup-node` v4 -> v6 in both `ci.yml` and `release.yml` to clear the Node 20 deprecation warning ahead of GitHub's forced bump to Node 24 on **2026-06-02**.
- Latest stable tags at time of bump: `actions/checkout@v6.0.2`, `actions/setup-node@v6.4.0` — pinned to the major (`@v6`) so dependabot/patch picks roll naturally.
- CI matrix updated from `["20", "22"]` -> `["22", "24"]`. Node 20 hits the same deprecation; 22 (current LTS) + 24 (what the actions now use internally) is the post-deprecation alignment. Two versions per the existing convention.
- `release.yml` Node version bumped 20 -> 22 to stay on a tested + still-supported LTS.

## Node version impact

- `actions/checkout@v6` and `actions/setup-node@v6` both run on Node 24 internally. Minimum runner version is `v2.327.1` (GitHub-hosted runners are well past this).
- Our `engines.node: ">=20.0.0"` is unaffected — that constrains consumers, not the CI runtime.

## release.yml compatibility review

The release workflow does `npm publish` via OIDC + creates a GitHub Release on tag push. Reviewed each touchpoint:

- `permissions.id-token: write` — unchanged.
- Tag-vs-`package.json` version check — unchanged (still bash + `node -p`).
- `registry-url: "https://registry.npmjs.org"` + `NODE_AUTH_TOKEN` env — input still supported and behaves identically in `setup-node@v6`.
- `always-auth` — removed in `setup-node@v6.1.0`. We never used it, so no change needed.
- `package-manager-cache` auto-detect (new in `setup-node@v5`) — does not trigger because our `package.json` has no `packageManager` field, and we pass `cache: npm` explicitly which takes precedence either way.
- `npm publish --provenance` flow — unchanged.

No input syntax changes required.

## Test plan

- [ ] CI on this PR passes against the new `node: [22, 24]` matrix (this is itself proof the `ci.yml` bump works).
- [ ] release.yml is tag-triggered only — cannot test without cutting a release. The next `v*.*.*` tag push will exercise it. Action behavioral changes between v4 and v6 are minor (Node version internal); inputs we use are unchanged.