### PR TITLE
chore(ci,observability): bundled-layout smoke + NARAI_DEBUG_RESOLVER

### DIFF
--- a/src/hub/index.ts
+++ b/src/hub/index.ts
@@ -72,6 +72,17 @@ function skillMdCandidates(root: string, name: string): string[] {
   ];
 }
 
+/** Emit a one-line breadcrumb to stderr when `NARAI_DEBUG_RESOLVER=1` is set.
+ *
+ * Mirrors the resolver's debug helper so operators get a single env var to
+ * diagnose silent SKILL_NOT_FOUND / fallback-path issues.
+ */
+function debugLog(msg: string): void {
+  if (process.env["NARAI_DEBUG_RESOLVER"] === "1") {
+    process.stderr.write(`[narai-primitives:hub] ${msg}\n`);
+  }
+}
+
 /** Read a file synchronously, returning null on failure. */
 function tryRead(p: string): string | null {
   try {
@@ -139,10 +150,12 @@ function prepareConnector(
   const root = packageRootFromCli(resolved.resolvedPath);
   const candidates = skillMdCandidates(root, name);
   let skillContent: string | null = null;
-  for (const candidate of candidates) {
-    const content = tryRead(candidate);
+  let matchedIndex = -1;
+  for (let i = 0; i < candidates.length; i++) {
+    const content = tryRead(candidates[i]);
     if (content !== null) {
       skillContent = content;
+      matchedIndex = i;
       break;
     }
   }
@@ -153,6 +166,11 @@ function prepareConnector(
         message: `SKILL.md not found at any of: ${candidates.join(", ")}`,
       },
     };
+  }
+  if (matchedIndex > 0) {
+    // Legacy SKILL.md path matched — bundled 2.x layout was missing or wrong.
+    // Worth surfacing for any operator who has NARAI_DEBUG_RESOLVER=1 set.
+    debugLog(`SKILL.md fallback for '${slice.name}' (legacy path): ${candidates[matchedIndex]}`);
   }
   return {
     prepared: {

--- a/src/toolkit/agent_resolver.ts
+++ b/src/toolkit/agent_resolver.ts
@@ -19,6 +19,10 @@
  *
  * Returns null if no candidate exists, so callers can fail with a clear
  * message instead of crashing on `spawn`.
+ *
+ * Set `NARAI_DEBUG_RESOLVER=1` to emit a one-line stderr breadcrumb for each
+ * resolution attempt — off by default; intended for diagnosing silent CLI
+ * misses in the field.
  */
 
 import * as fs from "node:fs";
@@ -107,6 +111,18 @@ function defaultBundledSelfRoot(): string | null {
   }
 }
 
+/**
+ * Emit a one-line breadcrumb to stderr when `NARAI_DEBUG_RESOLVER=1` is set.
+ *
+ * Off by default — operators opt in when diagnosing silent CLI-not-found or
+ * unexpected-fallback failures (the class of bug that drove 2.1.1/2.1.2).
+ */
+function debugLog(env: NodeJS.ProcessEnv, msg: string): void {
+  if (env["NARAI_DEBUG_RESOLVER"] === "1") {
+    process.stderr.write(`[narai-primitives:resolver] ${msg}\n`);
+  }
+}
+
 export function resolveAgentCli(opts: ResolveAgentCliOptions): ResolvedAgentCli | null {
   const env = opts.envOverride ?? process.env;
   const home = opts.homeOverride ?? os.homedir();
@@ -123,6 +139,7 @@ export function resolveAgentCli(opts: ResolveAgentCliOptions): ResolvedAgentCli 
   // 1. Explicit env-var override.
   const envPath = env[envVar];
   if (typeof envPath === "string" && envPath !== "" && fs.existsSync(envPath)) {
+    debugLog(env, `'${opts.name}' resolved via env (${envVar}): ${envPath}`);
     return { command: "node", args: [envPath], source: "env", resolvedPath: envPath };
   }
 
@@ -139,6 +156,7 @@ export function resolveAgentCli(opts: ResolveAgentCliOptions): ResolvedAgentCli 
       "cli.js",
     );
     if (fs.existsSync(bundledCli)) {
+      debugLog(env, `'${opts.name}' resolved via bundled-self: ${bundledCli}`);
       return {
         command: "node",
         args: [bundledCli],
@@ -161,6 +179,7 @@ export function resolveAgentCli(opts: ResolveAgentCliOptions): ResolvedAgentCli 
       if (!entry.includes(pluginContains)) continue;
       const candidate = path.join(pluginCache, entry, "node_modules", packageName, cliRelative);
       if (fs.existsSync(candidate)) {
+        debugLog(env, `'${opts.name}' resolved via plugin-cache: ${candidate}`);
         return { command: "node", args: [candidate], source: "plugin-cache", resolvedPath: candidate };
       }
     }
@@ -171,6 +190,7 @@ export function resolveAgentCli(opts: ResolveAgentCliOptions): ResolvedAgentCli 
   if (typeof pluginData === "string" && pluginData !== "") {
     const candidate = path.join(pluginData, "node_modules", packageName, cliRelative);
     if (fs.existsSync(candidate)) {
+      debugLog(env, `'${opts.name}' resolved via claude-plugin-data: ${candidate}`);
       return { command: "node", args: [candidate], source: "claude-plugin-data", resolvedPath: candidate };
     }
   }
@@ -178,8 +198,10 @@ export function resolveAgentCli(opts: ResolveAgentCliOptions): ResolvedAgentCli 
   // 5. Dev fallback (legacy ~/src/connectors/<name>-agent-connector layout).
   const devCandidate = path.join(devRoot, `${opts.name}-agent-connector`, cliRelative);
   if (fs.existsSync(devCandidate)) {
+    debugLog(env, `'${opts.name}' resolved via dev-fallback: ${devCandidate}`);
     return { command: "node", args: [devCandidate], source: "dev-fallback", resolvedPath: devCandidate };
   }
 
+  debugLog(env, `'${opts.name}' not resolved (no candidate found in any of: env, bundled-self, plugin-cache, claude-plugin-data, dev-fallback)`);
   return null;
 }

--- a/tests/hub/gather.test.ts
+++ b/tests/hub/gather.test.ts
@@ -221,6 +221,69 @@ describe("gather end-to-end with stubs", () => {
     expect(capturedSystemPrompt).toContain("jira legacy skill body");
   });
 
+  it("emits a NARAI_DEBUG_RESOLVER breadcrumb on legacy SKILL.md fallback", async () => {
+    // When SKILL.md only exists at the legacy path AND the operator has
+    // opted into resolver debug logs, prepareConnector should surface the
+    // fallback so silent layout regressions don't go unnoticed.
+    const cli = setupFakeConnector(tmpDir, "jira", {
+      skill: "# legacy",
+    });
+    const planner: Planner = {
+      plan: async () => JSON.stringify([{ connector: "jira", action: "x", params: {} }]),
+    };
+    const loader = stubLoader({ jira: { skill: "jira-agent-connector" } });
+    const cliResolver = stubCliResolver({ jira: cli });
+
+    const writes: string[] = [];
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    }) as typeof process.stderr.write;
+    const prevEnv = process.env["NARAI_DEBUG_RESOLVER"];
+    process.env["NARAI_DEBUG_RESOLVER"] = "1";
+    try {
+      await gather({ prompt: "?" }, { planner, configLoader: loader, cliResolver });
+    } finally {
+      process.stderr.write = originalWrite;
+      if (prevEnv === undefined) delete process.env["NARAI_DEBUG_RESOLVER"];
+      else process.env["NARAI_DEBUG_RESOLVER"] = prevEnv;
+    }
+
+    const stderr = writes.join("");
+    expect(stderr).toContain("[narai-primitives:hub]");
+    expect(stderr).toContain("SKILL.md fallback for 'jira'");
+    expect(stderr).toContain("legacy path");
+  });
+
+  it("is silent on legacy SKILL.md fallback when NARAI_DEBUG_RESOLVER is unset", async () => {
+    const cli = setupFakeConnector(tmpDir, "jira", {
+      skill: "# legacy",
+    });
+    const planner: Planner = {
+      plan: async () => JSON.stringify([{ connector: "jira", action: "x", params: {} }]),
+    };
+    const loader = stubLoader({ jira: { skill: "jira-agent-connector" } });
+    const cliResolver = stubCliResolver({ jira: cli });
+
+    const writes: string[] = [];
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    }) as typeof process.stderr.write;
+    const prevEnv = process.env["NARAI_DEBUG_RESOLVER"];
+    delete process.env["NARAI_DEBUG_RESOLVER"];
+    try {
+      await gather({ prompt: "?" }, { planner, configLoader: loader, cliResolver });
+    } finally {
+      process.stderr.write = originalWrite;
+      if (prevEnv !== undefined) process.env["NARAI_DEBUG_RESOLVER"] = prevEnv;
+    }
+
+    expect(writes.join("")).not.toContain("[narai-primitives:hub]");
+  });
+
   it("returns plan: [] and PLANNER_INVALID when planner output is unparsable", async () => {
     const cli = setupFakeConnector(tmpDir, "aws");
     const planner = stubPlanner("totally not json");

--- a/tests/integration/bundled_layout.test.ts
+++ b/tests/integration/bundled_layout.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Bundled-distribution smoke test.
+ *
+ * Asserts the post-build artifact actually has the shape every consumer
+ * (the hub, doc-wiki's gather() callers, the seven plugin manifests)
+ * expects. This is the gap that drove patch releases 2.1.1 (CLI not found)
+ * and 2.1.2 (SKILL.md not found): unit tests passed against `src/` while
+ * the bundled `dist/` layout was silently broken.
+ *
+ * Requires `npm run build` to have been run first. CI runs the build step
+ * before tests, so this is a no-op in unconfigured local checkouts — we
+ * skip rather than fail when `dist/` is absent so contributors aren't
+ * forced to rebuild on every test cycle.
+ */
+
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { resolveAgentCli } from "../../src/toolkit/agent_resolver.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..", "..");
+
+const CONNECTORS = ["aws", "confluence", "db", "gcp", "github", "jira", "notion"] as const;
+
+const distExists = fs.existsSync(path.join(repoRoot, "dist", "connectors"));
+
+describe.skipIf(!distExists)("bundled distribution layout", () => {
+  describe.each(CONNECTORS)("connector: %s", (name) => {
+    const cliPath = path.join(repoRoot, "dist", "connectors", name, "cli.js");
+    const skillPath = path.join(
+      repoRoot,
+      "plugins",
+      `${name}-agent`,
+      "skills",
+      `${name}-agent`,
+      "SKILL.md",
+    );
+
+    it("ships dist/connectors/<name>/cli.js (catches the 2.1.1 regression class)", () => {
+      expect(fs.existsSync(cliPath)).toBe(true);
+    });
+
+    it("ships plugins/<name>-agent/skills/<name>-agent/SKILL.md (catches the 2.1.2 regression class)", () => {
+      expect(fs.existsSync(skillPath)).toBe(true);
+    });
+
+    it("bundled CLI is a runnable Node script (spawn with no args returns a structured envelope)", () => {
+      // `import()` is unsafe — most CLIs auto-run main() and call
+      // process.exit at module load, which crashes the test runner.
+      // spawnSync mirrors how the hub actually invokes them, so we get
+      // the same surface a real call would.
+      const result = spawnSync(process.execPath, [cliPath], {
+        encoding: "utf8",
+        timeout: 10_000,
+      });
+      // CLIs may exit non-zero on no-args (CONFIG_ERROR, missing-action,
+      // etc.). What we're verifying is that the bundle is loadable and
+      // didn't crash with a module-resolution / syntax error.
+      expect(result.error).toBeUndefined();
+      const combined = `${result.stdout}\n${result.stderr}`;
+      expect(combined).not.toContain("Cannot find module");
+      expect(combined).not.toContain("SyntaxError");
+      expect(combined).not.toContain("ERR_MODULE_NOT_FOUND");
+    });
+
+    it("resolveAgentCli locates it via bundled-self with no overrides", () => {
+      // Use the real resolver against the real package root. This is the
+      // exact path that broke in 2.1.1: import.meta.url-based root walk +
+      // dist/connectors/<name>/cli.js lookup.
+      const resolved = resolveAgentCli({ name });
+      expect(resolved).not.toBeNull();
+      expect(resolved!.source).toBe("bundled-self");
+      expect(resolved!.resolvedPath).toBe(cliPath);
+    });
+  });
+});

--- a/tests/toolkit/agent_resolver.test.ts
+++ b/tests/toolkit/agent_resolver.test.ts
@@ -306,4 +306,92 @@ describe("resolveAgentCli", () => {
       fs.rmSync(pluginData, { recursive: true, force: true });
     }
   });
+
+  describe("debug logging (NARAI_DEBUG_RESOLVER)", () => {
+    let writes: string[];
+    let originalWrite: typeof process.stderr.write;
+
+    beforeEach(() => {
+      writes = [];
+      originalWrite = process.stderr.write.bind(process.stderr);
+      process.stderr.write = ((chunk: string | Uint8Array) => {
+        writes.push(typeof chunk === "string" ? chunk : chunk.toString());
+        return true;
+      }) as typeof process.stderr.write;
+    });
+    afterEach(() => {
+      process.stderr.write = originalWrite;
+    });
+
+    it("is silent by default (env var unset)", () => {
+      const customCli = path.join(fakeHome, "x", "cli.js");
+      fs.mkdirSync(path.dirname(customCli), { recursive: true });
+      fs.writeFileSync(customCli, "");
+      resolveAgentCli({
+        name: "jira",
+        homeOverride: fakeHome,
+        envOverride: { JIRA_AGENT_CLI: customCli },
+        bundledSelfRoot: null,
+      });
+      expect(writes.join("")).toBe("");
+    });
+
+    it("emits a stderr breadcrumb when env var is '1' on env-path resolution", () => {
+      const customCli = path.join(fakeHome, "x", "cli.js");
+      fs.mkdirSync(path.dirname(customCli), { recursive: true });
+      fs.writeFileSync(customCli, "");
+      resolveAgentCli({
+        name: "jira",
+        homeOverride: fakeHome,
+        envOverride: { JIRA_AGENT_CLI: customCli, NARAI_DEBUG_RESOLVER: "1" },
+        bundledSelfRoot: null,
+      });
+      const out = writes.join("");
+      expect(out).toContain("[narai-primitives:resolver]");
+      expect(out).toContain("'jira'");
+      expect(out).toContain("via env");
+      expect(out).toContain(customCli);
+    });
+
+    it("emits a stderr breadcrumb on bundled-self resolution", () => {
+      const root = path.join(fakeHome, "primitives");
+      const bundled = path.join(root, "dist", "connectors", "db", "cli.js");
+      fs.mkdirSync(path.dirname(bundled), { recursive: true });
+      fs.writeFileSync(bundled, "");
+      resolveAgentCli({
+        name: "db",
+        homeOverride: fakeHome,
+        envOverride: { NARAI_DEBUG_RESOLVER: "1" },
+        bundledSelfRoot: root,
+      });
+      const out = writes.join("");
+      expect(out).toContain("'db'");
+      expect(out).toContain("via bundled-self");
+      expect(out).toContain(bundled);
+    });
+
+    it("emits a 'not resolved' breadcrumb when nothing matches", () => {
+      resolveAgentCli({
+        name: "fake",
+        homeOverride: fakeHome,
+        envOverride: { NARAI_DEBUG_RESOLVER: "1" },
+        bundledSelfRoot: null,
+      });
+      const out = writes.join("");
+      expect(out).toContain("'fake' not resolved");
+    });
+
+    it("does NOT emit when env var is set to anything other than '1'", () => {
+      const customCli = path.join(fakeHome, "x", "cli.js");
+      fs.mkdirSync(path.dirname(customCli), { recursive: true });
+      fs.writeFileSync(customCli, "");
+      resolveAgentCli({
+        name: "jira",
+        homeOverride: fakeHome,
+        envOverride: { JIRA_AGENT_CLI: customCli, NARAI_DEBUG_RESOLVER: "true" },
+        bundledSelfRoot: null,
+      });
+      expect(writes.join("")).toBe("");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Two changes that close the coverage / observability gap surfaced by the recent 2.1.1–2.1.3 patch sequence:

- **Bundled-layout smoke test** (`tests/integration/bundled_layout.test.ts`) — runs after `npm run build` and asserts, for each of the 7 connectors, that the bundled artifact actually has the shape every consumer (hub, doc-wiki gather() callers, plugin manifests) expects. Would have caught 2.1.1 (`dist/connectors/<name>/cli.js` missing from the resolver chain) and 2.1.2 (`plugins/<name>-agent/skills/<name>-agent/SKILL.md` not found by the hub) **before** they shipped.
- **`NARAI_DEBUG_RESOLVER=1` breadcrumb** — opt-in stderr log (off by default) on every `resolveAgentCli` resolution and on legacy SKILL.md fallbacks in the hub. Operators diagnosing silent CLI/SKILL misses now have a flag to flip; historically these surfaced as null returns / `CONFIG_ERROR` with no path-level context.

No public API changes. Existing tests unchanged. The smoke test self-skips when `dist/` is absent so contributors aren't forced to rebuild on every local test cycle.

## Why

The three patch releases all had the same root cause: the test suite never exercised the bundled 2.x distribution layout end-to-end. Each was caught downstream (by `doc-wiki` evals or by users), not by `narai-primitives` CI. This PR moves the bundled-layout assertions upstream where they belong, and adds an opt-in diagnostic for the next time something silent goes wrong.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run build` — passes
- [x] `npm test` — 1611 passed / 26 live-DB skipped (unchanged)
- [x] New tests:
  - 28 bundled-layout assertions (4 × 7 connectors)
  - 5 resolver debug-log assertions (silent default, env+bundled-self+null breadcrumbs, non-`"1"` value gating)
  - 2 hub debug-log assertions (legacy SKILL.md fallback emit, silent default)
- [x] Manual smoke: `NARAI_DEBUG_RESOLVER=1 node -e 'import("narai-primitives/toolkit").then(m => m.resolveAgentCli({name:"db"}))'` emits the expected `[narai-primitives:resolver] 'db' resolved via bundled-self: …` line