### PR TITLE
docs: align invariants doc with README (ten → eleven)

### DIFF
--- a/docs/architecture-invariants.md
+++ b/docs/architecture-invariants.md
@@ -1,7 +1,7 @@
 # Architecture Invariants
 
 This document captures four load-bearing invariants in narai-primitives 2.x. Each
-exists because consolidating ten previously-separate packages into one bundled
+exists because consolidating eleven previously-separate packages into one bundled
 layout broke assumptions baked into the original per-package code. Three of the
 four invariants were violated at least once between 2.1.0 and 2.1.3 — every
 violation passed unit tests and only surfaced when an end-to-end caller


### PR DESCRIPTION
One-word factual fix: `docs/architecture-invariants.md:4` said 'ten previously-separate packages' but PR #14 just updated README to say 'eleven' (the actual count: 7 connectors + toolkit + config + hub + credential-providers). Aligning the docs.

No code change. No version bump.