### PR TITLE
docs: README package count + invariant version pin + CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,12 +2,54 @@
 
 Thanks for your interest in contributing. Most contributions fall into one of two buckets:
 
-1. **Fixes / improvements to existing code** — open a PR following the conventions in this repo. Tests and types must stay green.
-2. **A brand-new builtin connector** — read the rest of this document. It describes the file layout, naming, testing, and marketplace surfacing expected of a new builtin.
+1. **Fixes / improvements to existing code** — see [Fixes and improvements](#fixes-and-improvements) below for the local-dev loop, conventions, and PR hygiene.
+2. **A brand-new builtin connector** — read the [New builtin connector](#new-builtin-connector) section. It describes the file layout, naming, testing, and marketplace surfacing expected of a new builtin.
 
 If you instead want a **local connector** for your own project (private API, internal tool, one-off), don't add it here. Use the `/create-connector` Claude Code skill (shipped via the [`narai`](https://github.com/narailabs/narai-claude-plugins) marketplace) — it scaffolds a minimal local connector at `.connectors/connectors/<slug>/` with no plugin layer, no publish step, no `git init`. Builtins are reserved for connectors useful enough that bundling them in the core npm package and shipping a Claude Code plugin for them is justified.
 
-## Before you start
+## Fixes and improvements
+
+### Before you start
+
+Read [`docs/architecture-invariants.md`](docs/architecture-invariants.md) — four load-bearing invariants that have each failed at least once between 2.1.0 and 2.1.3 despite green unit tests. If your change touches `src/toolkit/agent_resolver.ts`, `src/hub/index.ts`, `src/credentials/`, `src/connectors/db/lib/drivers/`, or `src/connectors/db/dispatcher.ts`, that doc is required reading.
+
+### Local dev loop
+
+```sh
+npm install
+npm run build
+npm test
+```
+
+Live-DB integration tests are gated behind `TEST_LIVE_*` env vars (e.g. `TEST_LIVE_POSTGRES=1`) and stay skipped by default so CI is hermetic. `npm run typecheck` runs the strict pass without emitting; `npm run coverage` runs the full suite with v8 coverage and enforces global thresholds.
+
+### Code conventions
+
+- 2-space indent, ESM-only (`"type": "module"`).
+- Strict TypeScript with `exactOptionalPropertyTypes` (see `tsconfig.json`); don't widen the compiler options to silence errors.
+- No emojis in source or docs.
+- Follow existing file/module style; don't reformat adjacent code.
+
+### Releasing
+
+Releases are tag-driven via `.github/workflows/release.yml`. Bump `package.json` version, then:
+
+```sh
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+This triggers `npm publish --provenance` plus a GitHub Release. The workflow fails closed if the tag doesn't match `package.json`. Pre-release tags (`vX.Y.Z-rc.N`) publish under the `next` npm dist-tag and are marked as pre-releases on GitHub; plain semver tags go to `latest`.
+
+### PR hygiene
+
+- Include test coverage for behavior changes.
+- If you touch one of the four invariant paths above, run doc-wiki's `eval-14` (`wiki-gather-credential-boundary`) and `eval-20` (`wiki-gather-db-postgres-success`) manually before merging — both exercise the full `gather()` → connector subprocess → bundled `SKILL.md` → CLI → envelope round-trip and have caught bugs that passed unit tests in this repo. doc-wiki lives at <https://github.com/narailabs/doc-wiki>.
+- Keep PRs focused; don't bundle drive-by refactors with the core change.
+
+## New builtin connector
+
+Before you start:
 
 - Check that the service isn't already covered. Today's builtins: `aws`, `confluence`, `db` (postgres / mysql / sqlite / mssql / mongodb / dynamodb / oracle), `gcp`, `github`, `jira`, `notion`. Database backends not yet supported by `db` should usually go into `db`'s driver registry rather than start fresh.
 - File an issue first if you're unsure whether the connector belongs here. Adding a builtin is a long-term commitment to maintain it.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 Read-only connectors + planning hub + connector framework, in one package.
 
-Bundles what used to ship as eight separate `@narai/*` packages:
+Bundles what used to ship as eleven separate `@narai/*` packages:
 
 - `@narai/connector-toolkit` → `narai-primitives/toolkit`
 - `@narai/connector-config` → `narai-primitives/config`
 - `@narai/connector-hub` → `narai-primitives` (default) or `narai-primitives/hub`
+- `@narai/credential-providers` → `narai-primitives/credentials`
 - `@narai/aws-agent-connector` → `narai-primitives/aws`
 - `@narai/confluence-agent-connector` → `narai-primitives/confluence`
 - `@narai/db-agent-connector` → `narai-primitives/db`
@@ -14,8 +15,6 @@ Bundles what used to ship as eight separate `@narai/*` packages:
 - `@narai/github-agent-connector` → `narai-primitives/github`
 - `@narai/jira-agent-connector` → `narai-primitives/jira`
 - `@narai/notion-agent-connector` → `narai-primitives/notion`
-
-`@narai/credential-providers` stays as a separate package.
 
 ## Install
 
@@ -61,8 +60,8 @@ Update imports:
 +import { loadResolvedConfig } from "narai-primitives/config";
 ```
 
-The eight old packages are deprecated on npm and will receive no new releases.
+All eleven old packages are deprecated on npm and will receive no new releases.
 
 ## Contributing
 
-- [Architecture Invariants](docs/architecture-invariants.md) — load-bearing invariants every contributor should know before refactoring
+See [CONTRIBUTING.md](CONTRIBUTING.md). Contributors touching `src/toolkit/agent_resolver.ts`, `src/hub/index.ts`, `src/credentials/`, or `src/connectors/db/` should also read [`docs/architecture-invariants.md`](docs/architecture-invariants.md).

--- a/docs/architecture-invariants.md
+++ b/docs/architecture-invariants.md
@@ -101,9 +101,14 @@ files and assert the optional SDK / driver names appear only inside dynamic
 - `tests/credentials/lazy_loading.test.ts`
 - `tests/connectors/db/lazy_loading.test.ts`
 
-**History.** Discipline established as part of the 2.0 consolidation; both
-guard tests landed during the 2.1.x stabilization to make accidental
-top-level imports fail CI rather than runtime.
+**History.** Discipline established as part of the 2.0 consolidation. The
+credentials guard test (`tests/credentials/lazy_loading.test.ts`) landed in
+2.1.0 alongside the `@narai/credential-providers` absorption (commit
+`d1654dd`, "feat(credentials): absorb @narai/credential-providers as
+/credentials subpath"). The db-driver guard test
+(`tests/connectors/db/lazy_loading.test.ts`) followed in 2.1.1 (commit
+`a5de88f`, "test(db): lock in driver lazy-loading invariant"). Both make
+accidental top-level imports fail CI rather than runtime.
 
 ## 4. db schema dispatch: prefer `getSchemaAsync`
 


### PR DESCRIPTION
## Summary

Three small documentation follow-ups, shipped together:

### Fix 1: README package count

The bundle absorbs **eleven** old `@narai/*` packages, not eight. Updated `README.md`:

- Top-of-file count: "eight" → "eleven", with all 11 packages listed (3 framework: toolkit/config/hub absorbed in 2.0; 1 credentials: credential-providers absorbed in 2.1; 7 connectors: aws/confluence/db/gcp/github/jira/notion).
- Removed the stale "`@narai/credential-providers` stays as a separate package" line — it was absorbed in 2.1.
- Fixed matching "eight" → "eleven" in the migration section.

### Fix 2: Pin lazy-loading invariant version

Invariant #3 in `docs/architecture-invariants.md` previously said "established as part of the 2.0 consolidation; both guard tests landed during the 2.1.x stabilization" — fuzzy. Pinned via `git log --follow` + `git tag --contains`:

- `tests/credentials/lazy_loading.test.ts` introduced by `d1654dd` ("feat(credentials): absorb @narai/credential-providers as /credentials subpath"). Earliest tag containing it: **v2.1.0**.
- `tests/connectors/db/lazy_loading.test.ts` introduced by `a5de88f` ("test(db): lock in driver lazy-loading invariant"). Earliest tag containing it: **v2.1.1**.

### Fix 3: Promote inline Contributing section

`README.md` had a `## Contributing` section that was just a one-line link to `docs/architecture-invariants.md`. A `CONTRIBUTING.md` already existed but covered only the new-builtin-connector path, so it didn't actually serve general PR contributors. Added a top-level "Fixes and improvements" section to `CONTRIBUTING.md` (40 lines, well under the 60-line cap) covering: pre-read pointer to architecture-invariants, local-dev loop with `TEST_LIVE_*` gating note, code conventions (2-space, ESM-only, strict TS with `exactOptionalPropertyTypes`), tag-driven release flow, and PR hygiene (including running doc-wiki's eval-14 / eval-20 when touching the four invariant paths). The README's Contributing block now points at `CONTRIBUTING.md`.

## Test plan

- [x] `npm run typecheck` clean
- [x] Verified via `git log --follow` + `git tag --contains` that v2.1.0 and v2.1.1 are the correct version pins for the two guard tests
- [x] Re-read `CONTRIBUTING.md` end-to-end after the edits — flows correctly from intro buckets to "Fixes and improvements" to "New builtin connector"