### PR TITLE
feat(git-plugin): PreToolUse hook gating risky git commands

### DIFF
--- a/plugins/git-plugin/.claude-plugin/plugin.json
+++ b/plugins/git-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "git-plugin",
+  "version": "1.0.0",
+  "description": "Pre-tool-use hook that gates risky git commands (push, force-push, branch deletion, reset --hard, etc.). No agents or actions — hooks only.",
+  "author": "narailabs"
+}

--- a/plugins/git-plugin/CONTRIBUTING.md
+++ b/plugins/git-plugin/CONTRIBUTING.md
@@ -1,0 +1,114 @@
+# Contributing to `git-plugin`
+
+This plugin is small. Contributions usually land in one of three places:
+
+1. **A new default rule** — see [Adding a default rule](#adding-a-default-rule).
+2. **A bug in an existing rule** — false positive, missed pattern, edge case in the splitter. See [Fixing a rule](#fixing-a-rule).
+3. **Hook contract drift** — Claude Code changes the PreToolUse payload shape or output expectations. See [Hook contract](#hook-contract).
+
+For changes elsewhere in the repo (other connectors, toolkit, hub), follow the root [`CONTRIBUTING.md`](../../CONTRIBUTING.md). Plugin-specific guidance below.
+
+## Local dev loop
+
+```sh
+# from the repo root
+npm install
+npx vitest run tests/plugins/git-plugin/
+```
+
+The hook runs as a standalone Node ESM script. To smoke-test it end-to-end against a fake stdin payload:
+
+```sh
+echo '{"tool_name":"Bash","tool_input":{"command":"git push origin main"},"hook_event_name":"PreToolUse","cwd":"/tmp"}' \
+  | node plugins/git-plugin/hooks/git_gate.mjs
+```
+
+Should print `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny",...}}` to stdout. A non-git or unmatched command produces no output (the hook's signal that it has no opinion).
+
+## Adding a default rule
+
+Default rules live in [`hooks/rules.mjs`](hooks/rules.mjs) under `DEFAULT_RULES`. Each rule is:
+
+```js
+{
+  name: "rule_name",                                    // stable identifier
+  decision: "deny" | "ask" | "allow",
+  reason: "Sentence shown to the user in the prompt.",
+  match: (segment) => boolean,                          // pure function
+}
+```
+
+Rules are evaluated in order against each segment of a compound command (split on `&&`, `||`, `;`, `|`). The strictest matching decision wins (`deny` > `ask` > `allow`).
+
+### Steps
+
+1. Add the rule object to `DEFAULT_RULES` in `hooks/rules.mjs`. Keep `deny` rules at the top, `ask` rules below, ordered roughly by specificity — more specific rules first so their reason text wins ties.
+
+2. Add a `describe` block in [`tests/plugins/git-plugin/rules.test.ts`](../../tests/plugins/git-plugin/rules.test.ts) covering:
+   - **Positive cases**: each command form your rule is meant to catch (use `it.each`).
+   - **Negative cases**: adjacent-but-safe commands that must not fire. This is where most rule-design bugs hide. If you skip negative cases, your rule will produce false positives in the wild.
+   - **Precedence interaction**: if your rule's decision can be overruled by an existing `deny` rule, add a test that verifies the strictest-wins resolution.
+
+3. Document the rule in [`README.md`](README.md) under "Default rules". Match the existing table style.
+
+4. If the rule has known false-positive scenarios, document them under "Limitations" in `README.md` and mention that operators can disable via `GIT_GATE_DISABLE=<rule_name>`.
+
+### Style guidance
+
+- **Keep the regex anchored.** All default rules anchor on `^git\s+<verb>` so a string like `echo "git push"` doesn't trigger them. The splitter strips env-prefixes (`FOO=bar`) and `sudo`/`nice`/`time` before rules see the segment.
+- **Avoid lookbehinds and back-references** unless you have a clear reason. They make the rule harder to read and slower; this code runs on every Bash call.
+- **Bias toward over-flagging.** A safe command flagged for confirmation is annoying; a dangerous command that slipped through is the failure mode this plugin exists to prevent.
+- **Don't widen `match` to do I/O.** Rules are pure. If you need git state (current branch, remote URL), the hook entry point can add it to the segment context, but no rule should shell out or read files.
+
+## Fixing a rule
+
+If you're chasing a false positive or missed pattern:
+
+1. Reproduce in a test first — add the failing case to `rules.test.ts` so the regression is captured. The fix should make the new case pass without breaking the existing 70.
+2. Prefer narrowing the regex over deleting the rule. If the rule is genuinely unsalvageable, delete it cleanly (rule object, tests, README row, any `GIT_GATE_DISABLE` guidance) in a single commit.
+3. If the false positive is rare and the rule is otherwise valuable, document it under "Limitations" rather than weakening the rule.
+
+## Hook contract
+
+The plugin reads stdin and writes stdout per the [Claude Code hook
+contract](https://code.claude.com/docs/en/hooks.md). The current shape
+the entry point relies on:
+
+- **Input**: `{tool_name: "Bash", tool_input: {command: string}, ...}`
+- **Output**: `{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow"|"deny"|"ask", permissionDecisionReason: string}}`
+- **Exit code**: `0` for any decision (the JSON is the signal). Non-zero stays for genuine script errors.
+
+If Claude Code changes the contract:
+
+1. Update the JSDoc at the top of `hooks/git_gate.mjs` and the README's "How it works" section.
+2. Bump `version` in `.claude-plugin/plugin.json` and `package.json`.
+3. Test against the new Claude Code version with the smoke-test command above before merging.
+
+The hook entry point is the only file with side effects (stdin/stdout/fs/env). `rules.mjs` is pure and should stay that way — the test suite depends on it.
+
+## Code conventions
+
+- **No runtime npm deps.** The hook ships as raw `.mjs` files and runs under whatever Node Claude Code launches it with (≥ 20.10 per the user's environment). If you need YAML or another parser, justify it in the PR — adding deps couples the plugin's runtime to Claude Code session startup, and the current dependency-free design is deliberate.
+- **No bin/ shim and no SessionStart npm install.** Unlike the connector plugins, this plugin doesn't need them. Don't add infrastructure that isn't used.
+- **2-space indent**, ESM-only (`.mjs`), no TypeScript in plugin source. Tests are TS because Vitest's include glob is `**/*.test.ts`; that's fine — the test imports the `.mjs` file directly.
+- **No emojis** in source or docs (matches repo style).
+- **Match existing patterns** in `rules.mjs` and `git_gate.mjs`. Don't reformat adjacent code.
+
+## Commit + PR hygiene
+
+- Commit messages follow conventional-commits style: `feat(git-plugin): ...`, `fix(git-plugin): ...`, `docs(git-plugin): ...`, `test(git-plugin): ...`.
+- One logical change per commit. If a rule fix needs a test update and a README update, those go in the same commit.
+- Run `npx vitest run tests/plugins/git-plugin/` before pushing. The full repo suite (`npx vitest run`) should also pass — the plugin shouldn't affect anything outside its directory, but verify before claiming "no regressions".
+- Open the PR against `main`. The plugin lives outside the connector PR stack and ships independently.
+
+## Out of scope
+
+This plugin deliberately does NOT:
+
+- **Block the command.** The strictest decision is `deny`, which makes Claude refuse and surfaces the reason — but the user can still run the command themselves outside the session. See [SECURITY.md](SECURITY.md) for the full list of bypass paths and why they are intentional.
+- **Track git state.** No `git rev-parse`, no remote URL inspection, no branch detection. Rules operate on the literal command string. If you want behaviour gated on current branch (e.g., "deny rebase only when on main"), that's a real proposal — open an issue first to discuss whether the added I/O cost on every Bash call is worth it.
+- **Replace branch protection.** Server-side branch protection rules on the remote are the actual enforcement layer. This plugin reduces blast radius from agentic flows; it does not gate the remote.
+
+## License
+
+MIT — see `LICENSE` at the repo root.

--- a/plugins/git-plugin/README.md
+++ b/plugins/git-plugin/README.md
@@ -1,0 +1,92 @@
+# git-plugin
+
+Claude Code plugin that gates risky `git` commands at the `PreToolUse` hook.
+No agents, no actions — pure permission gating.
+
+## Default rules
+
+| Rule | Decision | When it fires |
+|---|---|---|
+| `push_main` | **deny** | `git push` whose refspec targets `main` or `master` |
+| `force_push` | **ask** | `git push --force` / `-f` / `--force-with-lease` |
+| `delete_branch_remote` | **ask** | `git push --delete`, `git push -d`, or `git push <remote> :branch` |
+| `push` | **ask** | Any other `git push` |
+| `delete_branch_local` | **ask** | `git branch -D`, `git branch --delete --force` |
+| `reset_hard` | **ask** | `git reset --hard` |
+| `checkout_discard` | **ask** | `git checkout <pathspec>` / `git restore --worktree` / `git checkout .` |
+| `clean_force` | **ask** | `git clean -f…` (any `-f` variant, including `-fdx`) |
+
+Decision precedence: `deny` > `ask` > `allow`. If multiple rules match across
+a compound command (`a && b`), the strictest wins.
+
+If no rule matches, the hook emits no decision and Claude Code's default
+permission flow continues.
+
+## Disabling rules
+
+Set `GIT_GATE_DISABLE` to a comma-separated list of rule names:
+
+```sh
+export GIT_GATE_DISABLE=push,push_main
+```
+
+…disables both the plain-`push` ask and the protected-branch deny.
+
+## Adding rules
+
+Create `~/.connectors/git-gate.json`:
+
+```json
+{
+  "disabled": ["push"],
+  "rules": [
+    {
+      "name": "deny_release",
+      "decision": "deny",
+      "reason": "Pushing to release branches needs SRE approval.",
+      "pattern": "^git\\s+push\\s+\\S+\\s+release\\b"
+    },
+    {
+      "name": "ask_worktree_remove",
+      "decision": "ask",
+      "reason": "Removing a worktree is irreversible.",
+      "pattern": "^git\\s+worktree\\s+remove\\b"
+    }
+  ]
+}
+```
+
+`pattern` is a JavaScript regex source applied to each command segment
+(after splitting on `&&`, `||`, `;`, `|`). `decision` must be one of
+`allow`, `ask`, `deny`. `reason` is shown to the user in the prompt.
+
+Custom rules are evaluated **after** the defaults; the strictest match
+across all rules wins.
+
+## How it works
+
+`PreToolUse` hooks fire before any Bash invocation. The hook reads
+Claude Code's stdin payload, classifies the `tool_input.command` against
+the rules in `hooks/rules.mjs`, and writes a JSON decision to stdout per
+the [hook contract](https://code.claude.com/docs/en/hooks.md).
+
+Compound commands (`cd repo && git push origin main`) split on `&&`, `||`,
+`;`, `|` and each segment is classified independently — the strictest
+decision wins. Leading env-var assignments (`FOO=bar git push`) and
+common prefixes (`sudo`, `nice`, `time`) are stripped before matching.
+
+## Limitations
+
+- The command splitter doesn't track quoted strings — a literal `&&`
+  inside single quotes will split the segment. Over-splitting is the
+  intended bias for a safety gate.
+- `push_main` matches any `main` or `master` token in the push args.
+  A branch literally named `feature/main` would trip this. Disable
+  `push_main` via env var or config if your repo has such names.
+- The hook runs on every Bash call. Performance is dominated by Node
+  startup (~30ms cold). The hook itself is O(rules × segments) regex
+  matching — negligible.
+
+## License
+
+MIT

--- a/plugins/git-plugin/SECURITY.md
+++ b/plugins/git-plugin/SECURITY.md
@@ -1,0 +1,139 @@
+# Security policy
+
+## What this plugin is
+
+A `PreToolUse` hook that classifies `git` invocations made through Claude
+Code's `Bash` tool and emits permission decisions (`allow` / `ask` /
+`deny`). It runs inside the user's Claude Code session, on the user's
+machine, with the user's privileges.
+
+## What this plugin is NOT
+
+**This plugin is not a security boundary.** It is a *speed bump* against
+accidental destructive commands — the same role as a shell alias that
+re-prompts on `rm -rf`. Treat it as a usability guardrail, not access
+control.
+
+A user (or anyone with write access to the user's environment) can defeat
+the plugin trivially by:
+
+- Running git outside Claude Code (a regular terminal, an IDE git panel, a
+  CI runner, etc.). The hook only fires for commands routed through
+  Claude Code's `Bash` tool.
+- Disabling the plugin in Claude Code (`/plugin disable git-plugin`) or
+  removing the marketplace entry.
+- Toggling permission mode to `bypassPermissions` — that mode skips the
+  hook entirely.
+- Accepting the `ask` prompt at the moment it appears.
+- Editing `~/.connectors/git-gate.json` to disable rules (the plugin
+  trusts that file unconditionally — see "Config file trust" below).
+- Writing a bash command that evades pattern matching (see
+  "Pattern-matching limits" below).
+
+If your threat model includes a malicious or curious user who has shell
+access on the same machine, this plugin does not help. Use repository
+permissions, branch protection rules on the remote, and CI policy
+checks instead — those run on infrastructure outside the user's control.
+
+## What it does help with
+
+- Stopping a model (or a sleepy human reviewing model output) from
+  running `git push origin main` without confirmation.
+- Catching `git reset --hard` and `git clean -fdx` before they execute.
+- Surfacing a confirmation prompt with operator-supplied reason text so
+  the user understands the consequences before approving.
+- Reducing blast radius from agentic flows that compose multiple git
+  commands in one Bash invocation — each compound segment is classified
+  independently.
+
+## Pattern-matching limits
+
+The classifier in `hooks/rules.mjs` works on the literal command string.
+Several constructs can evade matching:
+
+- **Quoted operators**: a literal `&&` inside single quotes splits the
+  command for the segmenter. Over-splitting is the intended bias —
+  every sub-segment still gets classified — but the segments themselves
+  are not properly tokenised, so a quoted git argument can defeat
+  pattern anchors. Example: `eval 'git push --force'` is classified by
+  matching on `git push --force` (the quoted body), but `eval "$(echo
+  git push)"` is not.
+- **Indirection**: `bash -c "$cmd"` where `$cmd` expands to a git
+  command. The hook sees the outer `bash -c "..."`, not the inner
+  expansion, and will not match.
+- **Aliases / functions**: a shell alias `gpf=git push --force` invoked
+  as `gpf` does not match because the hook never sees the resolved
+  command.
+- **Custom branch names**: the `push_main` rule matches any
+  `\bmain\b` or `\bmaster\b` token in the push args. A literal branch
+  named `feature/main` will trip the rule. Disable via
+  `GIT_GATE_DISABLE=push_main` if your repo uses such names.
+
+If you need defense-in-depth against these, add **server-side branch
+protection** on the remote and require status checks before merge. The
+plugin handles the local-side speed bump; the server enforces the rule.
+
+## Config file trust
+
+The plugin reads `~/.connectors/git-gate.json` if present. The file is
+trusted unconditionally — if an attacker can write to that path, they
+can:
+
+- Add a `disabled: [...]` entry to silence any default rule.
+- Add a custom rule with `decision: "allow"` to short-circuit a default
+  `ask` (note: `allow` cannot beat a `deny` due to precedence, but it
+  can beat an `ask`).
+
+Mitigations:
+
+- Keep the file's parent directory (`~/.connectors/`) writable only by
+  the owner (`chmod 700`).
+- Treat write access to `~/.connectors/git-gate.json` as equivalent to
+  shell access. If your threat model includes someone who can modify
+  files in `$HOME` but not run git directly, this plugin's config
+  surface is one of many they could weaponise.
+
+## Hook contract assumptions
+
+The plugin assumes Claude Code honours the documented hook contract
+(reads `tool_input.command` for `Bash` calls, respects
+`hookSpecificOutput.permissionDecision` of `"deny"`, etc.). If a future
+version of Claude Code changes the contract, the plugin may silently
+stop gating. Track the [hooks
+documentation](https://code.claude.com/docs/en/hooks.md) and verify
+behavior after Claude Code upgrades.
+
+The hook script itself is dependency-free Node ESM and reads only the
+stdin payload + optional config file. It does not invoke `git`, write
+files, or make network requests.
+
+## Reporting a vulnerability
+
+If you find a way for a `deny`-classified command to slip through the
+hook in default configuration (no env vars, no config file), please
+open an issue at
+<https://github.com/narailabs/narai-primitives/issues> with:
+
+- The command string the hook should have caught
+- The actual decision the hook produced (or null if none)
+- The Claude Code version and operating system
+
+Behaviour we consider intentional, not vulnerabilities:
+
+- Bypass via permission-mode toggling (`bypassPermissions`).
+- Bypass via env var or config file overrides.
+- Bypass via shell indirection (`bash -c`, `eval`, aliases) — see
+  "Pattern-matching limits".
+- False positives where a safe command matches a default rule (those
+  are usability bugs; please file them, but they are not security
+  issues).
+
+## Supported versions
+
+Only the latest published version of `git-plugin` receives security
+fixes. Older versions are not maintained. Pin to a specific version
+only if you have a tested compatibility constraint.
+
+## License
+
+MIT — see `LICENSE` at the repo root.

--- a/plugins/git-plugin/hooks/git_gate.mjs
+++ b/plugins/git-plugin/hooks/git_gate.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/**
+ * git_gate.mjs — PreToolUse hook entry point.
+ *
+ * Reads Claude Code's hook payload from stdin, classifies the bash command
+ * via rules.mjs, and writes a permission decision to stdout. Emits no
+ * decision (exit 0, empty stdout) if the command is not a git command or
+ * no rule matches — letting the default permission flow continue.
+ *
+ * Output shape:
+ *   { hookSpecificOutput: { hookEventName: "PreToolUse",
+ *                           permissionDecision: "allow"|"deny"|"ask",
+ *                           permissionDecisionReason: "..." } }
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { decide } from "./rules.mjs";
+
+main().catch((err) => {
+  // Best-effort: never crash Claude Code on a hook failure.
+  process.stderr.write(`git-gate hook error: ${err?.message ?? err}\n`);
+  process.exit(0);
+});
+
+async function main() {
+  const payload = await readStdinJson();
+  if (payload === null) return;
+
+  if (payload.tool_name !== "Bash") return;
+  const command = payload.tool_input?.command;
+  if (typeof command !== "string" || command.length === 0) return;
+
+  const config = loadConfig();
+  const disabled = mergeDisabled(config?.disabled);
+  const extraRules = compileExtraRules(config?.rules);
+
+  const rule = decide(command, { disabled, extraRules });
+  if (rule === null) return;
+
+  emit(rule.decision, rule.reason);
+}
+
+async function readStdinJson() {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  const raw = Buffer.concat(chunks).toString("utf-8").trim();
+  if (raw.length === 0) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function emit(permissionDecision, permissionDecisionReason) {
+  const out = {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision,
+      permissionDecisionReason,
+    },
+  };
+  process.stdout.write(JSON.stringify(out));
+}
+
+/**
+ * Read optional config from `~/.connectors/git-gate.json`.
+ *
+ * Shape:
+ *   {
+ *     "disabled": ["push", "force_push"],
+ *     "rules": [
+ *       { "name": "deny_push_to_release",
+ *         "decision": "deny",
+ *         "reason": "Pushing to release branches needs SRE approval.",
+ *         "pattern": "^git\\s+push\\s+\\S+\\s+release\\b" }
+ *     ]
+ *   }
+ *
+ * Pattern is a JS regex source. v1 supports JSON only — YAML may come later
+ * if there is demand. Keeps the hook dependency-free.
+ */
+function loadConfig() {
+  const home = os.homedir();
+  const file = path.join(home, ".connectors", "git-gate.json");
+  if (!fs.existsSync(file)) return null;
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, "utf-8"));
+    return typeof parsed === "object" && parsed !== null ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function mergeDisabled(fromConfig) {
+  const fromEnv = (process.env["GIT_GATE_DISABLE"] ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const fromCfg = Array.isArray(fromConfig)
+    ? fromConfig.filter((s) => typeof s === "string")
+    : [];
+  return new Set([...fromEnv, ...fromCfg]);
+}
+
+function compileExtraRules(rawRules) {
+  if (!Array.isArray(rawRules)) return [];
+  const out = [];
+  for (const r of rawRules) {
+    if (
+      typeof r?.name !== "string" ||
+      !["deny", "ask", "allow"].includes(r?.decision) ||
+      typeof r?.reason !== "string" ||
+      typeof r?.pattern !== "string"
+    ) {
+      continue;
+    }
+    let re;
+    try {
+      re = new RegExp(r.pattern);
+    } catch {
+      continue;
+    }
+    out.push({
+      name: r.name,
+      decision: r.decision,
+      reason: r.reason,
+      match: (s) => re.test(s),
+    });
+  }
+  return out;
+}

--- a/plugins/git-plugin/hooks/hooks.json
+++ b/plugins/git-plugin/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/git_gate.mjs\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/git-plugin/hooks/rules.mjs
+++ b/plugins/git-plugin/hooks/rules.mjs
@@ -1,0 +1,162 @@
+/**
+ * rules.mjs — git command classifier for the git-gate hook.
+ *
+ * Pure data + pure functions. No I/O. Imported by `git_gate.mjs` (the hook
+ * entry point) and by `tests/plugins/git-plugin/rules.test.mjs`.
+ *
+ * Decision precedence: `deny` > `ask` > `allow`. The hook returns the
+ * strictest matching rule's decision; if no rule matches, the hook emits
+ * no decision and the default permission flow continues.
+ *
+ * Each rule is `{name, decision, reason, match: (segment) => boolean}`.
+ * Rules are evaluated against each *segment* of a compound bash command
+ * (split on `&&`, `||`, `;`, `|`).
+ */
+
+/**
+ * Default rule set. Keep names stable — operators reference them via
+ * GIT_GATE_DISABLE and config files.
+ */
+export const DEFAULT_RULES = [
+  // ── DENY rules (precedence over ask) ────────────────────────────────────
+  {
+    name: "push_main",
+    decision: "deny",
+    reason: "Pushing to main/master is denied by policy. Open a PR instead.",
+    match: (s) => isGitPush(s) && targetsProtectedBranch(s),
+  },
+
+  // ── ASK rules ───────────────────────────────────────────────────────────
+  {
+    name: "force_push",
+    decision: "ask",
+    reason: "Force push rewrites remote history. Confirm before proceeding.",
+    match: (s) =>
+      isGitPush(s) && /\s(--force\b|--force-with-lease\b|-f\b)/.test(s),
+  },
+  {
+    name: "delete_branch_remote",
+    decision: "ask",
+    reason: "Deleting a remote branch is irreversible. Confirm.",
+    match: (s) =>
+      isGitPush(s) &&
+      (/\s(--delete\b|-d\b)/.test(s) || /\s\S+\s+:[\w./-]+/.test(s)),
+  },
+  {
+    name: "push",
+    decision: "ask",
+    reason: "Pushing publishes commits. Confirm before proceeding.",
+    match: (s) => isGitPush(s),
+  },
+  {
+    name: "delete_branch_local",
+    decision: "ask",
+    reason: "Force-deleting a local branch can lose unmerged commits.",
+    match: (s) =>
+      /^git\s+branch\s+(?:.*\s)?(-D\b|--delete\s+--force\b|-Df\b|-fD\b)/.test(s),
+  },
+  {
+    name: "reset_hard",
+    decision: "ask",
+    reason: "git reset --hard discards working-tree and index changes.",
+    match: (s) => /^git\s+reset\s+(?:.*\s)?--hard\b/.test(s),
+  },
+  {
+    name: "checkout_discard",
+    decision: "ask",
+    reason: "This checkout/restore discards working-tree changes.",
+    match: (s) =>
+      /^git\s+checkout\s+(?:--\s+|\.|[^\s-]\S*\.\S*)/.test(s) ||
+      /^git\s+checkout\s+\S+\s+--\s+\S/.test(s) ||
+      /^git\s+restore\s+(?:.*\s)?(--worktree\b|-W\b)/.test(s) ||
+      /^git\s+restore\s+\.$/.test(s),
+  },
+  {
+    name: "clean_force",
+    decision: "ask",
+    reason: "git clean -f removes untracked files (and -fdx removes ignored too).",
+    match: (s) => /^git\s+clean\s+(?:.*\s)?-[a-zA-Z]*f/.test(s),
+  },
+];
+
+/**
+ * Bash command splitter. Returns each independent command segment trimmed
+ * and stripped of leading env-prefixes (`FOO=bar`) and `sudo`.
+ *
+ * Limitations: doesn't track quoted strings — a literal `&&` inside a
+ * single-quoted string would split the command. This is a safety check,
+ * not a parser; over-splitting is the right bias.
+ */
+export function splitCompound(command) {
+  if (typeof command !== "string") return [];
+  // Split on chaining operators (greedy for multi-char first).
+  const parts = command.split(/\s*(?:&&|\|\||;|\|)\s*/);
+  return parts
+    .map((p) => stripPrefix(p.trim()))
+    .filter((p) => p.length > 0);
+}
+
+function stripPrefix(s) {
+  let cur = s;
+  // Strip leading env-var assignments (FOO=bar BAZ=qux ...)
+  while (/^[A-Za-z_][A-Za-z0-9_]*=\S*\s+/.test(cur)) {
+    cur = cur.replace(/^[A-Za-z_][A-Za-z0-9_]*=\S*\s+/, "");
+  }
+  // Strip leading sudo / nice / time prefixes
+  cur = cur.replace(/^(sudo|nice|time)\s+/, "");
+  return cur;
+}
+
+function isGitPush(s) {
+  return /^git\s+push(\s|$)/.test(s);
+}
+
+/**
+ * Detect that a `git push` targets main or master in any common refspec
+ * form. Conservative: any token matching `\bmain\b` or `\bmaster\b` after
+ * the `push` keyword counts. Operators with a "feature/main" branch may
+ * see false positives — they can disable `push_main` via GIT_GATE_DISABLE.
+ */
+function targetsProtectedBranch(s) {
+  // Strip "git push" prefix; inspect the remainder.
+  const tail = s.replace(/^git\s+push\s*/, "");
+  if (tail.length === 0) return false;
+  // Match :main, :master, HEAD:main, HEAD:master, ` main`, ` master` as
+  // word-bounded tokens in the tail.
+  return /(^|\s|:)(main|master)(\s|$)/.test(tail);
+}
+
+/**
+ * Decide for a full bash command. Walks compound segments, runs each
+ * against the active rules, returns the strictest match.
+ *
+ * `disabledNames` is a Set of rule names disabled by env var or config.
+ * `extraRules` is appended after the defaults (operator-supplied).
+ *
+ * Returns `null` if no rule matched (caller should emit no decision).
+ */
+export function decide(command, options = {}) {
+  const disabled = options.disabled ?? new Set();
+  const extra = options.extraRules ?? [];
+  const rules = [...DEFAULT_RULES, ...extra].filter(
+    (r) => !disabled.has(r.name),
+  );
+
+  let strictest = null;
+  for (const segment of splitCompound(command)) {
+    for (const rule of rules) {
+      if (rule.match(segment)) {
+        if (strictest === null || rank(rule) > rank(strictest)) {
+          strictest = rule;
+        }
+      }
+    }
+  }
+  return strictest;
+}
+
+function rank(rule) {
+  if (rule.decision === "deny") return 2;
+  if (rule.decision === "ask") return 1;
+  return 0;
+}

--- a/plugins/git-plugin/package.json
+++ b/plugins/git-plugin/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "git-plugin",
+  "version": "1.0.0",
+  "description": "Claude Code plugin: PreToolUse hook gating risky git commands.",
+  "type": "module",
+  "private": true,
+  "license": "MIT"
+}

--- a/plugins/git-plugin/tests/smoke.test.ts
+++ b/plugins/git-plugin/tests/smoke.test.ts
@@ -1,0 +1,316 @@
+/**
+ * smoke.test.ts — end-to-end subprocess tests for git_gate.mjs.
+ *
+ * Spawns the hook script as a real Node process, pipes a Claude Code
+ * PreToolUse payload via stdin, and asserts on the JSON written to
+ * stdout. Complements the pure-classifier unit tests in
+ * `tests/plugins/git-plugin/rules.test.ts` by covering the parts those
+ * tests skip: stdin reading, JSON parsing, env-var handling, config
+ * file loading, and stdout shape.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const HOOK_PATH = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "hooks",
+  "git_gate.mjs",
+);
+
+interface HookResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+async function runHook(
+  payload: unknown,
+  env: Record<string, string> = {},
+): Promise<HookResult> {
+  return new Promise<HookResult>((resolve, reject) => {
+    const proc = spawn("node", [HOOK_PATH], {
+      env: { ...process.env, ...env },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    proc.stdout.on("data", (d: Buffer) => (stdout += d.toString("utf-8")));
+    proc.stderr.on("data", (d: Buffer) => (stderr += d.toString("utf-8")));
+    proc.on("close", (code) =>
+      resolve({ stdout, stderr, exitCode: code ?? -1 }),
+    );
+    proc.on("error", reject);
+    proc.stdin.write(JSON.stringify(payload));
+    proc.stdin.end();
+  });
+}
+
+function parseDecision(stdout: string): {
+  permissionDecision: string;
+  permissionDecisionReason: string;
+} | null {
+  if (stdout.trim().length === 0) return null;
+  const parsed = JSON.parse(stdout);
+  return parsed.hookSpecificOutput ?? null;
+}
+
+describe("smoke: deny path", () => {
+  it("denies push to main with the expected JSON envelope", async () => {
+    const r = await runHook({
+      tool_name: "Bash",
+      tool_input: { command: "git push origin main" },
+      hook_event_name: "PreToolUse",
+      cwd: "/tmp",
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stderr).toBe("");
+    const d = parseDecision(r.stdout);
+    expect(d).not.toBeNull();
+    expect(d!.permissionDecision).toBe("deny");
+    expect(d!.permissionDecisionReason).toMatch(/main\/master/i);
+  });
+});
+
+describe("smoke: ask path", () => {
+  it("asks on plain push", async () => {
+    const r = await runHook({
+      tool_name: "Bash",
+      tool_input: { command: "git push" },
+      hook_event_name: "PreToolUse",
+      cwd: "/tmp",
+    });
+    expect(r.exitCode).toBe(0);
+    const d = parseDecision(r.stdout);
+    expect(d!.permissionDecision).toBe("ask");
+  });
+
+  it("asks on force push to a feature branch", async () => {
+    const r = await runHook({
+      tool_name: "Bash",
+      tool_input: { command: "git push --force origin feature" },
+      hook_event_name: "PreToolUse",
+      cwd: "/tmp",
+    });
+    const d = parseDecision(r.stdout);
+    expect(d!.permissionDecision).toBe("ask");
+    expect(d!.permissionDecisionReason).toMatch(/force/i);
+  });
+
+  it("asks on git clean -fdx", async () => {
+    const r = await runHook({
+      tool_name: "Bash",
+      tool_input: { command: "git clean -fdx" },
+      hook_event_name: "PreToolUse",
+      cwd: "/tmp",
+    });
+    expect(parseDecision(r.stdout)!.permissionDecision).toBe("ask");
+  });
+});
+
+describe("smoke: no-decision path", () => {
+  it("emits no decision for git status (safe)", async () => {
+    const r = await runHook({
+      tool_name: "Bash",
+      tool_input: { command: "git status" },
+      hook_event_name: "PreToolUse",
+      cwd: "/tmp",
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("");
+  });
+
+  it("emits no decision for non-git commands", async () => {
+    const r = await runHook({
+      tool_name: "Bash",
+      tool_input: { command: "ls -la" },
+      hook_event_name: "PreToolUse",
+      cwd: "/tmp",
+    });
+    expect(r.stdout).toBe("");
+  });
+
+  it("ignores non-Bash tool calls", async () => {
+    const r = await runHook({
+      tool_name: "Read",
+      tool_input: { file_path: "/tmp/foo" },
+      hook_event_name: "PreToolUse",
+      cwd: "/tmp",
+    });
+    expect(r.stdout).toBe("");
+  });
+});
+
+describe("smoke: graceful failure", () => {
+  it("does not crash on malformed stdin", async () => {
+    return new Promise<void>((resolve, reject) => {
+      const proc = spawn("node", [HOOK_PATH], {
+        env: process.env,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      let stdout = "";
+      proc.stdout.on("data", (d: Buffer) => (stdout += d.toString("utf-8")));
+      proc.on("close", (code) => {
+        try {
+          expect(code).toBe(0);
+          expect(stdout).toBe("");
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      });
+      proc.on("error", reject);
+      proc.stdin.write("not valid json {");
+      proc.stdin.end();
+    });
+  });
+
+  it("does not crash when tool_input.command is missing", async () => {
+    const r = await runHook({
+      tool_name: "Bash",
+      tool_input: {},
+      hook_event_name: "PreToolUse",
+      cwd: "/tmp",
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("");
+  });
+});
+
+describe("smoke: env-var override", () => {
+  it("GIT_GATE_DISABLE silences the named rule", async () => {
+    const r = await runHook(
+      {
+        tool_name: "Bash",
+        tool_input: { command: "git push" },
+        hook_event_name: "PreToolUse",
+        cwd: "/tmp",
+      },
+      { GIT_GATE_DISABLE: "push" },
+    );
+    expect(r.stdout).toBe("");
+  });
+
+  it("disabling push_main allows main pushes to fall through to push (still asks)", async () => {
+    const r = await runHook(
+      {
+        tool_name: "Bash",
+        tool_input: { command: "git push origin main" },
+        hook_event_name: "PreToolUse",
+        cwd: "/tmp",
+      },
+      { GIT_GATE_DISABLE: "push_main" },
+    );
+    const d = parseDecision(r.stdout);
+    expect(d!.permissionDecision).toBe("ask");
+  });
+});
+
+describe("smoke: config file override", () => {
+  let tmpHome: string;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "git-gate-smoke-"));
+    fs.mkdirSync(path.join(tmpHome, ".connectors"), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("custom rule from ~/.connectors/git-gate.json fires", async () => {
+    fs.writeFileSync(
+      path.join(tmpHome, ".connectors", "git-gate.json"),
+      JSON.stringify({
+        rules: [
+          {
+            name: "deny_release",
+            decision: "deny",
+            reason: "release branches need SRE",
+            pattern: "^git\\s+push\\s+\\S+\\s+release\\b",
+          },
+        ],
+      }),
+    );
+    const r = await runHook(
+      {
+        tool_name: "Bash",
+        tool_input: { command: "git push origin release/v1" },
+        hook_event_name: "PreToolUse",
+        cwd: "/tmp",
+      },
+      { HOME: tmpHome },
+    );
+    const d = parseDecision(r.stdout);
+    expect(d!.permissionDecision).toBe("deny");
+    expect(d!.permissionDecisionReason).toMatch(/release/i);
+  });
+
+  it("config-disabled rule is silenced", async () => {
+    fs.writeFileSync(
+      path.join(tmpHome, ".connectors", "git-gate.json"),
+      JSON.stringify({ disabled: ["push"] }),
+    );
+    const r = await runHook(
+      {
+        tool_name: "Bash",
+        tool_input: { command: "git push" },
+        hook_event_name: "PreToolUse",
+        cwd: "/tmp",
+      },
+      { HOME: tmpHome },
+    );
+    expect(r.stdout).toBe("");
+  });
+
+  it("malformed config does not crash the hook", async () => {
+    fs.writeFileSync(
+      path.join(tmpHome, ".connectors", "git-gate.json"),
+      "{ not valid json",
+    );
+    const r = await runHook(
+      {
+        tool_name: "Bash",
+        tool_input: { command: "git push origin main" },
+        hook_event_name: "PreToolUse",
+        cwd: "/tmp",
+      },
+      { HOME: tmpHome },
+    );
+    // Hook ignores the bad config and falls back to defaults.
+    expect(r.exitCode).toBe(0);
+    const d = parseDecision(r.stdout);
+    expect(d!.permissionDecision).toBe("deny");
+  });
+});
+
+describe("smoke: compound commands", () => {
+  it("strictest decision wins across `&&` segments", async () => {
+    const r = await runHook({
+      tool_name: "Bash",
+      tool_input: {
+        command: "git push origin feature && git push origin main",
+      },
+      hook_event_name: "PreToolUse",
+      cwd: "/tmp",
+    });
+    const d = parseDecision(r.stdout);
+    expect(d!.permissionDecision).toBe("deny");
+  });
+
+  it("env-var prefix on a chained git command still classifies", async () => {
+    const r = await runHook({
+      tool_name: "Bash",
+      tool_input: { command: "cd repo && FOO=bar git push --force" },
+      hook_event_name: "PreToolUse",
+      cwd: "/tmp",
+    });
+    const d = parseDecision(r.stdout);
+    expect(d!.permissionDecision).toBe("ask");
+    expect(d!.permissionDecisionReason).toMatch(/force/i);
+  });
+});

--- a/tests/plugins/git-plugin/rules.test.ts
+++ b/tests/plugins/git-plugin/rules.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect } from "vitest";
+import {
+  decide,
+  splitCompound,
+  DEFAULT_RULES,
+} from "../../../plugins/git-plugin/hooks/rules.mjs";
+
+function decision(cmd, opts) {
+  const r = decide(cmd, opts);
+  return r === null ? null : { name: r.name, decision: r.decision };
+}
+
+describe("splitCompound", () => {
+  it("returns single command unchanged", () => {
+    expect(splitCompound("git push")).toEqual(["git push"]);
+  });
+
+  it("splits on &&", () => {
+    expect(splitCompound("cd repo && git push")).toEqual([
+      "cd repo",
+      "git push",
+    ]);
+  });
+
+  it("splits on ||, ;, |", () => {
+    expect(splitCompound("a || b ; c | d")).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("strips leading env-var prefixes", () => {
+    expect(splitCompound("FOO=bar BAZ=qux git push")).toEqual(["git push"]);
+  });
+
+  it("strips leading sudo / nice / time", () => {
+    expect(splitCompound("sudo git push")).toEqual(["git push"]);
+    expect(splitCompound("nice git status")).toEqual(["git status"]);
+    expect(splitCompound("time git pull")).toEqual(["git pull"]);
+  });
+
+  it("ignores empty input", () => {
+    expect(splitCompound("")).toEqual([]);
+    expect(splitCompound(null)).toEqual([]);
+    expect(splitCompound(undefined)).toEqual([]);
+  });
+});
+
+describe("default rules — push_main (deny)", () => {
+  it.each([
+    "git push origin main",
+    "git push origin master",
+    "git push origin HEAD:main",
+    "git push origin HEAD:master",
+    "git push origin :main",
+    "git push --force origin main",
+    "git push -f origin master",
+  ])("denies %s", (cmd) => {
+    expect(decision(cmd)).toEqual({ name: "push_main", decision: "deny" });
+  });
+
+  it("does not fire on push to a feature branch", () => {
+    expect(decision("git push origin my-feature")).toEqual({
+      name: "push",
+      decision: "ask",
+    });
+  });
+
+  it("does not deny when target is unrelated despite branch name containing main", () => {
+    // 'maintenance' should not match \bmain\b
+    expect(decision("git push origin maintenance")?.name).toBe("push");
+  });
+});
+
+describe("default rules — force_push (ask)", () => {
+  it.each([
+    "git push --force",
+    "git push --force origin main",
+    "git push -f origin feature",
+    "git push --force-with-lease",
+    "git push --force-with-lease origin feature",
+  ])("asks on %s", (cmd) => {
+    const d = decide(cmd);
+    expect(d).not.toBeNull();
+    // push to main/master + force still wins via deny.
+    if (cmd.includes("main") || cmd.includes("master")) {
+      expect(d.name).toBe("push_main");
+    } else {
+      expect(d.name).toBe("force_push");
+      expect(d.decision).toBe("ask");
+    }
+  });
+});
+
+describe("default rules — delete_branch_remote (ask)", () => {
+  it.each([
+    "git push --delete origin feature",
+    "git push -d origin feature",
+    "git push origin :feature",
+  ])("asks on %s", (cmd) => {
+    const d = decide(cmd);
+    expect(d?.decision).toBe("ask");
+    expect(["delete_branch_remote", "push_main"]).toContain(d?.name);
+  });
+
+  it("does not classify a normal push as delete_branch_remote", () => {
+    expect(decide("git push origin feature")?.name).toBe("push");
+  });
+});
+
+describe("default rules — push (ask, plain)", () => {
+  it("asks on plain push", () => {
+    expect(decision("git push")).toEqual({ name: "push", decision: "ask" });
+  });
+
+  it("asks on push origin <branch>", () => {
+    expect(decision("git push origin feature")).toEqual({
+      name: "push",
+      decision: "ask",
+    });
+  });
+
+  it("asks on push --tags", () => {
+    expect(decision("git push --tags")).toEqual({
+      name: "push",
+      decision: "ask",
+    });
+  });
+});
+
+describe("default rules — delete_branch_local (ask)", () => {
+  it.each([
+    "git branch -D feature",
+    "git branch --delete --force feature",
+    "git branch -Df feature",
+  ])("asks on %s", (cmd) => {
+    expect(decision(cmd)).toEqual({
+      name: "delete_branch_local",
+      decision: "ask",
+    });
+  });
+
+  it("does not fire on git branch -d (lowercase, non-force)", () => {
+    expect(decide("git branch -d feature")).toBeNull();
+  });
+});
+
+describe("default rules — reset_hard (ask)", () => {
+  it("asks on git reset --hard", () => {
+    expect(decision("git reset --hard")).toEqual({
+      name: "reset_hard",
+      decision: "ask",
+    });
+  });
+
+  it("asks on git reset --hard HEAD~1", () => {
+    expect(decision("git reset --hard HEAD~1")).toEqual({
+      name: "reset_hard",
+      decision: "ask",
+    });
+  });
+
+  it("does not fire on git reset (no --hard)", () => {
+    expect(decide("git reset HEAD~1")).toBeNull();
+  });
+
+  it("does not fire on git reset --soft", () => {
+    expect(decide("git reset --soft HEAD~1")).toBeNull();
+  });
+});
+
+describe("default rules — checkout_discard (ask)", () => {
+  it.each([
+    "git checkout .",
+    "git checkout -- src/foo.ts",
+    "git checkout main -- src/foo.ts",
+    "git restore --worktree src/foo.ts",
+    "git restore -W src/foo.ts",
+    "git restore .",
+  ])("asks on %s", (cmd) => {
+    expect(decision(cmd)?.name).toBe("checkout_discard");
+  });
+
+  it("does not fire on plain branch switch", () => {
+    expect(decide("git checkout main")).toBeNull();
+    expect(decide("git checkout -b feature")).toBeNull();
+  });
+
+  it("does not fire on git restore --staged (index-only)", () => {
+    expect(decide("git restore --staged src/foo.ts")).toBeNull();
+  });
+});
+
+describe("default rules — clean_force (ask)", () => {
+  it.each([
+    "git clean -f",
+    "git clean -fd",
+    "git clean -fdx",
+    "git clean -df",
+    "git clean -xdf",
+  ])("asks on %s", (cmd) => {
+    expect(decision(cmd)).toEqual({ name: "clean_force", decision: "ask" });
+  });
+
+  it("does not fire on git clean -n (dry run)", () => {
+    expect(decide("git clean -n")).toBeNull();
+  });
+});
+
+describe("compound commands", () => {
+  it("strictest decision wins (deny > ask)", () => {
+    const d = decide("git push origin feature && git push origin main");
+    expect(d?.decision).toBe("deny");
+    expect(d?.name).toBe("push_main");
+  });
+
+  it("first segment matches if later segments are non-git", () => {
+    expect(decide("git push && echo done")).toEqual(
+      expect.objectContaining({ name: "push", decision: "ask" }),
+    );
+  });
+
+  it("non-git compound returns null", () => {
+    expect(decide("ls && cat foo.txt")).toBeNull();
+  });
+
+  it("env prefix on a chained git command still classifies", () => {
+    expect(decide("cd repo && FOO=bar git push --force")?.name).toBe(
+      "force_push",
+    );
+  });
+});
+
+describe("disabled rules", () => {
+  it("disabled rule is skipped", () => {
+    expect(
+      decide("git push", { disabled: new Set(["push"]) }),
+    ).toBeNull();
+  });
+
+  it("disabling push_main allows push to main (still asks)", () => {
+    const d = decide("git push origin main", {
+      disabled: new Set(["push_main"]),
+    });
+    expect(d?.name).toBe("push");
+    expect(d?.decision).toBe("ask");
+  });
+
+  it("disabling all relevant rules allows push silently", () => {
+    expect(
+      decide("git push origin main", {
+        disabled: new Set(["push_main", "push"]),
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("extra rules from config", () => {
+  const releaseRule = {
+    name: "deny_release",
+    decision: "deny",
+    reason: "release branch denied",
+    match: (s) => /^git\s+push\s+\S+\s+release\b/.test(s),
+  };
+
+  it("custom rule fires on matching command", () => {
+    expect(
+      decide("git push origin release/v1", { extraRules: [releaseRule] }),
+    ).toEqual(
+      expect.objectContaining({ name: "deny_release", decision: "deny" }),
+    );
+  });
+
+  it("custom deny beats default ask", () => {
+    // 'git push' alone would ask via 'push' rule; custom deny on release wins.
+    const d = decide("git push origin release/v1", {
+      extraRules: [releaseRule],
+    });
+    expect(d?.decision).toBe("deny");
+  });
+});
+
+describe("non-git commands return null", () => {
+  it.each([
+    "ls -la",
+    "npm install",
+    "git status",
+    "git log",
+    "git diff",
+    "git fetch origin",
+    "git pull",
+    "git commit -m 'msg'",
+    "git add .",
+    "git checkout main",
+  ])("%s does not match any rule", (cmd) => {
+    expect(decide(cmd)).toBeNull();
+  });
+});
+
+describe("default rule set sanity", () => {
+  it("every rule has the required fields", () => {
+    for (const r of DEFAULT_RULES) {
+      expect(typeof r.name).toBe("string");
+      expect(["deny", "ask", "allow"]).toContain(r.decision);
+      expect(typeof r.reason).toBe("string");
+      expect(typeof r.match).toBe("function");
+    }
+  });
+
+  it("rule names are unique", () => {
+    const names = DEFAULT_RULES.map((r) => r.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,11 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["src/**/*.test.ts", "tests/**/*.test.ts"],
+    include: [
+      "src/**/*.test.ts",
+      "tests/**/*.test.ts",
+      "plugins/**/tests/**/*.test.ts",
+    ],
     exclude: ["node_modules", "dist"],
     testTimeout: 30000,
   },


### PR DESCRIPTION
## Summary

New Claude Code plugin with **no agents, actions, or skills** — just a `PreToolUse` hook on the Bash tool that classifies `git` invocations and emits permission decisions per the [hook contract](https://code.claude.com/docs/en/hooks.md).

### Default rules

| Rule | Decision | Fires on |
|---|---|---|
| `push_main` | **deny** | `git push` whose refspec targets `main` or `master` (any form, force or not) |
| `force_push` | **ask** | `git push --force` / `-f` / `--force-with-lease` |
| `delete_branch_remote` | **ask** | `git push --delete`, `git push -d`, or `git push <remote> :branch` |
| `push` | **ask** | Any other `git push` |
| `delete_branch_local` | **ask** | `git branch -D` / `git branch --delete --force` |
| `reset_hard` | **ask** | `git reset --hard` |
| `checkout_discard` | **ask** | `git checkout <pathspec>` / `git restore --worktree` / `git checkout .` |
| `clean_force` | **ask** | `git clean -f…` (any `-f` variant) |

Decision precedence: `deny` > `ask` > `allow`. If no rule matches, the hook emits no decision and Claude Code's default permission flow continues.

Compound commands (`cd repo && git push origin main`) split on `&&` / `||` / `;` / `|` and each segment is classified independently — the strictest match wins. Leading env-var assignments (`FOO=bar git push`) and common prefixes (`sudo`, `nice`, `time`) are stripped before matching.

### Configuration

Two layers, both opt-in:

- **Env var**: `GIT_GATE_DISABLE=push,push_main` disables specific rules.
- **Config file**: `~/.connectors/git-gate.json` (sibling to `~/.connectors/config.yaml`) accepts `disabled: [...]` and/or `rules: [{name, decision, reason, pattern}]`. `pattern` is a JS regex source, applied to each command segment.

Custom rules are evaluated **after** the defaults; the strictest match across all rules wins.

### Why no YAML in v1

The hook runs on every Bash invocation; pulling in `js-yaml` would couple the plugin to other narai-primitives plugins being installed. JSON is parser-free in Node and covers the configuration surface cleanly. YAML can come in v2 if there's demand.

## Files

- `plugins/git-plugin/.claude-plugin/plugin.json` — manifest
- `plugins/git-plugin/hooks/hooks.json` — registers `PreToolUse` on `Bash`
- `plugins/git-plugin/hooks/git_gate.mjs` — entry point (reads stdin JSON, writes stdout JSON)
- `plugins/git-plugin/hooks/rules.mjs` — pure rules table + classifier (no I/O)
- `plugins/git-plugin/README.md` — full reference
- `plugins/git-plugin/package.json` — minimal manifest, no runtime deps
- `tests/plugins/git-plugin/rules.test.ts` — 70 tests

## Test plan

- [x] Unit tests: `npx vitest run tests/plugins/git-plugin/` — 70/70 pass, covering each default rule (positive + negative cases), compound commands, env-prefix stripping, decision precedence, env-var disable flags, custom config rules.
- [x] Full suite: `npx vitest run` — 1681/1681 pass, 26 skipped (pre-existing live-DB tests). No regressions.
- [x] End-to-end smoke: piped mock stdin payloads through `git_gate.mjs` and verified JSON output for `git push`, `git push origin main`, `git push --force`, `git status`, `git reset --hard`, `ls -la`. All produce expected decisions (or no decision for non-git / safe commands).
- [ ] Manual install via Claude Code marketplace and verify a `git push origin main` triggers the deny dialog with the configured reason.
- [ ] Manual: confirm `~/.connectors/git-gate.json` overrides take effect (test both `disabled` and a custom `rules[]` entry).

## Notes for reviewers

- The `push_main` rule matches any `\bmain\b` or `\bmaster\b` token in the push args. False positives are possible if you literally have a branch named `feature/main`; operators can disable via `GIT_GATE_DISABLE=push_main`. Documented in README + tests.
- The command splitter doesn't track quoted strings — a literal `&&` inside single quotes would split the segment. Over-splitting is the right bias for a safety gate; documented in README.
- The hook is dependency-free (no npm install at SessionStart). Pure Node ESM via `node "${CLAUDE_PLUGIN_ROOT}/hooks/git_gate.mjs"`.