### PR TITLE
feat: gitlab-connector (33 actions, self-hosted, unified notes)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ This triggers `npm publish --provenance` plus a GitHub Release. The workflow fai
 
 Before you start:
 
-- Check that the service isn't already covered. Today's builtins: `aws`, `confluence`, `db` (postgres / mysql / sqlite / mssql / mongodb / dynamodb / oracle), `gcp`, `github`, `jira`, `notion`. Database backends not yet supported by `db` should usually go into `db`'s driver registry rather than start fresh.
+- Check that the service isn't already covered. Today's builtins: `aws`, `confluence`, `db` (postgres / mysql / sqlite / mssql / mongodb / dynamodb / oracle), `gcp`, `github`, `gitlab`, `jira`, `notion`. Database backends not yet supported by `db` should usually go into `db`'s driver registry rather than start fresh.
 - File an issue first if you're unsure whether the connector belongs here. Adding a builtin is a long-term commitment to maintain it.
 - The connector must be **read-only** by default (or have a clearly delineated read-only mode). Write/delete/admin actions go through the toolkit's policy gate; we expect the contributor to explicitly classify them.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Bundles what used to ship as eleven separate `@narai/*` packages:
 - `@narai/github-agent-connector` → `narai-primitives/github`
 - `@narai/jira-agent-connector` → `narai-primitives/jira`
 - `@narai/notion-agent-connector` → `narai-primitives/notion`
+- `@narai/gitlab-agent-connector` → `narai-primitives/gitlab`
 
 ## Install
 

--- a/docs/superpowers/plans/2026-05-12-gitlab-connector.md
+++ b/docs/superpowers/plans/2026-05-12-gitlab-connector.md
@@ -1,0 +1,219 @@
+# GitLab connector — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `src/connectors/gitlab/` and `plugins/gitlab-connector/` mirroring the 36-action github-connector (PR #20), with GitLab-native terminology and 33 actions (14 read + 18 write + 1 admin).
+
+**Architecture:** Identical structure to github-connector: per-domain action modules under `actions/`, shared `_fields.ts` + `_pagination.ts` + `_types.ts`, behavior config loader, policy gate with delete-aspect floor. Auth via `Authorization: Bearer <PAT>` (GitLab ≥12.x).
+
+**Tech Stack:** TypeScript (strict, ESM), Zod 3, Vitest, `narai-primitives/toolkit`.
+
+**Spec:** `docs/superpowers/specs/2026-05-12-gitlab-connector-design.md`.
+
+---
+
+## File map
+
+**New source files (13):**
+- `src/connectors/gitlab/index.ts`
+- `src/connectors/gitlab/cli.ts`
+- `src/connectors/gitlab/actions/_fields.ts`
+- `src/connectors/gitlab/actions/_pagination.ts`
+- `src/connectors/gitlab/actions/_types.ts`
+- `src/connectors/gitlab/actions/reads.ts`
+- `src/connectors/gitlab/actions/merges.ts`
+- `src/connectors/gitlab/actions/issues.ts`
+- `src/connectors/gitlab/actions/notes.ts`
+- `src/connectors/gitlab/actions/releases.ts`
+- `src/connectors/gitlab/actions/pipelines.ts`
+- `src/connectors/gitlab/lib/gitlab_client.ts`
+- `src/connectors/gitlab/lib/gitlab_config.ts`
+
+**New plugin files (8):**
+- `plugins/gitlab-connector/.claude-plugin/plugin.json`
+- `plugins/gitlab-connector/bin/gitlab-connector`
+- `plugins/gitlab-connector/commands/gitlab-connector.md`
+- `plugins/gitlab-connector/hooks/hooks.json`
+- `plugins/gitlab-connector/package.json`
+- `plugins/gitlab-connector/plugin-config.json`
+- `plugins/gitlab-connector/README.md`
+- `plugins/gitlab-connector/skills/gitlab-connector/SKILL.md`
+
+**New test files (10):**
+- `tests/connectors/gitlab/unit/cli.test.ts`
+- `tests/connectors/gitlab/unit/gitlab_client_extras.test.ts`
+- `tests/connectors/gitlab/unit/gitlab_client_mutations.test.ts`
+- `tests/connectors/gitlab/unit/gitlab_config.test.ts`
+- `tests/connectors/gitlab/unit/actions_merges.test.ts`
+- `tests/connectors/gitlab/unit/actions_issues.test.ts`
+- `tests/connectors/gitlab/unit/actions_notes.test.ts`
+- `tests/connectors/gitlab/unit/actions_releases.test.ts`
+- `tests/connectors/gitlab/unit/actions_pipelines.test.ts`
+- `tests/connectors/gitlab/integration/framework.test.ts`
+
+**Modified:**
+- `package.json` (exports + bin)
+- `README.md` (bundle table)
+- `CONTRIBUTING.md` (bundled-builtins list)
+- `/Users/narayan/src/narai-claude-plugins/.claude-plugin/marketplace.json` (separate repo)
+
+---
+
+## Tasks
+
+Each task is TDD: failing tests first → minimal impl → tests pass → commit. Run `npx vitest run tests/connectors/gitlab` for fast feedback.
+
+### Task 1 — Behavior config loader
+
+`src/connectors/gitlab/lib/gitlab_config.ts` exposes `loadGitlabBehavior({ cwd, home, env })` returning `{ requireDraftMr, host }`. Precedence: env > repo YAML > user YAML > default. Tests cover the 14-case precedence matrix for both knobs.
+
+**Files:** `lib/gitlab_config.ts`, `tests/connectors/gitlab/unit/gitlab_config.test.ts`.
+
+**Pattern reference:** `src/connectors/github/lib/github_config.ts`.
+
+### Task 2 — GitlabClient + credentials
+
+`src/connectors/gitlab/lib/gitlab_client.ts`:
+- `loadGitlabCredentials()` reads `GITLAB_TOKEN`, `GITLAB_HOST` (default `https://gitlab.com`), optional `GITLAB_NAMESPACE`.
+- `GitlabClient` constructor takes `{ token, host, defaultNamespace, ... }`. baseUrl = `${host}/api/v4`. Auth header: `Bearer <token>`.
+- Methods (HTTP-level only): mirror github_client.ts methods 1:1 where they exist; for unified notes one method `getNotes(projectPath, noteableType, iid)`; for pipelines: `getPipeline`, `listPipelines(query)`, `listPipelineJobs(pipelineId)`, `getJobLogs(jobId)`, `retryPipeline`, `cancelPipeline`, `triggerPipeline(ref, token)`, `playJob(jobId)`, `retryFailedJobs(pipelineId)` (uses /retry endpoint scoped to failed).
+- `projectPath(namespace, project)` helper: returns `encodeURIComponent(`${namespace}/${project}`)`.
+- Extras tests in `gitlab_client_extras.test.ts` cover retry/timeout/rate-limit.
+
+**Files:** `lib/gitlab_client.ts`, `tests/connectors/gitlab/unit/gitlab_client_extras.test.ts` (+ `gitlab_client_mutations.test.ts` grows in later tasks).
+
+**Pattern reference:** `src/connectors/github/lib/github_client.ts`, `tests/connectors/github/unit/github_client_extras.test.ts`.
+
+### Task 3 — Shared utilities + 14 read actions
+
+`actions/_fields.ts` exports zod schemas: `namespaceField`, `projectField` (combined into `projectInputSchema = z.object({ namespace, project })`), `mrIidField`, `issueIidField`, `pipelineIdField`, `jobIdField`, `noteIdField`, `releaseTagField`, `linkIdField`, `refField`, `shaField`, `filePathField`.
+
+`actions/_pagination.ts` exports `paginateGitlab<T>(maxResults, fetchPage)` using `X-Next-Page` / `X-Total-Pages` headers (per `HttpResultOk.headers` — confirm shape).
+
+`actions/_types.ts` exports `GitlabActions`, `GitlabActionDeps`.
+
+`actions/reads.ts` defines `buildReadActions(deps)` with the 14 read actions (envelope shapes documented in spec §3.1).
+
+Tests in `actions_*` files exist by domain even though reads is one file — these classification + envelope tests live in `actions_merges.test.ts`, `actions_issues.test.ts`, etc. for the domain reads; pure-read actions (`project_info`, `search_code`, `get_file`, `list_pipelines`, etc.) get a `actions_reads.test.ts` file.
+
+**Files:** `actions/{_fields,_pagination,_types,reads}.ts`, `tests/connectors/gitlab/unit/actions_reads.test.ts`.
+
+**Pattern reference:** `src/connectors/github/actions/{_fields,_pagination,_types,reads}.ts`.
+
+### Task 4 — MR actions module (merges.ts)
+
+5 actions: `create_merge_request` (honors `require_draft_mr`), `update_merge_request` (rejects `state_event=close`), `close_merge_request` (delete aspect), `merge_merge_request` (admin, 405/406 → CONFLICT), and `get_merge_request` already in reads.
+
+GitLab merge endpoint returns 405 or 406 when not mergeable. Handler inspects `r.status` ∈ {405, 406, 409} and throws `ConnectorError("CONFLICT", message, false)`.
+
+**Files:** `actions/merges.ts`, `tests/connectors/gitlab/unit/actions_merges.test.ts`.
+
+**Pattern reference:** `src/connectors/github/actions/pulls.ts` for the require_draft pattern and conflict handling.
+
+### Task 5 — Issue actions module (issues.ts)
+
+3 writes: `create_issue`, `update_issue` (rejects `state_event=close`), `close_issue` (delete aspect, accepts optional `state_reason`).
+
+**Files:** `actions/issues.ts`, `tests/connectors/gitlab/unit/actions_issues.test.ts`.
+
+**Pattern reference:** `src/connectors/github/actions/issues.ts`.
+
+### Task 6 — Unified notes module (notes.ts)
+
+3 writes: `add_note`, `update_note`, `delete_note`. Each takes a `noteable_type: z.enum(["issue", "merge_request"])` and `noteable_iid`. `add_note` accepts optional `position` for MR diff notes: `{ position?: { base_sha, start_sha, head_sha, position_type: "text", new_path, new_line } }`.
+
+Routing in handler: builds the URL as `/projects/:id/{issues|merge_requests}/:iid/notes` based on `noteable_type`. Client method `addNote(projectPath, noteableType, noteableIid, body, position?)` handles the URL construction.
+
+**Files:** `actions/notes.ts`, `tests/connectors/gitlab/unit/actions_notes.test.ts`.
+
+**Pattern reference:** `src/connectors/github/actions/comments.ts` — but unified per spec §3.2.
+
+### Task 7 — Release actions module (releases.ts)
+
+4 writes: `create_release` (tag_name, name, description, ref?), `update_release`, `delete_release` (delete aspect), `delete_release_link` (delete aspect).
+
+**Files:** `actions/releases.ts`, `tests/connectors/gitlab/unit/actions_releases.test.ts`.
+
+**Pattern reference:** `src/connectors/github/actions/releases.ts`.
+
+### Task 8 — Pipeline actions module (pipelines.ts)
+
+5 writes (read pipeline actions live in reads.ts already):
+- `retry_pipeline` — POST `/projects/:id/pipelines/:id/retry`
+- `retry_failed_jobs` — POST `/projects/:id/pipelines/:id/retry` (GitLab's retry only re-runs failed jobs; alias for clarity)
+- `cancel_pipeline` — POST `/projects/:id/pipelines/:id/cancel`
+- `trigger_pipeline` — POST `/projects/:id/trigger/pipeline` with form params `token` + `ref` + `variables[]`
+- `play_job` — POST `/projects/:id/jobs/:id/play` for manual stages
+
+**Files:** `actions/pipelines.ts`, `tests/connectors/gitlab/unit/actions_pipelines.test.ts`.
+
+**Pattern reference:** `src/connectors/github/actions/workflows.ts`.
+
+### Task 9 — index.ts composition + CLI
+
+`src/connectors/gitlab/index.ts` builds the connector via `createConnector<GitlabClient>({...})`:
+- `name: "gitlab"`, `version: "1.0.0"`
+- `scope` callback returning `${host}/${defaultNamespace}` (mirror githubScope)
+- `policyFloorAspects: ["delete"]`
+- `defaultPolicy: { read: "success", write: "escalate", admin: "denied", aspects: { delete: "escalate" } }`
+- Compose 6 action modules via spread
+- `mapError: mapHttpError(CODE_MAP)` with `CONFLICT: "VALIDATION_ERROR"` added
+
+`src/connectors/gitlab/cli.ts` mirrors `src/connectors/github/cli.ts` (loadConnectorEnvironment).
+
+**Files:** `index.ts`, `cli.ts`.
+
+### Task 10 — CLI happy-path tests
+
+`tests/connectors/gitlab/unit/cli.test.ts` — 5 happy-path tests via `c.fetch(action, params)`:
+- `create_merge_request` → escalate
+- `create_issue` → escalate
+- `add_note` → escalate
+- `create_release` → escalate
+- `trigger_pipeline` → escalate
+
+Plus basic CLI plumbing tests (validActions surface, parses params correctly, etc).
+
+### Task 11 — Integration framework test
+
+`tests/connectors/gitlab/integration/framework.test.ts`:
+- `c.validActions.size === 33`
+- spot-checks of classifications (merge admin, close_merge_request write+delete, etc.)
+- merge_merge_request denied under default policy
+- merge_merge_request escalates after operator YAML sets `policy.admin: escalate`
+- floor rejection: operator YAML `policy.aspects.delete: success` → CONFIG_ERROR
+- X-Next-Page pagination smoke test
+
+### Task 12 — Plugin layer + package.json + marketplace
+
+- Create `plugins/gitlab-connector/` (all 8 files)
+- `package.json`:
+  - Add `"./gitlab": { types: "./dist/connectors/gitlab/index.d.ts", import: "./dist/connectors/gitlab/index.js" }` to `exports`
+  - Add `"gitlab-agent-connector": "./dist/connectors/gitlab/cli.js"` to `bin`
+- `README.md`: add row to bundle table
+- `CONTRIBUTING.md`: add `gitlab` to bundled-builtins list
+- Marketplace (separate repo `/Users/narayan/src/narai-claude-plugins`): add `gitlab-connector` entry, bump version 2.8.0 → 2.9.0
+
+---
+
+## Out of scope (deferred to v2)
+
+- OAuth bearer / PRIVATE-TOKEN header alternatives
+- GraphQL queries
+- Group-level operations
+- Project mirrors, wikis, snippets, CI variables
+- Pipeline trigger token management
+- Release asset binary extraction (links only)
+- Live integration tests with `TEST_LIVE_GITLAB=1`
+
+---
+
+## Verification
+
+```bash
+cd /Users/narayan/src/narai-primitives/.claude/worktrees/feat-gitlab-connector
+npm run build && npm run typecheck && npx vitest run tests/connectors/gitlab
+# Expected: ~145 tests pass, 0 fail
+```
+
+Adversarial review at the end of implementation: hunt for terminology slips (PR → MR), missed env vars, wrong CONFLICT codes (405/406 vs 409).

--- a/docs/superpowers/specs/2026-05-12-gitlab-connector-design.md
+++ b/docs/superpowers/specs/2026-05-12-gitlab-connector-design.md
@@ -62,7 +62,7 @@
 
 | Action | Endpoint |
 |---|---|
-| `merge_merge_request` | `PUT /projects/:id/merge_requests/:iid/merge`. Returns 405/406 on conflict — mapped to `VALIDATION_ERROR` via a `CONFLICT` code in CODE_MAP, mirroring github's 409 handling. Denied by default until operator sets `policy.admin: escalate` in `~/.gitlab-connector/config.yaml`. |
+| `merge_merge_request` | `PUT /projects/:id/merge_requests/:iid/merge`. Returns 405/406 on conflict — mapped to `VALIDATION_ERROR` via a `CONFLICT` code in CODE_MAP, mirroring github's 409 handling. Denied by default until operator sets `policy.admin: escalate` in `~/.gitlab-agent/config.yaml`. |
 
 ## 4. Architecture
 
@@ -101,7 +101,7 @@ Client wraps the shared toolkit `HttpClient` with `allowedMethods: {GET, POST, P
 
 ## 6. Behavior config
 
-`~/.gitlab-connector/config.yaml` (user) merges with `<cwd>/.gitlab-connector/config.yaml` (repo overlay):
+`~/.gitlab-agent/config.yaml` (user) merges with `<cwd>/.gitlab-agent/config.yaml` (repo overlay):
 
 ```yaml
 gitlab:

--- a/docs/superpowers/specs/2026-05-12-gitlab-connector-design.md
+++ b/docs/superpowers/specs/2026-05-12-gitlab-connector-design.md
@@ -1,0 +1,186 @@
+# GitLab connector — design spec
+
+**Status:** Approved 2026-05-12. Implementation plan in `docs/superpowers/plans/2026-05-12-gitlab-connector.md`.
+
+**Scope:** Add `src/connectors/gitlab/` mirroring the just-shipped `github-connector` (PR #20) for GitLab. Native GitLab terminology (Merge Request, Pipeline, Note, Project). 33 actions: 14 read + 18 write + 1 admin.
+
+**Builds on:** the github-connector's architecture (per-domain action modules under `actions/`, policy gate with delete-aspect floor, behavior config loader). Cite by file path where adaptation differs from a literal copy.
+
+---
+
+## 1. Goals
+
+1. Functional parity with github-connector: every github feature has a gitlab counterpart unless explicitly out of scope.
+2. GitLab-native terminology in action names (`merge_request`, `pipeline`, `note`, `project`) — not github terms translated.
+3. First-class self-hosted GitLab via `GITLAB_HOST` env var (default `https://gitlab.com`).
+4. Same policy model: writes escalate by default, admin denied until operator opts in, delete aspect floored.
+
+## 2. Non-goals
+
+- OAuth bearer token auth beyond PATs (v1 uses PAT via `Authorization: Bearer <token>`; GitLab ≥12.x supports this for PATs).
+- GraphQL queries (REST is fully featured for our 33 actions).
+- Group-level operations (project-scoped only).
+- Project mirroring, wiki, snippets, CI variables.
+- Pipeline trigger token management (`trigger_pipeline` accepts a token; managing trigger tokens themselves is out of scope).
+- Release asset binary extraction (GitLab releases use links, not binaries — `get_release_link` returns URL metadata only).
+- Live integration tests behind `TEST_LIVE_GITLAB=1` harness.
+
+## 3. Action surface (33 total)
+
+### 3.1 Reads (14)
+
+| Action | Endpoint |
+|---|---|
+| `project_info` | `GET /projects/:id` |
+| `search_code` | `GET /projects/:id/search?scope=blobs` |
+| `get_issues` | `GET /projects/:id/issues` (paginated) |
+| `get_issue` | `GET /projects/:id/issues/:iid` |
+| `get_merge_requests` | `GET /projects/:id/merge_requests` (paginated) |
+| `get_merge_request` | `GET /projects/:id/merge_requests/:iid` |
+| `get_file` | `GET /projects/:id/repository/files/:path?ref=…` |
+| `get_notes` | `GET /projects/:id/{issues\|merge_requests}/:iid/notes` (unified) |
+| `list_release_links` | `GET /projects/:id/releases/:tag/assets/links` |
+| `get_release_link` | `GET /projects/:id/releases/:tag/assets/links/:link_id` |
+| `list_pipelines` | `GET /projects/:id/pipelines` |
+| `get_pipeline` | `GET /projects/:id/pipelines/:id` |
+| `list_pipeline_jobs` | `GET /projects/:id/pipelines/:id/jobs` |
+| `get_job_logs` | `GET /projects/:id/jobs/:id/trace` (text response, no redirect) |
+
+### 3.2 Writes (18)
+
+**MRs (3):** `create_merge_request` (honors `require_draft_mr`), `update_merge_request` (rejects `state_event=close`), `close_merge_request` (delete aspect).
+
+**Issues (3):** `create_issue`, `update_issue` (rejects `state_event=close`), `close_issue` (delete aspect).
+
+**Notes (3 unified):** `add_note`, `update_note`, `delete_note` (delete aspect). Each takes `noteable_type: "issue" | "merge_request"` + `noteable_iid`. `add_note` accepts optional position payload (commit_sha + path + line) for MR diff notes.
+
+**Releases (4):** `create_release`, `update_release`, `delete_release` (delete aspect), `delete_release_link` (delete aspect).
+
+**Pipelines (5):** `retry_pipeline`, `retry_failed_jobs`, `cancel_pipeline`, `trigger_pipeline` (token+ref), `play_job` (manual stage trigger).
+
+### 3.3 Admin (1)
+
+| Action | Endpoint |
+|---|---|
+| `merge_merge_request` | `PUT /projects/:id/merge_requests/:iid/merge`. Returns 405/406 on conflict — mapped to `VALIDATION_ERROR` via a `CONFLICT` code in CODE_MAP, mirroring github's 409 handling. Denied by default until operator sets `policy.admin: escalate` in `~/.gitlab-connector/config.yaml`. |
+
+## 4. Architecture
+
+Mirror `src/connectors/github/` exactly:
+
+```
+src/connectors/gitlab/
+  index.ts                    — factory; policyFloorAspects + defaultPolicy + composes 6 action modules
+  cli.ts                      — narai-primitives/config wiring
+  actions/
+    _fields.ts                — zod schemas: namespaceField, projectField, mrIidField, issueIidField, pipelineIdField, jobIdField, refField, shaField, noteIdField, releaseTagField, linkIdField
+    _pagination.ts            — GitLab REST pagination via X-Next-Page header
+    _types.ts                 — GitlabActions, GitlabActionDeps
+    reads.ts                  — 14 read actions
+    merges.ts                 — 5 MR actions (incl. admin merge)
+    issues.ts                 — 4 issue actions
+    notes.ts                  — 3 unified note actions
+    releases.ts               — 4 release actions
+    pipelines.ts              — 9 pipeline actions
+  lib/
+    gitlab_client.ts          — HTTP client with configurable baseUrl, Bearer auth
+    gitlab_config.ts          — loadGitlabBehavior() → { requireDraftMr, host }
+```
+
+## 5. Auth & client
+
+`loadGitlabCredentials()` resolution (each step):
+1. `await resolveSecret("GITLAB_TOKEN")`
+2. `process.env.GITLAB_TOKEN`
+
+Same chain for `GITLAB_HOST` (default `https://gitlab.com`) and optional `GITLAB_NAMESPACE`.
+
+Auth: `Authorization: Bearer <token>`. Works for PATs on GitLab ≥12.x (the supported floor) and OAuth2 tokens.
+
+Client wraps the shared toolkit `HttpClient` with `allowedMethods: {GET, POST, PUT, PATCH, DELETE}` and `baseUrl: <host>/api/v4`.
+
+## 6. Behavior config
+
+`~/.gitlab-connector/config.yaml` (user) merges with `<cwd>/.gitlab-connector/config.yaml` (repo overlay):
+
+```yaml
+gitlab:
+  require_draft_mr: true       # forces draft: true on every create_merge_request
+  host: https://gitlab.mycorp  # overrides default https://gitlab.com
+```
+
+Env overrides:
+- `GITLAB_REQUIRE_DRAFT_MR` (1/0/true/false/yes/no/empty)
+- `GITLAB_HOST`
+
+Precedence (highest first): env > repo YAML > user YAML > default.
+
+## 7. Policy wiring
+
+```ts
+policyFloorAspects: ["delete"],
+defaultPolicy: {
+  read: "success",
+  write: "escalate",
+  admin: "denied",
+  aspects: { delete: "escalate" },
+},
+```
+
+Identical to github-connector's. `merge_merge_request` is denied until operator opts in.
+
+## 8. Plugin layer
+
+Mirror `plugins/github-connector/` shape under `plugins/gitlab-connector/`:
+- `.claude-plugin/plugin.json` — name `gitlab-connector-plugin`, version `1.0.0`
+- `bin/gitlab-connector` — bash exec shim
+- `commands/gitlab-connector.md`
+- `skills/gitlab-connector/SKILL.md` — frontmatter description + action tables + safety section
+- `hooks/hooks.json` — `USAGE_CONNECTOR_NAME=gitlab`
+- `package.json`, `plugin-config.json`, `README.md`
+
+## 9. Tests
+
+`tests/connectors/gitlab/`:
+- `unit/cli.test.ts` — 5 happy-path CLI invocations (write actions escalate by default)
+- `unit/gitlab_client_extras.test.ts` — retry/timeout/rate-limit (mirror github_client_extras pattern)
+- `unit/gitlab_client_mutations.test.ts` — one test per client method
+- `unit/gitlab_config.test.ts` — 14-case YAML+env precedence for both require_draft_mr AND host
+- `unit/actions_merges.test.ts` — 5 MR actions + classification + require_draft_mr enforcement + 405/406 conflict
+- `unit/actions_issues.test.ts` — issue actions
+- `unit/actions_notes.test.ts` — 3 unified note actions across both noteable_type variants
+- `unit/actions_releases.test.ts`
+- `unit/actions_pipelines.test.ts` — 9 pipeline actions
+- `integration/framework.test.ts` — 33-action surface, policy floors, admin opt-in flow
+
+Expected count: ~145 tests proportionate to github's 189 (smaller because of notes consolidation).
+
+## 10. Files modified outside the connector
+
+| File | Change |
+|---|---|
+| `package.json` | Add `"./gitlab"` to `exports`; add `"gitlab-agent-connector": "./dist/connectors/gitlab/cli.js"` to `bin` (keep `-agent-connector` npm convention) |
+| `README.md` | Add `narai-primitives/gitlab` row to the bundle table |
+| `CONTRIBUTING.md` | Add `gitlab` to the list of bundled builtins |
+| `narai-claude-plugins/.claude-plugin/marketplace.json` | Add `gitlab-connector` entry; bump `metadata.version` 2.8.0 → 2.9.0 |
+
+## 11. Reused patterns from github-connector (cite by path)
+
+- `src/connectors/github/index.ts` — factory composition + CODE_MAP + 409 handling pattern (adapt to 405/406)
+- `src/connectors/github/actions/pulls.ts` — action module factory shape + require_draft_pr enforcement (mirror for require_draft_mr)
+- `src/connectors/github/actions/_fields.ts` — shared zod schemas
+- `src/connectors/github/actions/_pagination.ts` — pagination generic (different header name for GitLab)
+- `src/connectors/github/lib/github_config.ts` — env+YAML precedence loader
+- `src/connectors/github/lib/github_client.ts` — HTTP client wrapping HttpClient
+- `plugins/github-connector/` — plugin layer template
+- `tests/connectors/github/integration/framework.test.ts` — policy gate integration test patterns
+
+## 12. Architecture invariants
+
+Reviewed against `docs/architecture-invariants.md`. New connector follows existing patterns:
+- Bundled CLI at `dist/connectors/gitlab/cli.js` — resolver auto-discovers via `bundled-self` step
+- `plugins/gitlab-connector/skills/gitlab-connector/SKILL.md` — hub's `skillMdCandidates` auto-derives this path
+- No optional peer dependencies — uses built-in `fetch` (same as github)
+- Not a db connector — schema dispatch not relevant
+
+No invariant-path file is touched.

--- a/package.json
+++ b/package.json
@@ -69,6 +69,10 @@
     "./linear": {
       "types": "./dist/connectors/linear/index.d.ts",
       "import": "./dist/connectors/linear/index.js"
+    },
+    "./gitlab": {
+      "types": "./dist/connectors/gitlab/index.d.ts",
+      "import": "./dist/connectors/gitlab/index.js"
     }
   },
   "bin": {
@@ -81,6 +85,7 @@
     "jira-agent-connector": "./dist/connectors/jira/cli.js",
     "notion-agent-connector": "./dist/connectors/notion/cli.js",
     "linear-agent-connector": "./dist/connectors/linear/cli.js",
+    "gitlab-agent-connector": "./dist/connectors/gitlab/cli.js",
     "usage-report": "./dist/toolkit/cli/usage-report.js"
   },
   "engines": {

--- a/plugins/gitlab-connector/.claude-plugin/plugin.json
+++ b/plugins/gitlab-connector/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "gitlab-connector-plugin",
+  "version": "1.0.0",
+  "description": "Read + write GitLab connector — projects, issues, merge requests, notes, releases, and CI pipelines. Policy-gated. Built on narai-primitives. Self-hosted GitLab supported via GITLAB_HOST.",
+  "author": "narailabs"
+}

--- a/plugins/gitlab-connector/README.md
+++ b/plugins/gitlab-connector/README.md
@@ -1,0 +1,62 @@
+# gitlab-connector plugin
+
+Read and write GitLab data — project info, code search, issues,
+merge requests, notes, releases, and CI pipelines — through the
+narai-primitives connector toolkit's policy gate.
+
+## Credentials
+
+Set `GITLAB_TOKEN` to a PAT with `api` scope.
+
+| Scope | Why |
+|---|---|
+| `api` | Full read + write access to projects, issues, MRs, notes, releases, and pipelines |
+
+Tokens without `api` scope will see `AUTH_ERROR` with a scope hint
+when invoking any endpoint.
+
+Optional environment variables:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `GITLAB_HOST` | `https://gitlab.com` | Self-hosted GitLab base URL |
+| `GITLAB_NAMESPACE` | (none) | Default group/user namespace; omit when passing `namespace` explicitly per action |
+
+## Config
+
+Place YAML at `~/.gitlab-connector/config.yaml` (user-level) or
+`<cwd>/.gitlab-connector/config.yaml` (repo overlay). Repo overlay wins on
+collisions.
+
+```yaml
+policy:
+  read: success
+  write: escalate
+  admin: escalate              # enables merge_merge_request
+  aspects:
+    delete: escalate            # cannot be set to success — floored
+approval_mode: confirm_once
+gitlab:
+  require_draft_mr: true       # forces every create_merge_request to draft=true
+  host: https://gitlab.example.com   # self-hosted GitLab base URL (overrides GITLAB_HOST)
+```
+
+Runtime override: `GITLAB_REQUIRE_DRAFT_MR=1` forces drafts even when
+the YAML says false; `GITLAB_REQUIRE_DRAFT_MR=0` forces non-drafts.
+Invalid values throw at startup.
+
+## Action surface
+
+33 actions across reads (14), writes (18), and admin (1). See
+`skills/gitlab-connector/SKILL.md` for the full table.
+
+## Self-hosted GitLab
+
+Self-hosted GitLab >= 12.x (Bearer-auth PAT support) is supported. Set
+`GITLAB_HOST` or `gitlab.host` in config to your instance base URL,
+e.g. `https://gitlab.example.com`. The connector appends `/api/v4/` to
+all requests.
+
+## License
+
+See repo root.

--- a/plugins/gitlab-connector/README.md
+++ b/plugins/gitlab-connector/README.md
@@ -24,8 +24,8 @@ Optional environment variables:
 
 ## Config
 
-Place YAML at `~/.gitlab-connector/config.yaml` (user-level) or
-`<cwd>/.gitlab-connector/config.yaml` (repo overlay). Repo overlay wins on
+Place YAML at `~/.gitlab-agent/config.yaml` (user-level) or
+`<cwd>/.gitlab-agent/config.yaml` (repo overlay). Repo overlay wins on
 collisions.
 
 ```yaml

--- a/plugins/gitlab-connector/bin/gitlab-connector
+++ b/plugins/gitlab-connector/bin/gitlab-connector
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${CLAUDE_PLUGIN_DATA:-}" ]; then
+  echo "gitlab-connector: CLAUDE_PLUGIN_DATA is not set (run from inside Claude Code)" >&2
+  exit 2
+fi
+
+CLI="${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/dist/connectors/gitlab/cli.js"
+
+if [ ! -f "$CLI" ]; then
+  echo "gitlab-connector: connector CLI not found at $CLI" >&2
+  echo "Restart your Claude Code session to re-run the SessionStart install hook." >&2
+  exit 2
+fi
+
+exec node "$CLI" "$@"

--- a/plugins/gitlab-connector/commands/gitlab-connector.md
+++ b/plugins/gitlab-connector/commands/gitlab-connector.md
@@ -1,0 +1,6 @@
+---
+description: Run a GitLab action via the gitlab-connector connector
+argument-hint: "<action> <params-json>"
+---
+
+Invoke the `gitlab-connector` skill with the user's $ARGUMENTS as the action name and params JSON. Return the connector's JSON envelope verbatim.

--- a/plugins/gitlab-connector/hooks/hooks.json
+++ b/plugins/gitlab-connector/hooks/hooks.json
@@ -1,0 +1,50 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "diff -q \"${CLAUDE_PLUGIN_ROOT}/package.json\" \"${CLAUDE_PLUGIN_DATA}/package.json\" >/dev/null 2>&1 || (mkdir -p \"${CLAUDE_PLUGIN_DATA}\" && cp \"${CLAUDE_PLUGIN_ROOT}/package.json\" \"${CLAUDE_PLUGIN_DATA}/\" && cd \"${CLAUDE_PLUGIN_DATA}\" && npm install --no-audit --no-fund) || rm -f \"${CLAUDE_PLUGIN_DATA}/package.json\""
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/dispatcher.mjs\" session-start"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/dispatcher.mjs\" pre-tool-use"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/dispatcher.mjs\" post-tool-use"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/dispatcher.mjs\" session-end"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/gitlab-connector/package.json
+++ b/plugins/gitlab-connector/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "gitlab-connector-plugin-runtime",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "narai-primitives": "^2.1.3"
+  }
+}

--- a/plugins/gitlab-connector/plugin-config.json
+++ b/plugins/gitlab-connector/plugin-config.json
@@ -1,0 +1,4 @@
+{
+  "name": "gitlab",
+  "binPath": "narai-primitives/dist/connectors/gitlab"
+}

--- a/plugins/gitlab-connector/skills/gitlab-connector/SKILL.md
+++ b/plugins/gitlab-connector/skills/gitlab-connector/SKILL.md
@@ -72,7 +72,7 @@ Return the connector's JSON envelope verbatim.
 | `merge_merge_request` | `namespace`, `project`, `mr_iid`, optional `merge_commit_message`/`squash_commit_message`/`should_remove_source_branch`/`merge_when_pipeline_succeeds`/`sha`/`squash` |
 
 To enable `merge_merge_request`, set `policy.admin: escalate` in
-`~/.gitlab-connector/config.yaml` (or the repo-level overlay).
+`~/.gitlab-agent/config.yaml` (or the repo-level overlay).
 
 ## Credentials
 
@@ -85,8 +85,8 @@ Optional:
 
 ## Config
 
-`~/.gitlab-connector/config.yaml` (user-level) merges with
-`<cwd>/.gitlab-connector/config.yaml` (repo overlay). Beyond the toolkit's
+`~/.gitlab-agent/config.yaml` (user-level) merges with
+`<cwd>/.gitlab-agent/config.yaml` (repo overlay). Beyond the toolkit's
 standard `policy` and `approval_mode` keys, the connector reads:
 
 ```yaml

--- a/plugins/gitlab-connector/skills/gitlab-connector/SKILL.md
+++ b/plugins/gitlab-connector/skills/gitlab-connector/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: gitlab-connector
+description: |
+  Use when the user asks about GitLab data or wants to act on GitLab —
+  project info, code search, issue/MR/release/pipeline inspection,
+  or any write that creates, updates, closes, or deletes an MR, issue,
+  note, or release; merging MRs (admin); and managing CI pipeline runs
+  (retry / cancel / trigger / play_job).
+context: fork
+---
+
+# GitLab Connector
+
+Answer the user's question by invoking the `gitlab-connector` binary
+exposed by this plugin. It delegates to `narai-primitives/gitlab`
+via GitLab's REST API v4.
+
+## Invocation
+
+```
+gitlab-connector --action <action> --params '<json>'
+```
+
+Return the connector's JSON envelope verbatim.
+
+## Read actions
+
+| Action | Required params |
+|---|---|
+| `project_info` | `namespace`, `project` |
+| `search_code` | `namespace`, `project`, `query`, optional `max_results` |
+| `get_issues` | `namespace`, `project`, optional `state`, `max_results` |
+| `get_issue` | `namespace`, `project`, `iid` |
+| `get_merge_requests` | `namespace`, `project`, optional `state`, `max_results` |
+| `get_merge_request` | `namespace`, `project`, `iid` |
+| `get_file` | `namespace`, `project`, `path`, optional `ref` |
+| `get_notes` | `namespace`, `project`, `noteable_type` ∈ {issue, merge_request}, `noteable_iid` |
+| `list_release_links` | `namespace`, `project`, `tag` |
+| `get_release_link` | `namespace`, `project`, `tag`, `link_id` |
+| `list_pipelines` | `namespace`, `project`, optional `ref`, `status`, `max_results` |
+| `get_pipeline` | `namespace`, `project`, `pipeline_id` |
+| `list_pipeline_jobs` | `namespace`, `project`, `pipeline_id` |
+| `get_job_logs` | `namespace`, `project`, `job_id` |
+
+## Write actions (escalate by default)
+
+| Action | Required params |
+|---|---|
+| `create_merge_request` | `namespace`, `project`, `source_branch`, `target_branch`, `title`, optional `description`/`draft`/`assignee_ids`/`reviewer_ids`/`labels`/`milestone_id`/`remove_source_branch`/`squash` |
+| `update_merge_request` | `namespace`, `project`, `mr_iid`, optional `title`/`description`/`target_branch`/`state_event=reopen`/`assignee_ids`/`reviewer_ids`/`labels`/`milestone_id`/`remove_source_branch`/`squash` |
+| `close_merge_request` | `namespace`, `project`, `mr_iid` |
+| `create_issue` | `namespace`, `project`, `title`, optional `description`/`assignee_ids`/`labels`/`milestone_id`/`due_date` |
+| `update_issue` | `namespace`, `project`, `iid`, optional `title`/`description`/`assignee_ids`/`labels`/`milestone_id`/`due_date`/`state_event=reopen` |
+| `close_issue` | `namespace`, `project`, `iid` |
+| `add_note` | `namespace`, `project`, `noteable_type`, `noteable_iid`, `body`, optional `position` (MR diff comments only) |
+| `update_note` | `namespace`, `project`, `noteable_type`, `noteable_iid`, `note_id`, `body` |
+| `delete_note` | `namespace`, `project`, `noteable_type`, `noteable_iid`, `note_id` |
+| `create_release` | `namespace`, `project`, `tag_name`, `name`, optional `description`/`ref`/`assets` |
+| `update_release` | `namespace`, `project`, `tag_name`, optional `name`/`description`/`milestones` |
+| `delete_release` | `namespace`, `project`, `tag_name` |
+| `delete_release_link` | `namespace`, `project`, `tag_name`, `link_id` |
+| `retry_pipeline` | `namespace`, `project`, `pipeline_id` |
+| `retry_failed_jobs` | `namespace`, `project`, `pipeline_id` |
+| `cancel_pipeline` | `namespace`, `project`, `pipeline_id` |
+| `trigger_pipeline` | `namespace`, `project`, `token`, `ref`, optional `variables` |
+| `play_job` | `namespace`, `project`, `job_id`, optional `variables` |
+
+## Admin actions (denied by default — operator must opt in)
+
+| Action | Required params |
+|---|---|
+| `merge_merge_request` | `namespace`, `project`, `mr_iid`, optional `merge_commit_message`/`squash_commit_message`/`should_remove_source_branch`/`merge_when_pipeline_succeeds`/`sha`/`squash` |
+
+To enable `merge_merge_request`, set `policy.admin: escalate` in
+`~/.gitlab-connector/config.yaml` (or the repo-level overlay).
+
+## Credentials
+
+Set `GITLAB_TOKEN` to a PAT with:
+- `api` scope — required for all read + write + admin actions
+
+Optional:
+- `GITLAB_HOST` — self-hosted GitLab base URL (default: `https://gitlab.com`)
+- `GITLAB_NAMESPACE` — default group/user namespace; omit when passing `namespace` explicitly
+
+## Config
+
+`~/.gitlab-connector/config.yaml` (user-level) merges with
+`<cwd>/.gitlab-connector/config.yaml` (repo overlay). Beyond the toolkit's
+standard `policy` and `approval_mode` keys, the connector reads:
+
+```yaml
+policy:
+  read: success
+  write: escalate
+  admin: escalate              # enables merge_merge_request
+  aspects:
+    delete: escalate            # cannot be set to success — floored
+approval_mode: confirm_once
+gitlab:
+  require_draft_mr: true       # forces every create_merge_request to draft=true
+  host: https://gitlab.example.com   # self-hosted GitLab base URL
+```
+
+Runtime override: `GITLAB_REQUIRE_DRAFT_MR=1` forces drafts even when
+the YAML says false; `GITLAB_REQUIRE_DRAFT_MR=0` forces non-drafts.
+Invalid values throw at startup.
+
+## Safety
+
+Every write call goes through the toolkit's policy gate. With no
+operator config, writes escalate (asking once), deletes escalate with a
+`delete` aspect for audit, and admin actions are denied until the
+operator explicitly opts in via YAML. The `delete` aspect is floored —
+operator config cannot downgrade it to `success`.

--- a/src/connectors/gitlab/actions/_fields.ts
+++ b/src/connectors/gitlab/actions/_fields.ts
@@ -8,9 +8,15 @@ import { z } from "zod";
 export const namespaceField = z
   .string()
   .regex(
-    /^[a-zA-Z0-9_.-]+$/,
-    "namespace: alphanumeric, dots, dashes, underscores only",
-  );
+    /^[a-zA-Z0-9_.-][a-zA-Z0-9_./-]*$/,
+    "namespace: alphanumeric, dots, dashes, underscores, or slash-separated subgroups (no leading/trailing slash)",
+  )
+  .refine((v) => !v.includes("//"), {
+    message: "namespace: consecutive slashes are not allowed",
+  })
+  .refine((v) => !v.endsWith("/"), {
+    message: "namespace: trailing slash is not allowed",
+  });
 
 export const projectField = z
   .string()

--- a/src/connectors/gitlab/actions/_fields.ts
+++ b/src/connectors/gitlab/actions/_fields.ts
@@ -1,0 +1,53 @@
+/**
+ * Zod field schemas shared across GitLab action modules. Each constraint
+ * mirrors what GitLab's API expects so that errors surface at the
+ * connector boundary rather than as 422s from upstream.
+ */
+import { z } from "zod";
+
+export const namespaceField = z
+  .string()
+  .regex(
+    /^[a-zA-Z0-9_.-]+$/,
+    "namespace: alphanumeric, dots, dashes, underscores only",
+  );
+
+export const projectField = z
+  .string()
+  .regex(
+    /^[a-zA-Z0-9_.-]+$/,
+    "project: alphanumeric, dots, dashes, underscores only",
+  );
+
+export const mrIidField = z.coerce.number().int().positive();
+export const issueIidField = z.coerce.number().int().positive();
+export const pipelineIdField = z.coerce.number().int().positive();
+export const jobIdField = z.coerce.number().int().positive();
+export const noteIdField = z.coerce.number().int().positive();
+export const linkIdField = z.coerce.number().int().positive();
+
+export const releaseTagField = z
+  .string()
+  .min(1)
+  .regex(/^[A-Za-z0-9._/+-]+$/, "Invalid tag");
+
+/** Accepts branch names, tag names, and commit SHAs. */
+export const refField = z
+  .string()
+  .min(1)
+  .regex(/^[A-Za-z0-9._/+-]+$/, "Invalid ref — must be a branch, tag, or SHA");
+
+export const shaField = z
+  .string()
+  .regex(/^[a-f0-9]{7,40}$/, "Invalid SHA — must be 7-40 hex characters");
+
+export const filePathField = z
+  .string()
+  .min(1, "get_file requires a non-empty 'path'")
+  .regex(
+    /^[a-zA-Z0-9_./ -]+$/,
+    "Invalid path — must be a valid file path",
+  )
+  .refine((p) => !p.includes(".."), {
+    message: "Path traversal not allowed — '..' is forbidden",
+  });

--- a/src/connectors/gitlab/actions/_pagination.ts
+++ b/src/connectors/gitlab/actions/_pagination.ts
@@ -1,0 +1,36 @@
+/**
+ * Paginate a GitLab listing endpoint: walks page=1,2,3... until maxResults
+ * is reached or a short page terminates. Throws ConnectorError on HTTP
+ * errors so the factory's mapError sees the canonical code.
+ *
+ * GitLab uses X-Next-Page header for pagination, but for simplicity we use
+ * the same short-page-detection approach as the GitHub paginator: stop when
+ * the server returns fewer items than requested (last page) or when we have
+ * accumulated enough results (truncate).
+ */
+import { throwIfHttpError, type HttpResult } from "narai-primitives/toolkit";
+
+export const GITLAB_MAX_PER_PAGE = 100;
+export const MAX_RESULTS_DEFAULT = 30;
+export const MAX_RESULTS_CAP = 1000;
+
+export async function paginateGitlab<T>(
+  maxResults: number,
+  fetchPage: (page: number, perPage: number) => Promise<HttpResult<T[]>>,
+): Promise<{ items: T[]; truncated: boolean }> {
+  const perPage = Math.min(GITLAB_MAX_PER_PAGE, Math.max(1, maxResults));
+  const acc: T[] = [];
+  let truncated = false;
+  for (let page = 1; ; page++) {
+    const result = await fetchPage(page, perPage);
+    throwIfHttpError(result);
+    const chunk = Array.isArray(result.data) ? result.data : [];
+    acc.push(...chunk);
+    if (chunk.length < perPage) break;
+    if (acc.length >= maxResults) {
+      truncated = true;
+      break;
+    }
+  }
+  return { items: acc.slice(0, maxResults), truncated };
+}

--- a/src/connectors/gitlab/actions/_types.ts
+++ b/src/connectors/gitlab/actions/_types.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared types used by every GitLab action-module factory.
+ */
+import type { ActionSpec } from "narai-primitives/toolkit";
+import type { GitlabBehavior } from "../lib/gitlab_config.js";
+import type { GitlabClient } from "../lib/gitlab_client.js";
+
+export type GitlabActions = Record<string, ActionSpec<any, GitlabClient>>;
+
+export interface GitlabActionDeps {
+  /** Runtime knobs (require_draft_mr, host, ...). */
+  behavior: GitlabBehavior;
+}

--- a/src/connectors/gitlab/actions/issues.ts
+++ b/src/connectors/gitlab/actions/issues.ts
@@ -1,0 +1,134 @@
+/**
+ * Issue action specs: create / update / close.
+ * (get_issue is in reads.ts.)
+ *
+ * update_issue's zod schema rejects state_event=close so closures are
+ * always routed through close_issue, which carries the delete aspect.
+ * Labels are accepted as string[] in the schema and joined to CSV before
+ * being sent to GitLab (which expects comma-separated labels).
+ */
+import { throwIfHttpError } from "narai-primitives/toolkit";
+import { z } from "zod";
+import type { GitlabActionDeps, GitlabActions } from "./_types.js";
+import type { GitlabIssue } from "../lib/gitlab_client.js";
+import { namespaceField, projectField, issueIidField } from "./_fields.js";
+
+const projectParams = z.object({
+  namespace: namespaceField,
+  project: projectField,
+});
+
+const createIssueParams = projectParams.extend({
+  title: z.string().min(1),
+  description: z.string().optional(),
+  assignee_ids: z.array(z.number().int().positive()).optional(),
+  labels: z.array(z.string()).optional(),
+  milestone_id: z.number().int().positive().optional(),
+  due_date: z.string().optional(),
+});
+
+const updateIssueParams = projectParams.extend({
+  iid: issueIidField,
+  title: z.string().min(1).optional(),
+  description: z.string().optional(),
+  assignee_ids: z.array(z.number().int().positive()).optional(),
+  labels: z.array(z.string()).optional(),
+  milestone_id: z.number().int().positive().optional(),
+  due_date: z.string().optional(),
+  state_event: z
+    .enum(["reopen"], {
+      errorMap: () => ({
+        message:
+          "update_issue only accepts state_event=reopen. Use close_issue to close.",
+      }),
+    })
+    .optional(),
+});
+
+const closeIssueParams = projectParams.extend({
+  iid: issueIidField,
+});
+
+function issueEnvelope(d: GitlabIssue) {
+  return {
+    iid: d.iid,
+    title: d.title,
+    state: d.state,
+    author: d.author?.username ?? "",
+    description: d.description ?? "",
+    labels: d.labels ?? [],
+    web_url: d.web_url ?? "",
+    updated_at: d.updated_at ?? null,
+  };
+}
+
+export function buildIssuesActions(_deps: GitlabActionDeps): GitlabActions {
+  return {
+    create_issue: {
+      description: "Create a new issue in a GitLab project",
+      params: createIssueParams,
+      classify: { kind: "write" },
+      handler: async (p, ctx) => {
+        const body: {
+          title: string;
+          description?: string;
+          assignee_ids?: number[];
+          labels?: string;
+          milestone_id?: number;
+          due_date?: string;
+        } = { title: p.title };
+        if (p.description !== undefined) body.description = p.description;
+        if (p.assignee_ids !== undefined) body.assignee_ids = p.assignee_ids;
+        if (p.labels !== undefined) body.labels = p.labels.join(",");
+        if (p.milestone_id !== undefined) body.milestone_id = p.milestone_id;
+        if (p.due_date !== undefined) body.due_date = p.due_date;
+        const r = await ctx.sdk.createIssue(p.namespace, p.project, body);
+        throwIfHttpError(r);
+        return issueEnvelope(r.data);
+      },
+    },
+
+    update_issue: {
+      description:
+        "Update a GitLab issue. Accepts state_event=reopen to reopen. Closing is a separate action.",
+      params: updateIssueParams,
+      classify: { kind: "write" },
+      handler: async (p, ctx) => {
+        const body: {
+          title?: string;
+          description?: string;
+          assignee_ids?: number[];
+          labels?: string;
+          milestone_id?: number;
+          due_date?: string;
+          state_event?: "reopen";
+        } = {};
+        if (p.title !== undefined) body.title = p.title;
+        if (p.description !== undefined) body.description = p.description;
+        if (p.assignee_ids !== undefined) body.assignee_ids = p.assignee_ids;
+        if (p.labels !== undefined) body.labels = p.labels.join(",");
+        if (p.milestone_id !== undefined) body.milestone_id = p.milestone_id;
+        if (p.due_date !== undefined) body.due_date = p.due_date;
+        if (p.state_event !== undefined) body.state_event = p.state_event;
+        const r = await ctx.sdk.updateIssue(p.namespace, p.project, p.iid, body);
+        throwIfHttpError(r);
+        return issueEnvelope(r.data);
+      },
+    },
+
+    close_issue: {
+      description:
+        "Close a GitLab issue (does not delete; REST has no hard-delete).",
+      params: closeIssueParams,
+      classify: { kind: "write", aspects: ["delete"] },
+      handler: async (p, ctx) => {
+        const r = await ctx.sdk.closeIssue(p.namespace, p.project, p.iid);
+        throwIfHttpError(r);
+        return {
+          ...issueEnvelope(r.data),
+          closed: true,
+        };
+      },
+    },
+  };
+}

--- a/src/connectors/gitlab/actions/merges.ts
+++ b/src/connectors/gitlab/actions/merges.ts
@@ -1,0 +1,219 @@
+/**
+ * Merge-request action specs: create / update / close / merge.
+ *
+ * Classification:
+ *   - create_merge_request : write   (require_draft_mr forces draft=true)
+ *   - update_merge_request : write   (schema rejects state_event=close)
+ *   - close_merge_request  : write + delete aspect
+ *   - merge_merge_request  : admin   (operator opt-in via YAML)
+ *
+ * 405/406/409-on-merge: GitLab returns these when the MR is not in a
+ * mergeable state, pipeline gate fails, or the SHA changed. We surface
+ * them as a VALIDATION_ERROR via the CONFLICT code (mapped in Task 9).
+ */
+import { ConnectorError, throwIfHttpError } from "narai-primitives/toolkit";
+import { z } from "zod";
+import type { GitlabActionDeps, GitlabActions } from "./_types.js";
+import type { GitlabMergeRequest } from "../lib/gitlab_client.js";
+import {
+  namespaceField,
+  projectField,
+  mrIidField,
+  refField,
+  shaField,
+} from "./_fields.js";
+
+const createMrParams = z.object({
+  namespace: namespaceField,
+  project: projectField,
+  source_branch: refField,
+  target_branch: refField,
+  title: z.string().min(1),
+  description: z.string().optional(),
+  assignee_ids: z.array(z.number().int().positive()).optional(),
+  reviewer_ids: z.array(z.number().int().positive()).optional(),
+  labels: z.string().optional(),
+  milestone_id: z.number().int().positive().optional(),
+  remove_source_branch: z.boolean().optional(),
+  squash: z.boolean().optional(),
+  draft: z.boolean().default(false),
+});
+
+const updateMrParams = z.object({
+  namespace: namespaceField,
+  project: projectField,
+  mr_iid: mrIidField,
+  title: z.string().min(1).optional(),
+  description: z.string().optional(),
+  target_branch: refField.optional(),
+  assignee_ids: z.array(z.number().int().positive()).optional(),
+  reviewer_ids: z.array(z.number().int().positive()).optional(),
+  labels: z.string().optional(),
+  milestone_id: z.number().int().positive().optional(),
+  state_event: z
+    .enum(["reopen"], {
+      errorMap: () => ({
+        message:
+          "update_merge_request only accepts state_event=reopen. Use close_merge_request to close.",
+      }),
+    })
+    .optional(),
+  remove_source_branch: z.boolean().optional(),
+  squash: z.boolean().optional(),
+});
+
+const closeMrParams = z.object({
+  namespace: namespaceField,
+  project: projectField,
+  mr_iid: mrIidField,
+});
+
+const mergeMrParams = z.object({
+  namespace: namespaceField,
+  project: projectField,
+  mr_iid: mrIidField,
+  merge_commit_message: z.string().optional(),
+  squash_commit_message: z.string().optional(),
+  should_remove_source_branch: z.boolean().optional(),
+  merge_when_pipeline_succeeds: z.boolean().optional(),
+  sha: shaField.optional(),
+  squash: z.boolean().optional(),
+});
+
+function mrEnvelope(d: GitlabMergeRequest) {
+  return {
+    iid: d.iid,
+    title: d.title,
+    state: d.state,
+    draft: d.draft ?? false,
+    author: d.author?.username ?? "",
+    source_branch: d.source_branch ?? "",
+    target_branch: d.target_branch ?? "",
+    sha: d.sha ?? "",
+    description: d.description ?? "",
+    url: d.web_url ?? "",
+    updated_at: d.updated_at ?? null,
+  };
+}
+
+export function buildMergesActions(deps: GitlabActionDeps): GitlabActions {
+  return {
+    create_merge_request: {
+      description:
+        "Open a new merge request. Honors the require_draft_mr config knob.",
+      params: createMrParams,
+      classify: { kind: "write" },
+      handler: async (p, ctx) => {
+        const requestedDraft = p.draft;
+        const draftToUse = deps.behavior.requireDraftMr ? true : requestedDraft;
+        const body: Parameters<typeof ctx.sdk.createMergeRequest>[2] = {
+          source_branch: p.source_branch,
+          target_branch: p.target_branch,
+          title: p.title,
+          draft: draftToUse,
+        };
+        if (p.description !== undefined) body.description = p.description;
+        if (p.assignee_ids !== undefined) body.assignee_ids = p.assignee_ids;
+        if (p.reviewer_ids !== undefined) body.reviewer_ids = p.reviewer_ids;
+        if (p.labels !== undefined) body.labels = p.labels;
+        if (p.milestone_id !== undefined) body.milestone_id = p.milestone_id;
+        if (p.remove_source_branch !== undefined)
+          body.remove_source_branch = p.remove_source_branch;
+        if (p.squash !== undefined) body.squash = p.squash;
+        const r = await ctx.sdk.createMergeRequest(p.namespace, p.project, body);
+        throwIfHttpError(r);
+        const envelope = mrEnvelope(r.data);
+        if (deps.behavior.requireDraftMr && !requestedDraft) {
+          return { ...envelope, draft_forced_by_config: true };
+        }
+        return envelope;
+      },
+    },
+
+    update_merge_request: {
+      description:
+        "Update title, description, target_branch, or set state_event=reopen. Closing is a separate action.",
+      params: updateMrParams,
+      classify: { kind: "write" },
+      handler: async (p, ctx) => {
+        const body: Parameters<typeof ctx.sdk.updateMergeRequest>[3] = {};
+        if (p.title !== undefined) body.title = p.title;
+        if (p.description !== undefined) body.description = p.description;
+        if (p.target_branch !== undefined) body.target_branch = p.target_branch;
+        if (p.assignee_ids !== undefined) body.assignee_ids = p.assignee_ids;
+        if (p.reviewer_ids !== undefined) body.reviewer_ids = p.reviewer_ids;
+        if (p.labels !== undefined) body.labels = p.labels;
+        if (p.milestone_id !== undefined) body.milestone_id = p.milestone_id;
+        if (p.state_event !== undefined) body.state_event = p.state_event;
+        if (p.remove_source_branch !== undefined)
+          body.remove_source_branch = p.remove_source_branch;
+        if (p.squash !== undefined) body.squash = p.squash;
+        const r = await ctx.sdk.updateMergeRequest(
+          p.namespace,
+          p.project,
+          p.mr_iid,
+          body,
+        );
+        throwIfHttpError(r);
+        return mrEnvelope(r.data);
+      },
+    },
+
+    close_merge_request: {
+      description: "Close a merge request.",
+      params: closeMrParams,
+      classify: { kind: "write", aspects: ["delete"] },
+      handler: async (p, ctx) => {
+        const r = await ctx.sdk.closeMergeRequest(
+          p.namespace,
+          p.project,
+          p.mr_iid,
+        );
+        throwIfHttpError(r);
+        return { ...mrEnvelope(r.data), closed: true };
+      },
+    },
+
+    merge_merge_request: {
+      description:
+        "Merge a merge request. Admin-classified — operator must opt in via config.",
+      params: mergeMrParams,
+      classify: { kind: "admin" },
+      handler: async (p, ctx) => {
+        const body: Parameters<typeof ctx.sdk.mergeMergeRequest>[3] = {};
+        if (p.merge_commit_message !== undefined)
+          body.merge_commit_message = p.merge_commit_message;
+        if (p.squash_commit_message !== undefined)
+          body.squash_commit_message = p.squash_commit_message;
+        if (p.should_remove_source_branch !== undefined)
+          body.should_remove_source_branch = p.should_remove_source_branch;
+        if (p.merge_when_pipeline_succeeds !== undefined)
+          body.merge_when_pipeline_succeeds = p.merge_when_pipeline_succeeds;
+        if (p.sha !== undefined) body.sha = p.sha;
+        if (p.squash !== undefined) body.squash = p.squash;
+        const r = await ctx.sdk.mergeMergeRequest(
+          p.namespace,
+          p.project,
+          p.mr_iid,
+          body,
+        );
+        if (!r.ok && (r.status === 405 || r.status === 406 || r.status === 409)) {
+          throw new ConnectorError(
+            "CONFLICT",
+            `merge_merge_request: MR not mergeable (${r.message})`,
+            false,
+          );
+        }
+        throwIfHttpError(r);
+        return {
+          namespace: p.namespace,
+          project: p.project,
+          mr_iid: p.mr_iid,
+          merged: r.data.merged,
+          merge_sha: r.data.sha,
+          message: r.data.message,
+        };
+      },
+    },
+  };
+}

--- a/src/connectors/gitlab/actions/notes.ts
+++ b/src/connectors/gitlab/actions/notes.ts
@@ -46,14 +46,36 @@ const addNoteParams = baseNoteParams
     }
   });
 
-const updateNoteParams = baseNoteParams.extend({
-  note_id: noteIdField,
-  body: z.string().min(1),
-});
+const updateNoteParams = baseNoteParams
+  .extend({
+    note_id: noteIdField,
+    body: z.string().min(1),
+    discussion_id: z.string().optional(),
+  })
+  .superRefine((val, ctx) => {
+    if (val.discussion_id !== undefined && val.noteable_type !== "merge_request") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["discussion_id"],
+        message: "discussion_id is only valid when noteable_type is 'merge_request'",
+      });
+    }
+  });
 
-const deleteNoteParams = baseNoteParams.extend({
-  note_id: noteIdField,
-});
+const deleteNoteParams = baseNoteParams
+  .extend({
+    note_id: noteIdField,
+    discussion_id: z.string().optional(),
+  })
+  .superRefine((val, ctx) => {
+    if (val.discussion_id !== undefined && val.noteable_type !== "merge_request") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["discussion_id"],
+        message: "discussion_id is only valid when noteable_type is 'merge_request'",
+      });
+    }
+  });
 
 // ── Factory ────────────────────────────────────────────────────────────────
 
@@ -92,6 +114,8 @@ export function buildNotesActions(_deps: GitlabActionDeps): GitlabActions {
       params: updateNoteParams,
       classify: { kind: "write" },
       handler: async (p: z.infer<typeof updateNoteParams>, ctx) => {
+        const updateOpts: { discussionId?: string } = {};
+        if (p.discussion_id !== undefined) updateOpts.discussionId = p.discussion_id;
         const r = await ctx.sdk.updateNote(
           p.namespace,
           p.project,
@@ -99,6 +123,7 @@ export function buildNotesActions(_deps: GitlabActionDeps): GitlabActions {
           p.noteable_iid,
           p.note_id,
           { body: p.body },
+          updateOpts,
         );
         throwIfHttpError(r);
         const d = r.data;
@@ -117,12 +142,15 @@ export function buildNotesActions(_deps: GitlabActionDeps): GitlabActions {
       params: deleteNoteParams,
       classify: { kind: "write", aspects: ["delete"] },
       handler: async (p: z.infer<typeof deleteNoteParams>, ctx) => {
+        const deleteOpts: { discussionId?: string } = {};
+        if (p.discussion_id !== undefined) deleteOpts.discussionId = p.discussion_id;
         const r = await ctx.sdk.deleteNote(
           p.namespace,
           p.project,
           p.noteable_type,
           p.noteable_iid,
           p.note_id,
+          deleteOpts,
         );
         throwIfHttpError(r);
         return {

--- a/src/connectors/gitlab/actions/notes.ts
+++ b/src/connectors/gitlab/actions/notes.ts
@@ -1,0 +1,135 @@
+/**
+ * Unified note actions: add_note, update_note, delete_note.
+ * All three accept a noteable_type discriminator ("issue" | "merge_request")
+ * and route to /issues/:iid/notes or /merge_requests/:iid/notes accordingly.
+ *
+ * add_note also accepts an optional position payload for MR diff comments.
+ * Schema enforces: position is only valid when noteable_type === "merge_request".
+ */
+import { throwIfHttpError } from "narai-primitives/toolkit";
+import { z } from "zod";
+import type { GitlabActionDeps, GitlabActions } from "./_types.js";
+import { namespaceField, projectField, noteIdField, shaField, filePathField } from "./_fields.js";
+
+// ── Param schemas ──────────────────────────────────────────────────────────
+
+const baseNoteParams = z.object({
+  namespace: namespaceField,
+  project: projectField,
+  noteable_type: z.enum(["issue", "merge_request"]),
+  noteable_iid: z.coerce.number().int().positive(),
+});
+
+const positionSchema = z.object({
+  base_sha: shaField,
+  start_sha: shaField,
+  head_sha: shaField,
+  position_type: z.literal("text"),
+  new_path: filePathField,
+  old_path: filePathField.optional(),
+  new_line: z.coerce.number().int().positive().optional(),
+  old_line: z.coerce.number().int().positive().optional(),
+});
+
+const addNoteParams = baseNoteParams
+  .extend({
+    body: z.string().min(1),
+    position: positionSchema.optional(),
+  })
+  .superRefine((val, ctx) => {
+    if (val.position !== undefined && val.noteable_type !== "merge_request") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["position"],
+        message: "position is only valid when noteable_type is 'merge_request'",
+      });
+    }
+  });
+
+const updateNoteParams = baseNoteParams.extend({
+  note_id: noteIdField,
+  body: z.string().min(1),
+});
+
+const deleteNoteParams = baseNoteParams.extend({
+  note_id: noteIdField,
+});
+
+// ── Factory ────────────────────────────────────────────────────────────────
+
+export function buildNotesActions(_deps: GitlabActionDeps): GitlabActions {
+  return {
+    add_note: {
+      description: "Add a note (comment) to a GitLab issue or merge request",
+      params: addNoteParams,
+      classify: { kind: "write" },
+      handler: async (p: z.infer<typeof addNoteParams>, ctx) => {
+        const noteBody: { body: string; position?: z.infer<typeof positionSchema> } = {
+          body: p.body,
+        };
+        if (p.position !== undefined) noteBody.position = p.position;
+        const r = await ctx.sdk.addNote(
+          p.namespace,
+          p.project,
+          p.noteable_type,
+          p.noteable_iid,
+          noteBody,
+        );
+        throwIfHttpError(r);
+        const d = r.data;
+        return {
+          id: d.id,
+          body: d.body,
+          author: d.author?.username ?? "",
+          created_at: d.created_at ?? null,
+          updated_at: d.updated_at ?? null,
+        };
+      },
+    },
+
+    update_note: {
+      description: "Update an existing note on a GitLab issue or merge request",
+      params: updateNoteParams,
+      classify: { kind: "write" },
+      handler: async (p: z.infer<typeof updateNoteParams>, ctx) => {
+        const r = await ctx.sdk.updateNote(
+          p.namespace,
+          p.project,
+          p.noteable_type,
+          p.noteable_iid,
+          p.note_id,
+          { body: p.body },
+        );
+        throwIfHttpError(r);
+        const d = r.data;
+        return {
+          id: d.id,
+          body: d.body,
+          author: d.author?.username ?? "",
+          created_at: d.created_at ?? null,
+          updated_at: d.updated_at ?? null,
+        };
+      },
+    },
+
+    delete_note: {
+      description: "Delete a note from a GitLab issue or merge request",
+      params: deleteNoteParams,
+      classify: { kind: "write", aspects: ["delete"] },
+      handler: async (p: z.infer<typeof deleteNoteParams>, ctx) => {
+        const r = await ctx.sdk.deleteNote(
+          p.namespace,
+          p.project,
+          p.noteable_type,
+          p.noteable_iid,
+          p.note_id,
+        );
+        throwIfHttpError(r);
+        return {
+          note_id: p.note_id,
+          deleted: true,
+        };
+      },
+    },
+  };
+}

--- a/src/connectors/gitlab/actions/notes.ts
+++ b/src/connectors/gitlab/actions/notes.ts
@@ -20,16 +20,26 @@ const baseNoteParams = z.object({
   noteable_iid: z.coerce.number().int().positive(),
 });
 
-const positionSchema = z.object({
-  base_sha: shaField,
-  start_sha: shaField,
-  head_sha: shaField,
-  position_type: z.literal("text"),
-  new_path: filePathField,
-  old_path: filePathField.optional(),
-  new_line: z.coerce.number().int().positive().optional(),
-  old_line: z.coerce.number().int().positive().optional(),
-});
+const positionSchema = z
+  .object({
+    base_sha: shaField,
+    start_sha: shaField,
+    head_sha: shaField,
+    position_type: z.literal("text"),
+    new_path: filePathField,
+    old_path: filePathField,
+    new_line: z.coerce.number().int().positive().optional(),
+    old_line: z.coerce.number().int().positive().optional(),
+  })
+  .superRefine((val, ctx) => {
+    if (val.new_line === undefined && val.old_line === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["new_line"],
+        message: "at least one of old_line or new_line must be set",
+      });
+    }
+  });
 
 const addNoteParams = baseNoteParams
   .extend({

--- a/src/connectors/gitlab/actions/pipelines.ts
+++ b/src/connectors/gitlab/actions/pipelines.ts
@@ -1,0 +1,155 @@
+/**
+ * Pipeline write actions: retry, cancel, trigger, and play_job.
+ * Read actions (list_pipelines, get_pipeline, list_pipeline_jobs, get_job_logs)
+ * live in reads.ts.
+ *
+ * Note: retry_failed_jobs is an alias for retry_pipeline. GitLab's retry
+ * endpoint already only re-runs failed/canceled jobs — there is no separate
+ * endpoint for "retry only failed jobs".
+ */
+import { throwIfHttpError } from "narai-primitives/toolkit";
+import { z } from "zod";
+import type { GitlabActionDeps, GitlabActions } from "./_types.js";
+import {
+  namespaceField,
+  projectField,
+  pipelineIdField,
+  jobIdField,
+  refField,
+} from "./_fields.js";
+
+const projectParams = z.object({
+  namespace: namespaceField,
+  project: projectField,
+});
+
+const pipelineActionParams = projectParams.extend({
+  pipeline_id: pipelineIdField,
+});
+
+const triggerPipelineParams = projectParams.extend({
+  token: z.string().min(1, "trigger_pipeline requires a non-empty 'token'"),
+  ref: refField,
+  variables: z.record(z.string()).optional(),
+});
+
+const playJobParams = projectParams.extend({
+  job_id: jobIdField,
+  variables: z.record(z.string()).optional(),
+});
+
+export function buildPipelinesActions(_deps: GitlabActionDeps): GitlabActions {
+  return {
+    retry_pipeline: {
+      description:
+        "Retry a GitLab pipeline — re-runs all failed and canceled jobs. Returns the updated pipeline.",
+      params: pipelineActionParams,
+      classify: { kind: "write" },
+      handler: async (p, ctx) => {
+        const r = await ctx.sdk.retryPipeline(p.namespace, p.project, p.pipeline_id);
+        throwIfHttpError(r);
+        const d = r.data;
+        return {
+          id: d.id,
+          status: d.status,
+          ref: d.ref,
+          sha: d.sha ?? "",
+          web_url: d.web_url ?? "",
+          created_at: d.created_at ?? null,
+          updated_at: d.updated_at ?? null,
+        };
+      },
+    },
+
+    retry_failed_jobs: {
+      description:
+        "Retry only failed/canceled jobs in a GitLab pipeline. This is an alias for retry_pipeline — GitLab's POST /pipelines/:id/retry endpoint already only re-runs failed and canceled jobs. Returns the updated pipeline.",
+      params: pipelineActionParams,
+      classify: { kind: "write" },
+      handler: async (p, ctx) => {
+        const r = await ctx.sdk.retryPipeline(p.namespace, p.project, p.pipeline_id);
+        throwIfHttpError(r);
+        const d = r.data;
+        return {
+          id: d.id,
+          status: d.status,
+          ref: d.ref,
+          sha: d.sha ?? "",
+          web_url: d.web_url ?? "",
+          created_at: d.created_at ?? null,
+          updated_at: d.updated_at ?? null,
+        };
+      },
+    },
+
+    cancel_pipeline: {
+      description:
+        "Cancel a running GitLab pipeline. Returns the canceled pipeline.",
+      params: pipelineActionParams,
+      classify: { kind: "write" },
+      handler: async (p, ctx) => {
+        const r = await ctx.sdk.cancelPipeline(p.namespace, p.project, p.pipeline_id);
+        throwIfHttpError(r);
+        const d = r.data;
+        return {
+          id: d.id,
+          status: d.status,
+          ref: d.ref,
+          sha: d.sha ?? "",
+          web_url: d.web_url ?? "",
+          created_at: d.created_at ?? null,
+          updated_at: d.updated_at ?? null,
+        };
+      },
+    },
+
+    trigger_pipeline: {
+      description:
+        "Trigger a new GitLab pipeline using a trigger token (not a PAT). Requires 'token' (a pipeline trigger token) and 'ref' (branch/tag). Optional 'variables' map is passed as pipeline variables. Returns the newly created pipeline.",
+      params: triggerPipelineParams,
+      classify: { kind: "write" },
+      handler: async (p, ctx) => {
+        const body: { token: string; ref: string; variables?: Record<string, string> } = {
+          token: p.token,
+          ref: p.ref,
+        };
+        if (p.variables !== undefined) body.variables = p.variables;
+        const r = await ctx.sdk.triggerPipeline(p.namespace, p.project, body);
+        throwIfHttpError(r);
+        const d = r.data;
+        return {
+          id: d.id,
+          status: d.status,
+          ref: d.ref,
+          sha: d.sha ?? "",
+          web_url: d.web_url ?? "",
+          created_at: d.created_at ?? null,
+          updated_at: d.updated_at ?? null,
+        };
+      },
+    },
+
+    play_job: {
+      description:
+        "Play (start) a manual GitLab CI job. Used for jobs in a manual stage that need explicit triggering. Optional 'variables' overrides inline job variables. Returns the started job.",
+      params: playJobParams,
+      classify: { kind: "write" },
+      handler: async (p, ctx) => {
+        const r = await ctx.sdk.playJob(p.namespace, p.project, p.job_id, p.variables);
+        throwIfHttpError(r);
+        const d = r.data;
+        return {
+          id: d.id,
+          name: d.name,
+          stage: d.stage ?? "",
+          status: d.status,
+          web_url: d.web_url ?? "",
+          created_at: d.created_at ?? null,
+          started_at: d.started_at ?? null,
+          finished_at: d.finished_at ?? null,
+          duration: d.duration ?? null,
+        };
+      },
+    },
+  };
+}

--- a/src/connectors/gitlab/actions/reads.ts
+++ b/src/connectors/gitlab/actions/reads.ts
@@ -87,6 +87,7 @@ const getPipelineParams = projectParams.extend({
 
 const listPipelineJobsParams = projectParams.extend({
   pipeline_id: pipelineIdField,
+  max_results: z.coerce.number().int().positive().default(MAX_RESULTS_DEFAULT),
 });
 
 const getJobLogsParams = projectParams.extend({
@@ -396,17 +397,18 @@ export function buildReadActions(_deps: GitlabActionDeps): GitlabActions {
       params: listPipelineJobsParams,
       classify: { kind: "read" },
       handler: async (p: z.infer<typeof listPipelineJobsParams>, ctx) => {
-        const result = await ctx.sdk.listPipelineJobs(
-          p.namespace,
-          p.project,
-          p.pipeline_id,
+        const limit = Math.min(p.max_results, MAX_RESULTS_CAP);
+        const page = await paginateGitlab(limit, (pageNum, perPage) =>
+          ctx.sdk.listPipelineJobs(p.namespace, p.project, p.pipeline_id, {
+            page: pageNum,
+            perPage,
+          }),
         );
-        throwIfHttpError(result);
-        const jobs = result.data ?? [];
         return {
           pipeline_id: p.pipeline_id,
-          total: jobs.length,
-          jobs: jobs.map((j) => ({
+          total: page.items.length,
+          truncated: page.truncated,
+          jobs: page.items.map((j) => ({
             id: j.id,
             name: j.name,
             stage: j.stage ?? "",

--- a/src/connectors/gitlab/actions/reads.ts
+++ b/src/connectors/gitlab/actions/reads.ts
@@ -124,18 +124,18 @@ export function buildReadActions(_deps: GitlabActionDeps): GitlabActions {
       classify: { kind: "read" },
       handler: async (p: z.infer<typeof searchCodeParams>, ctx) => {
         const limit = Math.min(p.max_results, MAX_RESULTS_CAP);
-        const result = await ctx.sdk.searchCode(p.namespace, p.project, p.query);
-        throwIfHttpError(result);
-        const items = (result.data ?? []).slice(0, limit);
+        const page = await paginateGitlab(limit, (pageNum, perPage) =>
+          ctx.sdk.searchCode(p.namespace, p.project, p.query, { page: pageNum, perPage }),
+        );
         return {
-          total: items.length,
-          items: items.map((it) => ({
+          total: page.items.length,
+          items: page.items.map((it) => ({
             path: it.path,
             filename: it.filename,
             ref: it.ref,
             startline: it.startline,
           })),
-          truncated: result.data.length > limit,
+          truncated: page.truncated,
         };
       },
     },

--- a/src/connectors/gitlab/actions/reads.ts
+++ b/src/connectors/gitlab/actions/reads.ts
@@ -63,6 +63,7 @@ const getFileParams = projectParams.extend({
 const getNotesParams = projectParams.extend({
   noteable_type: z.enum(["issue", "merge_request"]),
   noteable_iid: z.coerce.number().int().positive(),
+  max_results: z.coerce.number().int().positive().default(MAX_RESULTS_DEFAULT),
 });
 
 const listReleaseLinksParams = projectParams.extend({
@@ -269,19 +270,19 @@ export function buildReadActions(_deps: GitlabActionDeps): GitlabActions {
       params: getNotesParams,
       classify: { kind: "read" },
       handler: async (p: z.infer<typeof getNotesParams>, ctx) => {
-        const result = await ctx.sdk.getNotes(
-          p.namespace,
-          p.project,
-          p.noteable_type,
-          p.noteable_iid,
+        const limit = Math.min(p.max_results, MAX_RESULTS_CAP);
+        const page = await paginateGitlab(limit, (pageNum, perPage) =>
+          ctx.sdk.getNotes(p.namespace, p.project, p.noteable_type, p.noteable_iid, {
+            page: pageNum,
+            perPage,
+          }),
         );
-        throwIfHttpError(result);
-        const notes = result.data ?? [];
         return {
           noteable_type: p.noteable_type,
           noteable_iid: p.noteable_iid,
-          total: notes.length,
-          notes: notes.map((n) => ({
+          total: page.items.length,
+          truncated: page.truncated,
+          notes: page.items.map((n) => ({
             id: n.id,
             body: n.body,
             author: n.author?.username ?? "",

--- a/src/connectors/gitlab/actions/reads.ts
+++ b/src/connectors/gitlab/actions/reads.ts
@@ -327,12 +327,17 @@ export function buildReadActions(_deps: GitlabActionDeps): GitlabActions {
             });
           }
         }
+        // Apply secondary cap: one discussion can contain many notes, so the
+        // flattened count may exceed the requested limit even when the discussion
+        // paginator did not report truncation.
+        const notesTruncated = flatNotes.length > limit;
+        const cappedNotes = flatNotes.slice(0, limit);
         return {
           noteable_type: p.noteable_type,
           noteable_iid: p.noteable_iid,
-          total: flatNotes.length,
-          truncated: page.truncated,
-          notes: flatNotes,
+          total: cappedNotes.length,
+          truncated: page.truncated || notesTruncated,
+          notes: cappedNotes,
         };
       },
     },

--- a/src/connectors/gitlab/actions/reads.ts
+++ b/src/connectors/gitlab/actions/reads.ts
@@ -272,25 +272,67 @@ export function buildReadActions(_deps: GitlabActionDeps): GitlabActions {
       classify: { kind: "read" },
       handler: async (p: z.infer<typeof getNotesParams>, ctx) => {
         const limit = Math.min(p.max_results, MAX_RESULTS_CAP);
+
+        if (p.noteable_type === "issue") {
+          const page = await paginateGitlab(limit, (pageNum, perPage) =>
+            ctx.sdk.getNotes(p.namespace, p.project, p.noteable_type, p.noteable_iid, {
+              page: pageNum,
+              perPage,
+            }),
+          );
+          return {
+            noteable_type: p.noteable_type,
+            noteable_iid: p.noteable_iid,
+            total: page.items.length,
+            truncated: page.truncated,
+            notes: page.items.map((n) => ({
+              id: n.id,
+              body: n.body,
+              author: n.author?.username ?? "",
+              created_at: n.created_at ?? null,
+              updated_at: n.updated_at ?? null,
+              system: n.system ?? false,
+              discussion_id: null,
+            })),
+          };
+        }
+
+        // For merge_requests: fetch discussions and flatten notes so that
+        // DiscussionNote/DiffNote entries (not returned by /notes) are included.
         const page = await paginateGitlab(limit, (pageNum, perPage) =>
-          ctx.sdk.getNotes(p.namespace, p.project, p.noteable_type, p.noteable_iid, {
+          ctx.sdk.getDiscussions(p.namespace, p.project, p.noteable_iid, {
             page: pageNum,
             perPage,
           }),
         );
+        const flatNotes: {
+          id: number;
+          body: string;
+          author: string;
+          created_at: string | null;
+          updated_at: string | null;
+          system: boolean;
+          discussion_id: string;
+        }[] = [];
+        for (const discussion of page.items) {
+          for (const n of discussion.notes) {
+            flatNotes.push({
+              id: n.id,
+              body: n.body,
+              author: n.author?.username ?? "",
+              created_at: n.created_at ?? null,
+              updated_at: n.updated_at ?? null,
+              system: n.system ?? false,
+              discussion_id: discussion.id,
+            });
+          }
+        }
         return {
           noteable_type: p.noteable_type,
           noteable_iid: p.noteable_iid,
-          total: page.items.length,
+          total: flatNotes.length,
           truncated: page.truncated,
-          notes: page.items.map((n) => ({
-            id: n.id,
-            body: n.body,
-            author: n.author?.username ?? "",
-            created_at: n.created_at ?? null,
-            updated_at: n.updated_at ?? null,
-            system: n.system ?? false,
-          })),
+          notes: flatNotes,
         };
       },
     },

--- a/src/connectors/gitlab/actions/reads.ts
+++ b/src/connectors/gitlab/actions/reads.ts
@@ -1,0 +1,439 @@
+/**
+ * Read-only actions on the GitLab connector. All 14 actions have
+ * classify `{ kind: "read" }`.
+ *
+ * Pagination: listing endpoints use paginateGitlab, which walks
+ * page=1,2,3... until max_results is reached or a short page terminates.
+ * HTTP errors propagate as ConnectorError via `throwIfHttpError`.
+ */
+import { throwIfHttpError } from "narai-primitives/toolkit";
+import { z } from "zod";
+import type { GitlabActionDeps, GitlabActions } from "./_types.js";
+import {
+  namespaceField,
+  projectField,
+  issueIidField,
+  mrIidField,
+  pipelineIdField,
+  jobIdField,
+  linkIdField,
+  releaseTagField,
+  refField,
+  filePathField,
+} from "./_fields.js";
+import { paginateGitlab, MAX_RESULTS_DEFAULT, MAX_RESULTS_CAP } from "./_pagination.js";
+
+// ── Param schemas ──────────────────────────────────────────────────────────
+
+const projectParams = z.object({
+  namespace: namespaceField,
+  project: projectField,
+});
+
+const searchCodeParams = projectParams.extend({
+  query: z.string().min(1, "search_code requires a non-empty 'query' string"),
+  max_results: z.coerce.number().int().positive().default(MAX_RESULTS_DEFAULT),
+});
+
+const VALID_STATES = z.enum(["opened", "closed", "all"]);
+
+const listIssuesParams = projectParams.extend({
+  state: VALID_STATES.default("opened"),
+  max_results: z.coerce.number().int().positive().default(MAX_RESULTS_DEFAULT),
+});
+
+const getIssueParams = projectParams.extend({
+  iid: issueIidField,
+});
+
+const listMrsParams = projectParams.extend({
+  state: VALID_STATES.default("opened"),
+  max_results: z.coerce.number().int().positive().default(MAX_RESULTS_DEFAULT),
+});
+
+const getMrParams = projectParams.extend({
+  iid: mrIidField,
+});
+
+const getFileParams = projectParams.extend({
+  path: filePathField,
+  ref: refField.default("main"),
+});
+
+const getNotesParams = projectParams.extend({
+  noteable_type: z.enum(["issue", "merge_request"]),
+  noteable_iid: z.coerce.number().int().positive(),
+});
+
+const listReleaseLinksParams = projectParams.extend({
+  tag: releaseTagField,
+});
+
+const getReleaseLinkParams = projectParams.extend({
+  tag: releaseTagField,
+  link_id: linkIdField,
+});
+
+const listPipelinesParams = projectParams.extend({
+  ref: refField.optional(),
+  status: z.string().optional(),
+  max_results: z.coerce.number().int().positive().default(MAX_RESULTS_DEFAULT),
+});
+
+const getPipelineParams = projectParams.extend({
+  pipeline_id: pipelineIdField,
+});
+
+const listPipelineJobsParams = projectParams.extend({
+  pipeline_id: pipelineIdField,
+});
+
+const getJobLogsParams = projectParams.extend({
+  job_id: jobIdField,
+});
+
+// ── Factory ────────────────────────────────────────────────────────────────
+
+export function buildReadActions(_deps: GitlabActionDeps): GitlabActions {
+  return {
+    project_info: {
+      description: "Fetch GitLab project metadata",
+      params: projectParams,
+      classify: { kind: "read" },
+      handler: async (p: z.infer<typeof projectParams>, ctx) => {
+        const result = await ctx.sdk.getProject(p.namespace, p.project);
+        throwIfHttpError(result);
+        const d = result.data;
+        return {
+          id: d.id,
+          name: d.name,
+          path_with_namespace: d.path_with_namespace,
+          default_branch: d.default_branch ?? "main",
+          description: d.description ?? "",
+          visibility: d.visibility ?? null,
+          web_url: d.web_url ?? "",
+          ssh_url_to_repo: d.ssh_url_to_repo ?? "",
+          http_url_to_repo: d.http_url_to_repo ?? "",
+        };
+      },
+    },
+
+    search_code: {
+      description: "Search code in a GitLab project (scope=blobs)",
+      params: searchCodeParams,
+      classify: { kind: "read" },
+      handler: async (p: z.infer<typeof searchCodeParams>, ctx) => {
+        const limit = Math.min(p.max_results, MAX_RESULTS_CAP);
+        const result = await ctx.sdk.searchCode(p.namespace, p.project, p.query);
+        throwIfHttpError(result);
+        const items = (result.data ?? []).slice(0, limit);
+        return {
+          total: items.length,
+          items: items.map((it) => ({
+            path: it.path,
+            filename: it.filename,
+            ref: it.ref,
+            startline: it.startline,
+          })),
+          truncated: result.data.length > limit,
+        };
+      },
+    },
+
+    get_issues: {
+      description: "List issues in a GitLab project, paginated up to max_results",
+      params: listIssuesParams,
+      classify: { kind: "read" },
+      handler: async (p: z.infer<typeof listIssuesParams>, ctx) => {
+        const limit = Math.min(p.max_results, MAX_RESULTS_CAP);
+        const page = await paginateGitlab(limit, (pageNum, perPage) =>
+          ctx.sdk.listIssues(p.namespace, p.project, {
+            state: p.state,
+            per_page: perPage,
+            page: pageNum,
+          }),
+        );
+        return {
+          total: page.items.length,
+          issues: page.items.map((i) => ({
+            iid: i.iid,
+            title: i.title,
+            state: i.state,
+            author: i.author?.username ?? "",
+            labels: i.labels ?? [],
+            web_url: i.web_url ?? "",
+            updated_at: i.updated_at ?? null,
+          })),
+          truncated: page.truncated,
+        };
+      },
+    },
+
+    get_issue: {
+      description: "Fetch a single GitLab issue by IID",
+      params: getIssueParams,
+      classify: { kind: "read" },
+      handler: async (p: z.infer<typeof getIssueParams>, ctx) => {
+        const result = await ctx.sdk.getIssue(p.namespace, p.project, p.iid);
+        throwIfHttpError(result);
+        const d = result.data;
+        return {
+          iid: d.iid,
+          title: d.title,
+          state: d.state,
+          author: d.author?.username ?? "",
+          description: d.description ?? "",
+          labels: d.labels ?? [],
+          web_url: d.web_url ?? "",
+          updated_at: d.updated_at ?? null,
+        };
+      },
+    },
+
+    get_merge_requests: {
+      description: "List merge requests in a GitLab project, paginated up to max_results",
+      params: listMrsParams,
+      classify: { kind: "read" },
+      handler: async (p: z.infer<typeof listMrsParams>, ctx) => {
+        const limit = Math.min(p.max_results, MAX_RESULTS_CAP);
+        const page = await paginateGitlab(limit, (pageNum, perPage) =>
+          ctx.sdk.listMergeRequests(p.namespace, p.project, {
+            state: p.state,
+            per_page: perPage,
+            page: pageNum,
+          }),
+        );
+        return {
+          total: page.items.length,
+          merge_requests: page.items.map((mr) => ({
+            iid: mr.iid,
+            title: mr.title,
+            state: mr.state,
+            author: mr.author?.username ?? "",
+            web_url: mr.web_url ?? "",
+            updated_at: mr.updated_at ?? null,
+          })),
+          truncated: page.truncated,
+        };
+      },
+    },
+
+    get_merge_request: {
+      description: "Fetch a single GitLab merge request by IID",
+      params: getMrParams,
+      classify: { kind: "read" },
+      handler: async (p: z.infer<typeof getMrParams>, ctx) => {
+        const result = await ctx.sdk.getMergeRequest(p.namespace, p.project, p.iid);
+        throwIfHttpError(result);
+        const d = result.data;
+        return {
+          iid: d.iid,
+          title: d.title,
+          state: d.state,
+          author: d.author?.username ?? "",
+          description: d.description ?? "",
+          source_branch: d.source_branch ?? "",
+          target_branch: d.target_branch ?? "",
+          sha: d.sha ?? "",
+          draft: d.draft ?? false,
+          web_url: d.web_url ?? "",
+          updated_at: d.updated_at ?? null,
+        };
+      },
+    },
+
+    get_file: {
+      description: "Fetch a file's contents at a given ref from a GitLab project",
+      params: getFileParams,
+      classify: { kind: "read" },
+      handler: async (p: z.infer<typeof getFileParams>, ctx) => {
+        const result = await ctx.sdk.getFile(p.namespace, p.project, p.path, p.ref);
+        throwIfHttpError(result);
+        const d = result.data;
+        let decoded = "";
+        if (d.encoding === "base64" && d.content) {
+          decoded = Buffer.from(d.content, "base64").toString("utf-8");
+        }
+        return {
+          path: d.file_path,
+          ref: d.ref,
+          size_bytes: d.size ?? 0,
+          content: decoded,
+          encoding: "utf-8",
+        };
+      },
+    },
+
+    get_notes: {
+      description: "List notes (comments) on a GitLab issue or merge request",
+      params: getNotesParams,
+      classify: { kind: "read" },
+      handler: async (p: z.infer<typeof getNotesParams>, ctx) => {
+        const result = await ctx.sdk.getNotes(
+          p.namespace,
+          p.project,
+          p.noteable_type,
+          p.noteable_iid,
+        );
+        throwIfHttpError(result);
+        const notes = result.data ?? [];
+        return {
+          noteable_type: p.noteable_type,
+          noteable_iid: p.noteable_iid,
+          total: notes.length,
+          notes: notes.map((n) => ({
+            id: n.id,
+            body: n.body,
+            author: n.author?.username ?? "",
+            created_at: n.created_at ?? null,
+            updated_at: n.updated_at ?? null,
+            system: n.system ?? false,
+          })),
+        };
+      },
+    },
+
+    list_release_links: {
+      description: "List asset links for a GitLab release by tag",
+      params: listReleaseLinksParams,
+      classify: { kind: "read" },
+      handler: async (p: z.infer<typeof listReleaseLinksParams>, ctx) => {
+        const result = await ctx.sdk.listReleaseLinks(p.namespace, p.project, p.tag);
+        throwIfHttpError(result);
+        const links = result.data ?? [];
+        return {
+          tag: p.tag,
+          total: links.length,
+          links: links.map((l) => ({
+            id: l.id,
+            name: l.name,
+            url: l.url,
+            link_type: l.link_type ?? null,
+          })),
+        };
+      },
+    },
+
+    get_release_link: {
+      description: "Fetch a single GitLab release asset link by ID",
+      params: getReleaseLinkParams,
+      classify: { kind: "read" },
+      handler: async (p: z.infer<typeof getReleaseLinkParams>, ctx) => {
+        const result = await ctx.sdk.getReleaseLink(
+          p.namespace,
+          p.project,
+          p.tag,
+          p.link_id,
+        );
+        throwIfHttpError(result);
+        const d = result.data;
+        return {
+          id: d.id,
+          name: d.name,
+          url: d.url,
+          link_type: d.link_type ?? null,
+          tag: p.tag,
+        };
+      },
+    },
+
+    list_pipelines: {
+      description: "List pipelines in a GitLab project, paginated up to max_results",
+      params: listPipelinesParams,
+      classify: { kind: "read" },
+      handler: async (p: z.infer<typeof listPipelinesParams>, ctx) => {
+        const limit = Math.min(p.max_results, MAX_RESULTS_CAP);
+        const page = await paginateGitlab(limit, (pageNum, perPage) => {
+          const q: Parameters<typeof ctx.sdk.listPipelines>[2] = {
+            per_page: perPage,
+            page: pageNum,
+          };
+          if (p.ref !== undefined) q.ref = p.ref;
+          if (p.status !== undefined) q.status = p.status;
+          return ctx.sdk.listPipelines(p.namespace, p.project, q);
+        });
+        return {
+          total: page.items.length,
+          pipelines: page.items.map((pl) => ({
+            id: pl.id,
+            status: pl.status,
+            ref: pl.ref,
+            sha: pl.sha ?? "",
+            web_url: pl.web_url ?? "",
+            created_at: pl.created_at ?? null,
+            updated_at: pl.updated_at ?? null,
+          })),
+          truncated: page.truncated,
+        };
+      },
+    },
+
+    get_pipeline: {
+      description: "Fetch a single GitLab pipeline by ID",
+      params: getPipelineParams,
+      classify: { kind: "read" },
+      handler: async (p: z.infer<typeof getPipelineParams>, ctx) => {
+        const result = await ctx.sdk.getPipeline(p.namespace, p.project, p.pipeline_id);
+        throwIfHttpError(result);
+        const d = result.data;
+        return {
+          id: d.id,
+          status: d.status,
+          ref: d.ref,
+          sha: d.sha ?? "",
+          web_url: d.web_url ?? "",
+          created_at: d.created_at ?? null,
+          updated_at: d.updated_at ?? null,
+          duration: d.duration ?? null,
+          finished_at: d.finished_at ?? null,
+        };
+      },
+    },
+
+    list_pipeline_jobs: {
+      description: "List jobs for a GitLab pipeline",
+      params: listPipelineJobsParams,
+      classify: { kind: "read" },
+      handler: async (p: z.infer<typeof listPipelineJobsParams>, ctx) => {
+        const result = await ctx.sdk.listPipelineJobs(
+          p.namespace,
+          p.project,
+          p.pipeline_id,
+        );
+        throwIfHttpError(result);
+        const jobs = result.data ?? [];
+        return {
+          pipeline_id: p.pipeline_id,
+          total: jobs.length,
+          jobs: jobs.map((j) => ({
+            id: j.id,
+            name: j.name,
+            stage: j.stage ?? "",
+            status: j.status,
+            created_at: j.created_at ?? null,
+            started_at: j.started_at ?? null,
+            finished_at: j.finished_at ?? null,
+            duration: j.duration ?? null,
+            web_url: j.web_url ?? "",
+          })),
+        };
+      },
+    },
+
+    get_job_logs: {
+      description: "Fetch the trace log for a GitLab CI job",
+      params: getJobLogsParams,
+      classify: { kind: "read" },
+      handler: async (p: z.infer<typeof getJobLogsParams>, ctx) => {
+        const result = await ctx.sdk.getJobLogs(p.namespace, p.project, p.job_id);
+        throwIfHttpError(result);
+        const logs = typeof result.data === "string" ? result.data : "";
+        return {
+          job_id: p.job_id,
+          logs,
+          content_length: logs.length,
+        };
+      },
+    },
+  };
+}

--- a/src/connectors/gitlab/actions/releases.ts
+++ b/src/connectors/gitlab/actions/releases.ts
@@ -1,0 +1,118 @@
+/**
+ * Release write actions: create / update / delete + delete_release_link.
+ * Read actions (list_release_links, get_release_link) live in reads.ts.
+ * Asset binary upload is out of scope — GitLab releases use links, not
+ * multipart-uploaded assets.
+ */
+import { throwIfHttpError } from "narai-primitives/toolkit";
+import { z } from "zod";
+import type { GitlabActionDeps, GitlabActions } from "./_types.js";
+import { namespaceField, projectField, releaseTagField, linkIdField } from "./_fields.js";
+
+const projectParams = z.object({
+  namespace: namespaceField,
+  project: projectField,
+});
+
+const assetLinkSchema = z.object({
+  name: z.string().min(1),
+  url: z.string().url(),
+  link_type: z.enum(["other", "runbook", "image", "package"]).optional(),
+});
+
+const createReleaseParams = projectParams.extend({
+  tag_name: releaseTagField,
+  name: z.string().min(1),
+  description: z.string().optional(),
+  ref: z.string().min(1).optional(),
+  assets: z
+    .object({ links: z.array(assetLinkSchema) })
+    .optional(),
+});
+
+const updateReleaseParams = projectParams.extend({
+  tag_name: releaseTagField,
+  name: z.string().min(1).optional(),
+  description: z.string().optional(),
+  milestones: z.array(z.string()).optional(),
+});
+
+const deleteReleaseParams = projectParams.extend({
+  tag_name: releaseTagField,
+});
+
+const deleteReleaseLinkParams = projectParams.extend({
+  tag_name: releaseTagField,
+  link_id: linkIdField,
+});
+
+export function buildReleasesActions(_deps: GitlabActionDeps): GitlabActions {
+  return {
+    create_release: {
+      description: "Create a GitLab release for an existing or new tag",
+      params: createReleaseParams,
+      classify: { kind: "write" },
+      handler: async (p, ctx) => {
+        const body: {
+          tag_name: string;
+          name: string;
+          description?: string;
+          ref?: string;
+          assets?: { links: { name: string; url: string; link_type?: string }[] };
+        } = { tag_name: p.tag_name, name: p.name };
+        if (p.description !== undefined) body.description = p.description;
+        if (p.ref !== undefined) body.ref = p.ref;
+        if (p.assets !== undefined) body.assets = p.assets;
+        const r = await ctx.sdk.createRelease(p.namespace, p.project, body);
+        throwIfHttpError(r);
+        return r.data;
+      },
+    },
+
+    update_release: {
+      description: "Update a GitLab release's name, description, or milestones",
+      params: updateReleaseParams,
+      classify: { kind: "write" },
+      handler: async (p, ctx) => {
+        const body: {
+          name?: string;
+          description?: string;
+          milestones?: string[];
+        } = {};
+        if (p.name !== undefined) body.name = p.name;
+        if (p.description !== undefined) body.description = p.description;
+        if (p.milestones !== undefined) body.milestones = p.milestones;
+        const r = await ctx.sdk.updateRelease(p.namespace, p.project, p.tag_name, body);
+        throwIfHttpError(r);
+        return r.data;
+      },
+    },
+
+    delete_release: {
+      description: "Delete a GitLab release (does not delete the underlying git tag)",
+      params: deleteReleaseParams,
+      classify: { kind: "write", aspects: ["delete"] },
+      handler: async (p, ctx) => {
+        const r = await ctx.sdk.deleteRelease(p.namespace, p.project, p.tag_name);
+        throwIfHttpError(r);
+        return { tag_name: p.tag_name, deleted: true };
+      },
+    },
+
+    delete_release_link: {
+      description: "Delete an asset link from a GitLab release",
+      params: deleteReleaseLinkParams,
+      classify: { kind: "write", aspects: ["delete"] },
+      handler: async (p, ctx) => {
+        const r = await ctx.sdk.deleteReleaseLink(
+          p.namespace,
+          p.project,
+          p.tag_name,
+          p.link_id,
+        );
+        throwIfHttpError(r);
+        return { link_id: p.link_id, deleted: true };
+      },
+    },
+  };
+}

--- a/src/connectors/gitlab/cli.ts
+++ b/src/connectors/gitlab/cli.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+/**
+ * Thin bin entry. Library code lives in index.ts.
+ *
+ * Reads `~/.connectors/config.yaml` (or `NARAI_CONFIG_BLOB`, when injected
+ * by `@narai/connector-hub`) before `main()` runs and applies any configured
+ * GitLab token / default namespace to `process.env`. Existing exports win —
+ * the bootstrap only fills in undefined entries.
+ */
+import { loadConnectorEnvironment } from "narai-primitives/config";
+import connector from "./index.js";
+
+const GITLAB_ENV_MAPPING: Record<string, string> = {
+  token: "GITLAB_TOKEN",
+  host: "GITLAB_HOST",
+  namespace: "GITLAB_NAMESPACE",
+};
+
+async function run(): Promise<number> {
+  await loadConnectorEnvironment("gitlab", { envMapping: GITLAB_ENV_MAPPING });
+  return connector.main(process.argv.slice(2));
+}
+
+void run().then((code) => {
+  process.exit(code);
+});

--- a/src/connectors/gitlab/index.ts
+++ b/src/connectors/gitlab/index.ts
@@ -64,6 +64,8 @@ export function buildGitlabConnector(overrides: BuildOptions = {}): Connector {
     return (creds as unknown as Record<string, unknown> | null) ?? {};
   };
 
+  const behavior = loadGitlabBehavior();
+
   // default SDK constructor reads credentials & wraps in GitlabClient
   const defaultSdk = async () => {
     const creds = await loadGitlabCredentials();
@@ -76,12 +78,10 @@ export function buildGitlabConnector(overrides: BuildOptions = {}): Connector {
     }
     return new GitlabClient({
       token: creds.token,
-      host: creds.host,
+      host: behavior.host,
       ...(creds.defaultNamespace ? { defaultNamespace: creds.defaultNamespace } : {}),
     });
   };
-
-  const behavior = loadGitlabBehavior();
 
   return createConnector<GitlabClient>({
     name: "gitlab",

--- a/src/connectors/gitlab/index.ts
+++ b/src/connectors/gitlab/index.ts
@@ -4,7 +4,7 @@
  * Exposes 14 read, 18 write, and 1 admin action across projects,
  * issues, merge requests, notes, releases, and CI pipelines. Writes
  * escalate by default and admin is denied until the operator opts in
- * via ~/.gitlab-connector/config.yaml; see SKILL.md for the full surface.
+ * via ~/.gitlab-agent/config.yaml; see SKILL.md for the full surface.
  *
  * Built on @narai/connector-toolkit. Self-hosted GitLab is supported
  * via GITLAB_HOST env var or YAML config.

--- a/src/connectors/gitlab/index.ts
+++ b/src/connectors/gitlab/index.ts
@@ -1,0 +1,123 @@
+/**
+ * @narai/gitlab-connector — GitLab REST connector.
+ *
+ * Exposes 14 read, 18 write, and 1 admin action across projects,
+ * issues, merge requests, notes, releases, and CI pipelines. Writes
+ * escalate by default and admin is denied until the operator opts in
+ * via ~/.gitlab-connector/config.yaml; see SKILL.md for the full surface.
+ *
+ * Built on @narai/connector-toolkit. Self-hosted GitLab is supported
+ * via GITLAB_HOST env var or YAML config.
+ */
+import {
+  ConnectorError,
+  createConnector,
+  mapHttpError,
+  type Connector,
+  type ErrorCode,
+} from "narai-primitives/toolkit";
+import { GitlabClient, loadGitlabCredentials } from "./lib/gitlab_client.js";
+import { loadGitlabBehavior } from "./lib/gitlab_config.js";
+import { buildReadActions } from "./actions/reads.js";
+import { buildMergesActions } from "./actions/merges.js";
+import { buildIssuesActions } from "./actions/issues.js";
+import { buildNotesActions } from "./actions/notes.js";
+import { buildReleasesActions } from "./actions/releases.js";
+import { buildPipelinesActions } from "./actions/pipelines.js";
+
+const CODE_MAP: Record<string, ErrorCode> = {
+  UNAUTHORIZED: "AUTH_ERROR",
+  FORBIDDEN: "AUTH_ERROR",
+  NOT_FOUND: "NOT_FOUND",
+  RATE_LIMITED: "RATE_LIMITED",
+  TIMEOUT: "TIMEOUT",
+  NETWORK_ERROR: "CONNECTION_ERROR",
+  SERVER_ERROR: "CONNECTION_ERROR",
+  BAD_REQUEST: "VALIDATION_ERROR",
+  UNPROCESSABLE: "VALIDATION_ERROR",
+  INVALID_URL: "VALIDATION_ERROR",
+  METHOD_NOT_ALLOWED: "VALIDATION_ERROR",
+  HTTP_ERROR: "CONNECTION_ERROR",
+  CONFIG_ERROR: "CONFIG_ERROR",
+  CONFLICT: "VALIDATION_ERROR",
+};
+
+export interface BuildOptions {
+  sdk?: () => Promise<GitlabClient>;
+  credentials?: () => Promise<Record<string, unknown>>;
+}
+
+export function gitlabScope(ctx: {
+  sdk: GitlabClient;
+  action: string;
+  params: unknown;
+}): string | null {
+  const ns = ctx.sdk.defaultNamespace;
+  if (!ns) return null;
+  return `${ctx.sdk.host}/${ns}`;
+}
+
+export function buildGitlabConnector(overrides: BuildOptions = {}): Connector {
+  // load credentials default
+  const defaultCredentials = async () => {
+    const creds = await loadGitlabCredentials();
+    return (creds as unknown as Record<string, unknown> | null) ?? {};
+  };
+
+  // default SDK constructor reads credentials & wraps in GitlabClient
+  const defaultSdk = async () => {
+    const creds = await loadGitlabCredentials();
+    if (!creds) {
+      throw new ConnectorError(
+        "CONFIG_ERROR",
+        "GitLab credentials not configured. Set GITLAB_TOKEN (personal access token) or register a credential provider via narai-primitives/credentials.",
+        false,
+      );
+    }
+    return new GitlabClient({
+      token: creds.token,
+      host: creds.host,
+      ...(creds.defaultNamespace ? { defaultNamespace: creds.defaultNamespace } : {}),
+    });
+  };
+
+  const behavior = loadGitlabBehavior();
+
+  return createConnector<GitlabClient>({
+    name: "gitlab",
+    version: "1.0.0",
+    scope: gitlabScope,
+    credentials: overrides.credentials ?? defaultCredentials,
+    sdk: overrides.sdk ?? defaultSdk,
+    policyFloorAspects: ["delete"],
+    defaultPolicy: {
+      read: "success",
+      write: "escalate",
+      admin: "denied",
+      aspects: { delete: "escalate" },
+    },
+    actions: {
+      ...buildReadActions({ behavior }),
+      ...buildMergesActions({ behavior }),
+      ...buildIssuesActions({ behavior }),
+      ...buildNotesActions({ behavior }),
+      ...buildReleasesActions({ behavior }),
+      ...buildPipelinesActions({ behavior }),
+    },
+    mapError: mapHttpError(CODE_MAP),
+  });
+}
+
+// Default production connector instance
+const connector = buildGitlabConnector();
+export default connector;
+export const { main, fetch, validActions } = connector;
+
+// Re-exports for callers / tests
+export {
+  GitlabClient,
+  loadGitlabCredentials,
+  type GitlabClientOptions,
+  type GitlabResult,
+} from "./lib/gitlab_client.js";
+export { ConnectorError as GitlabError } from "narai-primitives/toolkit";

--- a/src/connectors/gitlab/index.ts
+++ b/src/connectors/gitlab/index.ts
@@ -76,9 +76,11 @@ export function buildGitlabConnector(overrides: BuildOptions = {}): Connector {
         false,
       );
     }
+    // Precedence: secret/env (creds.host) > YAML (behavior.host) > GitlabClient default
+    const host = creds.host ?? behavior.host ?? undefined;
     return new GitlabClient({
       token: creds.token,
-      host: behavior.host,
+      ...(host !== undefined ? { host } : {}),
       ...(creds.defaultNamespace ? { defaultNamespace: creds.defaultNamespace } : {}),
     });
   };

--- a/src/connectors/gitlab/lib/gitlab_client.ts
+++ b/src/connectors/gitlab/lib/gitlab_client.ts
@@ -239,10 +239,11 @@ export class GitlabClient {
     namespace: string,
     project: string,
     query: string,
+    opts: { page?: number; perPage?: number } = {},
   ): Promise<GitlabResult<GitlabSearchBlob[]>> {
     return this.get<GitlabSearchBlob[]>(
       `/projects/${this.projectPath(namespace, project)}/search`,
-      { scope: "blobs", search: query },
+      { scope: "blobs", search: query, page: opts.page, per_page: opts.perPage },
     );
   }
 

--- a/src/connectors/gitlab/lib/gitlab_client.ts
+++ b/src/connectors/gitlab/lib/gitlab_client.ts
@@ -3,8 +3,9 @@
  * `HttpClient` in `narai-primitives/toolkit`: supplies Bearer auth,
  * sets baseUrl to `<host>/api/v4`, and allows all five HTTP methods.
  *
- * Per-domain methods (createMr, addNote, retryPipeline, etc.) are added
- * in later tasks; only `getProject` is present here for extras tests.
+ * Read methods added in Task 3: searchCode, listIssues, getIssue,
+ * listMergeRequests, getMergeRequest, getFile, getNotes, listReleaseLinks,
+ * getReleaseLink, listPipelines, getPipeline, listPipelineJobs, getJobLogs.
  */
 import {
   HttpClient,
@@ -39,6 +40,91 @@ export interface GitlabProject {
   web_url?: string;
   ssh_url_to_repo?: string;
   http_url_to_repo?: string;
+}
+
+export interface GitlabSearchBlob {
+  filename: string;
+  path: string;
+  ref: string;
+  startline: number;
+  project_id: number;
+}
+
+export interface GitlabIssue {
+  iid: number;
+  title: string;
+  state: string;
+  author?: { username?: string };
+  labels?: string[];
+  description?: string | null;
+  web_url?: string;
+  updated_at?: string;
+}
+
+export interface GitlabMergeRequest {
+  iid: number;
+  title: string;
+  state: string;
+  author?: { username?: string };
+  description?: string | null;
+  source_branch?: string;
+  target_branch?: string;
+  sha?: string;
+  draft?: boolean;
+  web_url?: string;
+  updated_at?: string;
+}
+
+export interface GitlabFileContent {
+  file_name: string;
+  file_path: string;
+  size: number;
+  encoding: string;
+  content: string;
+  ref: string;
+  blob_id?: string;
+  commit_id?: string;
+  last_commit_id?: string;
+}
+
+export interface GitlabNote {
+  id: number;
+  body: string;
+  author?: { username?: string };
+  created_at?: string;
+  updated_at?: string;
+  system?: boolean;
+}
+
+export interface GitlabReleaseLink {
+  id: number;
+  name: string;
+  url: string;
+  link_type?: string;
+}
+
+export interface GitlabPipeline {
+  id: number;
+  status: string;
+  ref: string;
+  sha?: string;
+  web_url?: string;
+  created_at?: string;
+  updated_at?: string;
+  duration?: number | null;
+  finished_at?: string | null;
+}
+
+export interface GitlabJob {
+  id: number;
+  name: string;
+  stage?: string;
+  status: string;
+  created_at?: string;
+  started_at?: string | null;
+  finished_at?: string | null;
+  duration?: number | null;
+  web_url?: string;
 }
 
 // ── Credential loader ────────────────────────────────────────────────────────
@@ -140,12 +226,163 @@ export class GitlabClient {
     return this._http.request<T>("DELETE", relPath);
   }
 
-  // ── Concrete method (for extras tests; domain methods land in later tasks) ─
+  // ── Read methods ─────────────────────────────────────────────────────────
 
   public async getProject(
     namespace: string,
     project: string,
   ): Promise<GitlabResult<GitlabProject>> {
     return this.get<GitlabProject>(`/projects/${this.projectPath(namespace, project)}`);
+  }
+
+  public async searchCode(
+    namespace: string,
+    project: string,
+    query: string,
+  ): Promise<GitlabResult<GitlabSearchBlob[]>> {
+    return this.get<GitlabSearchBlob[]>(
+      `/projects/${this.projectPath(namespace, project)}/search`,
+      { scope: "blobs", search: query },
+    );
+  }
+
+  public async listIssues(
+    namespace: string,
+    project: string,
+    query: { state?: string; per_page?: number; page?: number } = {},
+  ): Promise<GitlabResult<GitlabIssue[]>> {
+    return this.get<GitlabIssue[]>(
+      `/projects/${this.projectPath(namespace, project)}/issues`,
+      { state: query.state, per_page: query.per_page, page: query.page },
+    );
+  }
+
+  public async getIssue(
+    namespace: string,
+    project: string,
+    iid: number,
+  ): Promise<GitlabResult<GitlabIssue>> {
+    return this.get<GitlabIssue>(
+      `/projects/${this.projectPath(namespace, project)}/issues/${iid}`,
+    );
+  }
+
+  public async listMergeRequests(
+    namespace: string,
+    project: string,
+    query: { state?: string; per_page?: number; page?: number } = {},
+  ): Promise<GitlabResult<GitlabMergeRequest[]>> {
+    return this.get<GitlabMergeRequest[]>(
+      `/projects/${this.projectPath(namespace, project)}/merge_requests`,
+      { state: query.state, per_page: query.per_page, page: query.page },
+    );
+  }
+
+  public async getMergeRequest(
+    namespace: string,
+    project: string,
+    iid: number,
+  ): Promise<GitlabResult<GitlabMergeRequest>> {
+    return this.get<GitlabMergeRequest>(
+      `/projects/${this.projectPath(namespace, project)}/merge_requests/${iid}`,
+    );
+  }
+
+  /**
+   * Fetches a file at a given ref. The path itself is URL-encoded because
+   * GitLab requires the file path to be encoded in the URL segment.
+   */
+  public async getFile(
+    namespace: string,
+    project: string,
+    filePath: string,
+    ref = "main",
+  ): Promise<GitlabResult<GitlabFileContent>> {
+    return this.get<GitlabFileContent>(
+      `/projects/${this.projectPath(namespace, project)}/repository/files/${encodeURIComponent(filePath)}`,
+      { ref },
+    );
+  }
+
+  /**
+   * Fetches notes (comments) on an issue or merge request.
+   * `noteableType` is "issue" | "merge_request"; maps to URL segment
+   * "issues" or "merge_requests".
+   */
+  public async getNotes(
+    namespace: string,
+    project: string,
+    noteableType: "issue" | "merge_request",
+    iid: number,
+  ): Promise<GitlabResult<GitlabNote[]>> {
+    const segment = noteableType === "issue" ? "issues" : "merge_requests";
+    return this.get<GitlabNote[]>(
+      `/projects/${this.projectPath(namespace, project)}/${segment}/${iid}/notes`,
+    );
+  }
+
+  public async listReleaseLinks(
+    namespace: string,
+    project: string,
+    tag: string,
+  ): Promise<GitlabResult<GitlabReleaseLink[]>> {
+    return this.get<GitlabReleaseLink[]>(
+      `/projects/${this.projectPath(namespace, project)}/releases/${encodeURIComponent(tag)}/assets/links`,
+    );
+  }
+
+  public async getReleaseLink(
+    namespace: string,
+    project: string,
+    tag: string,
+    linkId: number,
+  ): Promise<GitlabResult<GitlabReleaseLink>> {
+    return this.get<GitlabReleaseLink>(
+      `/projects/${this.projectPath(namespace, project)}/releases/${encodeURIComponent(tag)}/assets/links/${linkId}`,
+    );
+  }
+
+  public async listPipelines(
+    namespace: string,
+    project: string,
+    query: { ref?: string; status?: string; per_page?: number; page?: number } = {},
+  ): Promise<GitlabResult<GitlabPipeline[]>> {
+    return this.get<GitlabPipeline[]>(
+      `/projects/${this.projectPath(namespace, project)}/pipelines`,
+      { ref: query.ref, status: query.status, per_page: query.per_page, page: query.page },
+    );
+  }
+
+  public async getPipeline(
+    namespace: string,
+    project: string,
+    pipelineId: number,
+  ): Promise<GitlabResult<GitlabPipeline>> {
+    return this.get<GitlabPipeline>(
+      `/projects/${this.projectPath(namespace, project)}/pipelines/${pipelineId}`,
+    );
+  }
+
+  public async listPipelineJobs(
+    namespace: string,
+    project: string,
+    pipelineId: number,
+  ): Promise<GitlabResult<GitlabJob[]>> {
+    return this.get<GitlabJob[]>(
+      `/projects/${this.projectPath(namespace, project)}/pipelines/${pipelineId}/jobs`,
+    );
+  }
+
+  /** Returns the job trace log as a plain text string. */
+  public async getJobLogs(
+    namespace: string,
+    project: string,
+    jobId: number,
+  ): Promise<GitlabResult<string>> {
+    return this._http.request<string>(
+      "GET",
+      `/projects/${this.projectPath(namespace, project)}/jobs/${jobId}/trace`,
+      { responseType: "text" },
+    );
   }
 }

--- a/src/connectors/gitlab/lib/gitlab_client.ts
+++ b/src/connectors/gitlab/lib/gitlab_client.ts
@@ -1,0 +1,151 @@
+/**
+ * gitlab_client.ts — GitLab REST client. Thin wrapper over the shared
+ * `HttpClient` in `narai-primitives/toolkit`: supplies Bearer auth,
+ * sets baseUrl to `<host>/api/v4`, and allows all five HTTP methods.
+ *
+ * Per-domain methods (createMr, addNote, retryPipeline, etc.) are added
+ * in later tasks; only `getProject` is present here for extras tests.
+ */
+import {
+  HttpClient,
+  type HttpResult,
+} from "narai-primitives/toolkit";
+import { resolveSecret } from "narai-primitives/credentials";
+
+const GITLAB_DEFAULT_HOST = "https://gitlab.com";
+
+// ── Options & types ──────────────────────────────────────────────────────────
+
+export interface GitlabClientOptions {
+  token: string;
+  host?: string;
+  defaultNamespace?: string;
+  rateLimitPerMin?: number;
+  connectTimeoutMs?: number;
+  readTimeoutMs?: number;
+  fetchImpl?: typeof globalThis.fetch;
+  sleepImpl?: (ms: number) => Promise<void>;
+}
+
+export type GitlabResult<T> = HttpResult<T>;
+
+export interface GitlabProject {
+  id: number;
+  name: string;
+  path_with_namespace: string;
+  default_branch?: string;
+  description?: string | null;
+  visibility?: string;
+  web_url?: string;
+  ssh_url_to_repo?: string;
+  http_url_to_repo?: string;
+}
+
+// ── Credential loader ────────────────────────────────────────────────────────
+
+export async function loadGitlabCredentials(): Promise<{
+  token: string;
+  host: string;
+  defaultNamespace: string | null;
+} | null> {
+  const token =
+    (await resolveSecret("GITLAB_TOKEN")) ??
+    process.env["GITLAB_TOKEN"] ??
+    null;
+  if (!token) return null;
+
+  const host =
+    (await resolveSecret("GITLAB_HOST")) ??
+    process.env["GITLAB_HOST"] ??
+    GITLAB_DEFAULT_HOST;
+
+  const defaultNamespace =
+    (await resolveSecret("GITLAB_NAMESPACE")) ??
+    process.env["GITLAB_NAMESPACE"] ??
+    null;
+
+  return { token, host, defaultNamespace };
+}
+
+// ── GitlabClient ─────────────────────────────────────────────────────────────
+
+export class GitlabClient {
+  private readonly _http: HttpClient;
+  private readonly _defaultNamespace: string | null;
+
+  constructor(opts: GitlabClientOptions) {
+    const host = opts.host ?? GITLAB_DEFAULT_HOST;
+    this._defaultNamespace = opts.defaultNamespace ?? null;
+    this._http = new HttpClient({
+      baseUrl: `${host}/api/v4`,
+      authHeader: `Bearer ${opts.token}`,
+      serviceName: "GitLab",
+      allowedMethods: new Set(["GET", "POST", "PUT", "PATCH", "DELETE"]),
+      rateLimitPerMin: opts.rateLimitPerMin,
+      connectTimeoutMs: opts.connectTimeoutMs,
+      readTimeoutMs: opts.readTimeoutMs,
+      fetchImpl: opts.fetchImpl,
+      sleepImpl: opts.sleepImpl,
+    });
+  }
+
+  public get host(): string {
+    return this._http.host;
+  }
+
+  public get defaultNamespace(): string | null {
+    return this._defaultNamespace;
+  }
+
+  /**
+   * Encodes `namespace/project` for use in GitLab project API paths.
+   * All slashes (including those in group/subgroup paths) are percent-encoded.
+   * Example: projectPath("group/sub", "proj") → "group%2Fsub%2Fproj"
+   */
+  public projectPath(namespace: string, project: string): string {
+    return encodeURIComponent(`${namespace}/${project}`);
+  }
+
+  // ── Minimal HTTP wrappers ────────────────────────────────────────────────
+
+  public async get<T = unknown>(
+    relPath: string,
+    query?: Record<string, string | number | boolean | undefined | null>,
+  ): Promise<GitlabResult<T>> {
+    return this._http.request<T>("GET", relPath, { query });
+  }
+
+  public async post<T = unknown>(
+    relPath: string,
+    body?: Record<string, unknown>,
+  ): Promise<GitlabResult<T>> {
+    return this._http.request<T>("POST", relPath, { body });
+  }
+
+  public async patch<T = unknown>(
+    relPath: string,
+    body?: Record<string, unknown>,
+  ): Promise<GitlabResult<T>> {
+    return this._http.request<T>("PATCH", relPath, { body });
+  }
+
+  public async put<T = unknown>(
+    relPath: string,
+    body?: Record<string, unknown>,
+  ): Promise<GitlabResult<T>> {
+    return this._http.request<T>("PUT", relPath, { body });
+  }
+
+  public async delete<T = unknown>(relPath: string): Promise<GitlabResult<T>> {
+    return this._http.request<T>("DELETE", relPath);
+  }
+
+  // ── Concrete method (for extras tests; domain methods land in later tasks) ─
+
+  public async getProject(
+    namespace: string,
+    project: string,
+  ): Promise<GitlabResult<GitlabProject>> {
+    return this.get<GitlabProject>(`/projects/${this.projectPath(namespace, project)}`);
+  }
+}

--- a/src/connectors/gitlab/lib/gitlab_client.ts
+++ b/src/connectors/gitlab/lib/gitlab_client.ts
@@ -386,6 +386,57 @@ export class GitlabClient {
     );
   }
 
+  // ── Issue mutations ──────────────────────────────────────────────────────
+
+  public async createIssue(
+    namespace: string,
+    project: string,
+    body: {
+      title: string;
+      description?: string;
+      assignee_ids?: number[];
+      labels?: string;
+      milestone_id?: number;
+      due_date?: string;
+    },
+  ): Promise<GitlabResult<GitlabIssue>> {
+    return this.post<GitlabIssue>(
+      `/projects/${this.projectPath(namespace, project)}/issues`,
+      body as Record<string, unknown>,
+    );
+  }
+
+  public async updateIssue(
+    namespace: string,
+    project: string,
+    iid: number,
+    body: {
+      title?: string;
+      description?: string;
+      assignee_ids?: number[];
+      labels?: string;
+      milestone_id?: number;
+      due_date?: string;
+      state_event?: "reopen";
+    },
+  ): Promise<GitlabResult<GitlabIssue>> {
+    return this.put<GitlabIssue>(
+      `/projects/${this.projectPath(namespace, project)}/issues/${iid}`,
+      body as Record<string, unknown>,
+    );
+  }
+
+  public async closeIssue(
+    namespace: string,
+    project: string,
+    iid: number,
+  ): Promise<GitlabResult<GitlabIssue>> {
+    return this.put<GitlabIssue>(
+      `/projects/${this.projectPath(namespace, project)}/issues/${iid}`,
+      { state_event: "close" },
+    );
+  }
+
   // ── Merge request mutations ──────────────────────────────────────────────
 
   public async createMergeRequest(

--- a/src/connectors/gitlab/lib/gitlab_client.ts
+++ b/src/connectors/gitlab/lib/gitlab_client.ts
@@ -129,26 +129,33 @@ export interface GitlabJob {
 
 // ── Credential loader ────────────────────────────────────────────────────────
 
+function emptyToNull(v: string | null | undefined): string | null {
+  return v == null || v === "" ? null : v;
+}
+
 export async function loadGitlabCredentials(): Promise<{
   token: string;
   host: string | null;
   defaultNamespace: string | null;
 } | null> {
-  const token =
+  const token = emptyToNull(
     (await resolveSecret("GITLAB_TOKEN")) ??
     process.env["GITLAB_TOKEN"] ??
-    null;
+    null,
+  );
   if (!token) return null;
 
-  const host =
+  const host = emptyToNull(
     (await resolveSecret("GITLAB_HOST")) ??
     process.env["GITLAB_HOST"] ??
-    null;
+    null,
+  );
 
-  const defaultNamespace =
+  const defaultNamespace = emptyToNull(
     (await resolveSecret("GITLAB_NAMESPACE")) ??
     process.env["GITLAB_NAMESPACE"] ??
-    null;
+    null,
+  );
 
   return { token, host, defaultNamespace };
 }
@@ -315,10 +322,12 @@ export class GitlabClient {
     project: string,
     noteableType: "issue" | "merge_request",
     iid: number,
+    opts: { page?: number; perPage?: number } = {},
   ): Promise<GitlabResult<GitlabNote[]>> {
     const segment = noteableType === "issue" ? "issues" : "merge_requests";
     return this.get<GitlabNote[]>(
       `/projects/${this.projectPath(namespace, project)}/${segment}/${iid}/notes`,
+      { page: opts.page, per_page: opts.perPage },
     );
   }
 

--- a/src/connectors/gitlab/lib/gitlab_client.ts
+++ b/src/connectors/gitlab/lib/gitlab_client.ts
@@ -615,4 +615,59 @@ export class GitlabClient {
       `/projects/${this.projectPath(namespace, project)}/releases/${encodeURIComponent(tag)}/assets/links/${linkId}`,
     );
   }
+
+  // ── Pipeline mutations ───────────────────────────────────────────────────
+
+  public async retryPipeline(
+    namespace: string,
+    project: string,
+    pipelineId: number,
+  ): Promise<GitlabResult<GitlabPipeline>> {
+    return this.post<GitlabPipeline>(
+      `/projects/${this.projectPath(namespace, project)}/pipelines/${pipelineId}/retry`,
+    );
+  }
+
+  public async cancelPipeline(
+    namespace: string,
+    project: string,
+    pipelineId: number,
+  ): Promise<GitlabResult<GitlabPipeline>> {
+    return this.post<GitlabPipeline>(
+      `/projects/${this.projectPath(namespace, project)}/pipelines/${pipelineId}/cancel`,
+    );
+  }
+
+  public async triggerPipeline(
+    namespace: string,
+    project: string,
+    body: {
+      token: string;
+      ref: string;
+      variables?: Record<string, string>;
+    },
+  ): Promise<GitlabResult<GitlabPipeline>> {
+    return this.post<GitlabPipeline>(
+      `/projects/${this.projectPath(namespace, project)}/trigger/pipeline`,
+      body as Record<string, unknown>,
+    );
+  }
+
+  public async playJob(
+    namespace: string,
+    project: string,
+    jobId: number,
+    variables?: Record<string, string>,
+  ): Promise<GitlabResult<GitlabJob>> {
+    const body: Record<string, unknown> = {};
+    if (variables !== undefined) {
+      body["job_variables_attributes"] = Object.entries(variables).map(
+        ([key, value]) => ({ key, value }),
+      );
+    }
+    return this.post<GitlabJob>(
+      `/projects/${this.projectPath(namespace, project)}/jobs/${jobId}/play`,
+      body,
+    );
+  }
 }

--- a/src/connectors/gitlab/lib/gitlab_client.ts
+++ b/src/connectors/gitlab/lib/gitlab_client.ts
@@ -559,4 +559,60 @@ export class GitlabClient {
       `/projects/${this.projectPath(namespace, project)}/${this.noteSegment(noteableType)}/${iid}/notes/${noteId}`,
     );
   }
+
+  // ── Release mutations ────────────────────────────────────────────────────
+
+  public async createRelease(
+    namespace: string,
+    project: string,
+    body: {
+      tag_name: string;
+      name: string;
+      description?: string;
+      ref?: string;
+      assets?: { links: { name: string; url: string; link_type?: string }[] };
+    },
+  ): Promise<GitlabResult<Record<string, unknown>>> {
+    return this.post<Record<string, unknown>>(
+      `/projects/${this.projectPath(namespace, project)}/releases`,
+      body as Record<string, unknown>,
+    );
+  }
+
+  public async updateRelease(
+    namespace: string,
+    project: string,
+    tag: string,
+    body: {
+      name?: string;
+      description?: string;
+      milestones?: string[];
+    },
+  ): Promise<GitlabResult<Record<string, unknown>>> {
+    return this.put<Record<string, unknown>>(
+      `/projects/${this.projectPath(namespace, project)}/releases/${encodeURIComponent(tag)}`,
+      body as Record<string, unknown>,
+    );
+  }
+
+  public async deleteRelease(
+    namespace: string,
+    project: string,
+    tag: string,
+  ): Promise<GitlabResult<null>> {
+    return this.delete<null>(
+      `/projects/${this.projectPath(namespace, project)}/releases/${encodeURIComponent(tag)}`,
+    );
+  }
+
+  public async deleteReleaseLink(
+    namespace: string,
+    project: string,
+    tag: string,
+    linkId: number,
+  ): Promise<GitlabResult<null>> {
+    return this.delete<null>(
+      `/projects/${this.projectPath(namespace, project)}/releases/${encodeURIComponent(tag)}/assets/links/${linkId}`,
+    );
+  }
 }

--- a/src/connectors/gitlab/lib/gitlab_client.ts
+++ b/src/connectors/gitlab/lib/gitlab_client.ts
@@ -131,7 +131,7 @@ export interface GitlabJob {
 
 export async function loadGitlabCredentials(): Promise<{
   token: string;
-  host: string;
+  host: string | null;
   defaultNamespace: string | null;
 } | null> {
   const token =
@@ -143,7 +143,7 @@ export async function loadGitlabCredentials(): Promise<{
   const host =
     (await resolveSecret("GITLAB_HOST")) ??
     process.env["GITLAB_HOST"] ??
-    GITLAB_DEFAULT_HOST;
+    null;
 
   const defaultNamespace =
     (await resolveSecret("GITLAB_NAMESPACE")) ??

--- a/src/connectors/gitlab/lib/gitlab_client.ts
+++ b/src/connectors/gitlab/lib/gitlab_client.ts
@@ -514,4 +514,49 @@ export class GitlabClient {
       body as Record<string, unknown>,
     );
   }
+
+  // ── Note mutations ───────────────────────────────────────────────────────
+
+  private noteSegment(noteableType: "issue" | "merge_request"): string {
+    return noteableType === "issue" ? "issues" : "merge_requests";
+  }
+
+  public async addNote(
+    namespace: string,
+    project: string,
+    noteableType: "issue" | "merge_request",
+    iid: number,
+    body: { body: string; position?: Record<string, unknown> },
+  ): Promise<GitlabResult<GitlabNote>> {
+    return this.post<GitlabNote>(
+      `/projects/${this.projectPath(namespace, project)}/${this.noteSegment(noteableType)}/${iid}/notes`,
+      body as Record<string, unknown>,
+    );
+  }
+
+  public async updateNote(
+    namespace: string,
+    project: string,
+    noteableType: "issue" | "merge_request",
+    iid: number,
+    noteId: number,
+    body: { body: string },
+  ): Promise<GitlabResult<GitlabNote>> {
+    return this.put<GitlabNote>(
+      `/projects/${this.projectPath(namespace, project)}/${this.noteSegment(noteableType)}/${iid}/notes/${noteId}`,
+      body as Record<string, unknown>,
+    );
+  }
+
+  public async deleteNote(
+    namespace: string,
+    project: string,
+    noteableType: "issue" | "merge_request",
+    iid: number,
+    noteId: number,
+  ): Promise<GitlabResult<null>> {
+    return this.delete<null>(
+      `/projects/${this.projectPath(namespace, project)}/${this.noteSegment(noteableType)}/${iid}/notes/${noteId}`,
+    );
+  }
 }

--- a/src/connectors/gitlab/lib/gitlab_client.ts
+++ b/src/connectors/gitlab/lib/gitlab_client.ts
@@ -385,4 +385,82 @@ export class GitlabClient {
       { responseType: "text" },
     );
   }
+
+  // ── Merge request mutations ──────────────────────────────────────────────
+
+  public async createMergeRequest(
+    namespace: string,
+    project: string,
+    body: {
+      source_branch: string;
+      target_branch: string;
+      title: string;
+      description?: string;
+      assignee_ids?: number[];
+      reviewer_ids?: number[];
+      labels?: string;
+      milestone_id?: number;
+      remove_source_branch?: boolean;
+      squash?: boolean;
+      draft?: boolean;
+    },
+  ): Promise<GitlabResult<GitlabMergeRequest>> {
+    return this.post<GitlabMergeRequest>(
+      `/projects/${this.projectPath(namespace, project)}/merge_requests`,
+      body as Record<string, unknown>,
+    );
+  }
+
+  public async updateMergeRequest(
+    namespace: string,
+    project: string,
+    iid: number,
+    body: {
+      title?: string;
+      description?: string;
+      target_branch?: string;
+      assignee_ids?: number[];
+      reviewer_ids?: number[];
+      labels?: string;
+      milestone_id?: number;
+      state_event?: "reopen";
+      remove_source_branch?: boolean;
+      squash?: boolean;
+    },
+  ): Promise<GitlabResult<GitlabMergeRequest>> {
+    return this.put<GitlabMergeRequest>(
+      `/projects/${this.projectPath(namespace, project)}/merge_requests/${iid}`,
+      body as Record<string, unknown>,
+    );
+  }
+
+  public async closeMergeRequest(
+    namespace: string,
+    project: string,
+    iid: number,
+  ): Promise<GitlabResult<GitlabMergeRequest>> {
+    return this.put<GitlabMergeRequest>(
+      `/projects/${this.projectPath(namespace, project)}/merge_requests/${iid}`,
+      { state_event: "close" },
+    );
+  }
+
+  public async mergeMergeRequest(
+    namespace: string,
+    project: string,
+    iid: number,
+    body: {
+      merge_commit_message?: string;
+      squash_commit_message?: string;
+      should_remove_source_branch?: boolean;
+      merge_when_pipeline_succeeds?: boolean;
+      sha?: string;
+      squash?: boolean;
+    } = {},
+  ): Promise<GitlabResult<{ sha: string; merged: boolean; message: string }>> {
+    return this.put<{ sha: string; merged: boolean; message: string }>(
+      `/projects/${this.projectPath(namespace, project)}/merge_requests/${iid}/merge`,
+      body as Record<string, unknown>,
+    );
+  }
 }

--- a/src/connectors/gitlab/lib/gitlab_client.ts
+++ b/src/connectors/gitlab/lib/gitlab_client.ts
@@ -96,6 +96,23 @@ export interface GitlabNote {
   system?: boolean;
 }
 
+export interface GitlabDiscussion {
+  id: string;
+  individual_note: boolean;
+  notes: GitlabNote[];
+}
+
+export interface GitlabPositionPayload {
+  base_sha: string;
+  start_sha: string;
+  head_sha: string;
+  position_type: "text";
+  new_path: string;
+  old_path?: string | undefined;
+  new_line?: number | undefined;
+  old_line?: number | undefined;
+}
+
 export interface GitlabReleaseLink {
   id: number;
   name: string;
@@ -377,9 +394,14 @@ export class GitlabClient {
     namespace: string,
     project: string,
     pipelineId: number,
+    opts: { page?: number; perPage?: number } = {},
   ): Promise<GitlabResult<GitlabJob[]>> {
+    const query: Record<string, string | number> = {};
+    if (opts.page !== undefined) query.page = opts.page;
+    if (opts.perPage !== undefined) query.per_page = opts.perPage;
     return this.get<GitlabJob[]>(
       `/projects/${this.projectPath(namespace, project)}/pipelines/${pipelineId}/jobs`,
+      query,
     );
   }
 
@@ -536,10 +558,33 @@ export class GitlabClient {
     project: string,
     noteableType: "issue" | "merge_request",
     iid: number,
-    body: { body: string; position?: Record<string, unknown> },
+    body: { body: string; position?: GitlabPositionPayload },
   ): Promise<GitlabResult<GitlabNote>> {
+    const projectPath = this.projectPath(namespace, project);
+    const segment = this.noteSegment(noteableType);
+    // For MR diff notes (with position payload), GitLab requires the
+    // /discussions endpoint — /notes silently strips position and creates
+    // a non-diff conversation comment.
+    if (noteableType === "merge_request" && body.position) {
+      const discussionResult = await this.post<GitlabDiscussion>(
+        `/projects/${projectPath}/${segment}/${iid}/discussions`,
+        body as Record<string, unknown>,
+      );
+      if (!discussionResult.ok) return discussionResult as unknown as GitlabResult<GitlabNote>;
+      const firstNote = discussionResult.data.notes?.[0];
+      if (!firstNote) {
+        return {
+          ok: false,
+          code: "SERVER_ERROR",
+          status: discussionResult.status,
+          message: "discussion created but no notes returned",
+          retriable: false,
+        };
+      }
+      return { ok: true, status: discussionResult.status, data: firstNote };
+    }
     return this.post<GitlabNote>(
-      `/projects/${this.projectPath(namespace, project)}/${this.noteSegment(noteableType)}/${iid}/notes`,
+      `/projects/${projectPath}/${segment}/${iid}/notes`,
       body as Record<string, unknown>,
     );
   }

--- a/src/connectors/gitlab/lib/gitlab_client.ts
+++ b/src/connectors/gitlab/lib/gitlab_client.ts
@@ -348,6 +348,27 @@ export class GitlabClient {
     );
   }
 
+  /**
+   * Fetches discussions (including diff/inline threads) on a merge request.
+   * GitLab's Notes API does not return DiscussionNote/DiffNote entries;
+   * those are only available via the Discussions API.
+   */
+  public async getDiscussions(
+    namespace: string,
+    project: string,
+    mrIid: number,
+    opts: { page?: number; perPage?: number } = {},
+  ): Promise<GitlabResult<GitlabDiscussion[]>> {
+    const projectPath = this.projectPath(namespace, project);
+    const query: Record<string, string | number> = {};
+    if (opts.page !== undefined) query.page = opts.page;
+    if (opts.perPage !== undefined) query.per_page = opts.perPage;
+    return this.get<GitlabDiscussion[]>(
+      `/projects/${projectPath}/merge_requests/${mrIid}/discussions`,
+      query,
+    );
+  }
+
   public async listReleaseLinks(
     namespace: string,
     project: string,
@@ -596,11 +617,14 @@ export class GitlabClient {
     iid: number,
     noteId: number,
     body: { body: string },
+    opts: { discussionId?: string } = {},
   ): Promise<GitlabResult<GitlabNote>> {
-    return this.put<GitlabNote>(
-      `/projects/${this.projectPath(namespace, project)}/${this.noteSegment(noteableType)}/${iid}/notes/${noteId}`,
-      body as Record<string, unknown>,
-    );
+    const projectPath = this.projectPath(namespace, project);
+    const notePath =
+      noteableType === "merge_request" && opts.discussionId
+        ? `/projects/${projectPath}/merge_requests/${iid}/discussions/${opts.discussionId}/notes/${noteId}`
+        : `/projects/${projectPath}/${this.noteSegment(noteableType)}/${iid}/notes/${noteId}`;
+    return this.put<GitlabNote>(notePath, body as Record<string, unknown>);
   }
 
   public async deleteNote(
@@ -609,10 +633,14 @@ export class GitlabClient {
     noteableType: "issue" | "merge_request",
     iid: number,
     noteId: number,
+    opts: { discussionId?: string } = {},
   ): Promise<GitlabResult<null>> {
-    return this.delete<null>(
-      `/projects/${this.projectPath(namespace, project)}/${this.noteSegment(noteableType)}/${iid}/notes/${noteId}`,
-    );
+    const projectPath = this.projectPath(namespace, project);
+    const notePath =
+      noteableType === "merge_request" && opts.discussionId
+        ? `/projects/${projectPath}/merge_requests/${iid}/discussions/${opts.discussionId}/notes/${noteId}`
+        : `/projects/${projectPath}/${this.noteSegment(noteableType)}/${iid}/notes/${noteId}`;
+    return this.delete<null>(notePath);
   }
 
   // ── Release mutations ────────────────────────────────────────────────────

--- a/src/connectors/gitlab/lib/gitlab_config.ts
+++ b/src/connectors/gitlab/lib/gitlab_config.ts
@@ -8,8 +8,8 @@
  *
  * Precedence (highest wins):
  *   1. GITLAB_REQUIRE_DRAFT_MR / GITLAB_HOST env vars
- *   2. <cwd>/.gitlab-connector/config.yaml `gitlab.*`
- *   3. ~/.gitlab-connector/config.yaml  `gitlab.*`
+ *   2. <cwd>/.gitlab-agent/config.yaml `gitlab.*`
+ *   3. ~/.gitlab-agent/config.yaml  `gitlab.*`
  *   4. defaults: requireDraftMr=false, host="https://gitlab.com"
  *
  * Replicates the toolkit's discover-and-merge pattern locally so we don't
@@ -117,8 +117,8 @@ export function loadGitlabBehavior(
   let requireDraftMr = false;
   let host = "https://gitlab.com";
 
-  const userCfg = path.join(home, ".gitlab-connector", "config.yaml");
-  const repoCfg = path.join(cwd, ".gitlab-connector", "config.yaml");
+  const userCfg = path.join(home, ".gitlab-agent", "config.yaml");
+  const repoCfg = path.join(cwd, ".gitlab-agent", "config.yaml");
 
   const userDraft = readGitlabSectionFlag(userCfg, "require_draft_mr");
   if (userDraft !== undefined) requireDraftMr = userDraft;

--- a/src/connectors/gitlab/lib/gitlab_config.ts
+++ b/src/connectors/gitlab/lib/gitlab_config.ts
@@ -6,11 +6,15 @@
  *   rewritten to draft mode regardless of caller input.
  * - `host` — the GitLab instance base URL (default: "https://gitlab.com").
  *
- * Precedence (highest wins):
- *   1. GITLAB_REQUIRE_DRAFT_MR / GITLAB_HOST env vars
- *   2. <cwd>/.gitlab-agent/config.yaml `gitlab.*`
- *   3. ~/.gitlab-agent/config.yaml  `gitlab.*`
- *   4. defaults: requireDraftMr=false, host="https://gitlab.com"
+ * Precedence for host (highest wins, as merged in defaultSdk):
+ *   1. resolveSecret("GITLAB_HOST") — secret provider (Vault, AWS SM, etc.)
+ *   2. GITLAB_HOST env var
+ *   3. <cwd>/.gitlab-agent/config.yaml `gitlab.host`
+ *   4. ~/.gitlab-agent/config.yaml  `gitlab.host`
+ *   5. Default https://gitlab.com (applied in GitlabClient constructor)
+ *
+ * loadGitlabBehavior() returns host=null when neither env nor YAML sets it,
+ * allowing the caller to distinguish "explicitly configured" from "absent".
  *
  * Replicates the toolkit's discover-and-merge pattern locally so we don't
  * depend on internals of `toolkit/policy/config.ts` that aren't part of
@@ -23,7 +27,7 @@ import * as yaml from "js-yaml";
 
 export interface GitlabBehavior {
   requireDraftMr: boolean;
-  host: string;
+  host: string | null;
 }
 
 export interface LoadGitlabBehaviorOptions {
@@ -115,7 +119,7 @@ export function loadGitlabBehavior(
   const env = opts.env ?? process.env;
 
   let requireDraftMr = false;
-  let host = "https://gitlab.com";
+  let host: string | null = null;
 
   const userCfg = path.join(home, ".gitlab-agent", "config.yaml");
   const repoCfg = path.join(cwd, ".gitlab-agent", "config.yaml");

--- a/src/connectors/gitlab/lib/gitlab_config.ts
+++ b/src/connectors/gitlab/lib/gitlab_config.ts
@@ -1,0 +1,142 @@
+/**
+ * Connector-specific runtime knobs that sit outside the toolkit's
+ * policy/approval YAML. Today: `require_draft_mr` and `host`.
+ *
+ * - `require_draft_mr` — when true, every `create_merge_request` call is
+ *   rewritten to draft mode regardless of caller input.
+ * - `host` — the GitLab instance base URL (default: "https://gitlab.com").
+ *
+ * Precedence (highest wins):
+ *   1. GITLAB_REQUIRE_DRAFT_MR / GITLAB_HOST env vars
+ *   2. <cwd>/.gitlab-connector/config.yaml `gitlab.*`
+ *   3. ~/.gitlab-connector/config.yaml  `gitlab.*`
+ *   4. defaults: requireDraftMr=false, host="https://gitlab.com"
+ *
+ * Replicates the toolkit's discover-and-merge pattern locally so we don't
+ * depend on internals of `toolkit/policy/config.ts` that aren't part of
+ * its public surface.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as yaml from "js-yaml";
+
+export interface GitlabBehavior {
+  requireDraftMr: boolean;
+  host: string;
+}
+
+export interface LoadGitlabBehaviorOptions {
+  cwd?: string;
+  home?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+const TRUTHY = new Set(["1", "true", "yes"]);
+const FALSY = new Set(["0", "false", "no"]);
+
+function readYamlFile(filePath: string): Record<string, unknown> | null {
+  if (!fs.existsSync(filePath)) return null;
+  const raw = fs.readFileSync(filePath, "utf-8");
+  const parsed = yaml.load(raw);
+  if (parsed === null || parsed === undefined) return {};
+  if (typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      `gitlab config: expected a YAML mapping at root of ${filePath}, got ${
+        Array.isArray(parsed) ? "list" : typeof parsed
+      }`,
+    );
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function getGitlabSection(
+  configPath: string,
+): Record<string, unknown> | undefined {
+  const doc = readYamlFile(configPath);
+  if (doc === null) return undefined;
+  const section = doc["gitlab"];
+  if (section === undefined) return undefined;
+  if (typeof section !== "object" || section === null || Array.isArray(section)) {
+    throw new Error(
+      `gitlab config: 'gitlab:' section in ${configPath} must be a mapping`,
+    );
+  }
+  return section as Record<string, unknown>;
+}
+
+function readGitlabSectionFlag(
+  configPath: string,
+  key: string,
+): boolean | undefined {
+  const section = getGitlabSection(configPath);
+  if (section === undefined) return undefined;
+  const value = section[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== "boolean") {
+    throw new Error(
+      `gitlab config: 'gitlab.${key}' in ${configPath} must be a boolean, got ${typeof value}`,
+    );
+  }
+  return value;
+}
+
+function readGitlabSectionString(
+  configPath: string,
+  key: string,
+): string | undefined {
+  const section = getGitlabSection(configPath);
+  if (section === undefined) return undefined;
+  const value = section[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") {
+    throw new Error(
+      `gitlab config: 'gitlab.${key}' in ${configPath} must be a string, got ${typeof value}`,
+    );
+  }
+  return value;
+}
+
+function parseEnvBoolOverride(raw: string | undefined): boolean | undefined {
+  if (raw === undefined || raw === "") return undefined;
+  const v = raw.toLowerCase();
+  if (TRUTHY.has(v)) return true;
+  if (FALSY.has(v)) return false;
+  throw new Error(
+    `GITLAB_REQUIRE_DRAFT_MR: expected one of 1/0/true/false/yes/no, got ${JSON.stringify(raw)}`,
+  );
+}
+
+export function loadGitlabBehavior(
+  opts: LoadGitlabBehaviorOptions = {},
+): GitlabBehavior {
+  const home = opts.home ?? os.homedir();
+  const cwd = opts.cwd ?? process.cwd();
+  const env = opts.env ?? process.env;
+
+  let requireDraftMr = false;
+  let host = "https://gitlab.com";
+
+  const userCfg = path.join(home, ".gitlab-connector", "config.yaml");
+  const repoCfg = path.join(cwd, ".gitlab-connector", "config.yaml");
+
+  const userDraft = readGitlabSectionFlag(userCfg, "require_draft_mr");
+  if (userDraft !== undefined) requireDraftMr = userDraft;
+
+  const userHost = readGitlabSectionString(userCfg, "host");
+  if (userHost !== undefined) host = userHost;
+
+  const repoDraft = readGitlabSectionFlag(repoCfg, "require_draft_mr");
+  if (repoDraft !== undefined) requireDraftMr = repoDraft;
+
+  const repoHost = readGitlabSectionString(repoCfg, "host");
+  if (repoHost !== undefined) host = repoHost;
+
+  const envDraft = parseEnvBoolOverride(env["GITLAB_REQUIRE_DRAFT_MR"]);
+  if (envDraft !== undefined) requireDraftMr = envDraft;
+
+  const envHost = env["GITLAB_HOST"];
+  if (envHost !== undefined && envHost !== "") host = envHost;
+
+  return { requireDraftMr, host };
+}

--- a/tests/connectors/gitlab/integration/framework.test.ts
+++ b/tests/connectors/gitlab/integration/framework.test.ts
@@ -351,6 +351,23 @@ describe("defaultSdk host precedence: secret > env > YAML > default", () => {
 
     expect(capturedUrl).toMatch(/^https:\/\/gitlab\.com\/api\/v4\//);
   });
+
+  it("GITLAB_HOST='' is treated as unset so YAML host wins", async () => {
+    const agentDir = path.join(tmpHome, ".gitlab-agent");
+    fs.mkdirSync(agentDir, { recursive: true });
+    fs.writeFileSync(path.join(agentDir, "config.yaml"), "gitlab:\n  host: https://yaml.example\n");
+    process.env["GITLAB_TOKEN"] = "tok";
+    process.env["GITLAB_HOST"] = "";
+
+    let capturedUrl = "";
+    const restore = stubFetch((url) => { capturedUrl = url; });
+    try {
+      const c = buildGitlabConnector();
+      await c.fetch("project_info", { namespace: "g", project: "p" });
+    } finally { restore(); }
+
+    expect(capturedUrl).toMatch(/^https:\/\/yaml\.example\/api\/v4\//);
+  });
 });
 
 describe("--curate flag", () => {

--- a/tests/connectors/gitlab/integration/framework.test.ts
+++ b/tests/connectors/gitlab/integration/framework.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Framework integration tests — policy gate, hardship logger, --curate.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildGitlabConnector } from "../../../../src/connectors/gitlab/index.js";
+import {
+  GitlabClient,
+  type GitlabClientOptions,
+} from "../../../../src/connectors/gitlab/lib/gitlab_client.js";
+
+let tmpHome: string;
+let tmpCwd: string;
+let origHome: string | undefined;
+let origCwd: string;
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "gl-home-"));
+  tmpCwd = fs.mkdtempSync(path.join(os.tmpdir(), "gl-cwd-"));
+  origHome = process.env["HOME"];
+  origCwd = process.cwd();
+  process.env["HOME"] = tmpHome;
+  process.chdir(tmpCwd);
+  delete process.env["GITLAB_TOKEN"];
+});
+
+afterEach(() => {
+  process.chdir(origCwd);
+  if (origHome !== undefined) process.env["HOME"] = origHome;
+  else delete process.env["HOME"];
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+  fs.rmSync(tmpCwd, { recursive: true, force: true });
+});
+
+function jsonResponse(body: unknown, init: { status?: number } = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeClient(
+  overrides: Partial<GitlabClientOptions>,
+  fetchMock: (url: string) => Promise<Response>,
+): GitlabClient {
+  return new GitlabClient({
+    token: "gl_test",
+    rateLimitPerMin: 100,
+    connectTimeoutMs: 50,
+    readTimeoutMs: 50,
+    fetchImpl: async (url) => fetchMock(String(url)),
+    sleepImpl: async () => {},
+    ...overrides,
+  });
+}
+
+function writeRepoPolicy(yaml: string) {
+  const dir = path.join(tmpCwd, ".gitlab-agent");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "config.yaml"), yaml);
+}
+
+describe("action surface — count + classifications", () => {
+  it("validActions.size === 33", () => {
+    const c = buildGitlabConnector({
+      sdk: async () => makeClient({}, async () => jsonResponse({})),
+      credentials: async () => ({ token: "gl_test", host: "https://gitlab.com" }),
+    });
+    expect(c.validActions.size).toBe(33);
+  });
+
+  it("spot-checks: merge_merge_request is in validActions", () => {
+    const c = buildGitlabConnector({
+      sdk: async () => makeClient({}, async () => jsonResponse({})),
+      credentials: async () => ({ token: "gl_test", host: "https://gitlab.com" }),
+    });
+    expect(c.validActions.has("merge_merge_request")).toBe(true);
+    expect(c.validActions.has("close_merge_request")).toBe(true);
+    expect(c.validActions.has("delete_note")).toBe(true);
+    expect(c.validActions.has("delete_release")).toBe(true);
+    expect(c.validActions.has("delete_release_link")).toBe(true);
+    expect(c.validActions.has("project_info")).toBe(true);
+  });
+});
+
+describe("default-policy gate", () => {
+  it("merge_merge_request returns denied under no operator config", async () => {
+    // No writeRepoPolicy — falls through to the connector's defaultPolicy (admin: denied).
+    const c = buildGitlabConnector({
+      sdk: async () =>
+        makeClient({}, async () => jsonResponse({ state: "merged", iid: 1 })),
+      credentials: async () => ({ token: "gl_test", host: "https://gitlab.com" }),
+    });
+    const r = await c.fetch("merge_merge_request", {
+      namespace: "mygroup",
+      project: "myrepo",
+      mr_iid: 1,
+    });
+    expect(r.status).toBe("denied");
+    expect((r as { reason?: string }).reason).toMatch(/admin/);
+  });
+
+  it("close_merge_request escalates by default (write+delete aspect)", async () => {
+    const c = buildGitlabConnector({
+      sdk: async () =>
+        makeClient({}, async () =>
+          jsonResponse({ iid: 1, title: "t", state: "closed" }),
+        ),
+      credentials: async () => ({ token: "gl_test", host: "https://gitlab.com" }),
+    });
+    const r = await c.fetch("close_merge_request", {
+      namespace: "mygroup",
+      project: "myrepo",
+      mr_iid: 1,
+    });
+    expect(r.status).toBe("escalate");
+  });
+});
+
+describe("operator opt-in", () => {
+  it("merge_merge_request returns escalate with policy.admin: escalate", async () => {
+    writeRepoPolicy("policy:\n  admin: escalate\n");
+    const c = buildGitlabConnector({
+      sdk: async () =>
+        makeClient({}, async () =>
+          jsonResponse({ state: "merged", iid: 1, sha: "abc" }),
+        ),
+      credentials: async () => ({ token: "gl_test", host: "https://gitlab.com" }),
+    });
+    const r = await c.fetch("merge_merge_request", {
+      namespace: "mygroup",
+      project: "myrepo",
+      mr_iid: 1,
+    });
+    expect(r.status).toBe("escalate");
+  });
+});
+
+describe("floor enforcement", () => {
+  it("policy.aspects.delete: success produces CONFIG_ERROR at startup", async () => {
+    writeRepoPolicy("policy:\n  aspects:\n    delete: success\n");
+    const c = buildGitlabConnector({
+      sdk: async () => makeClient({}, async () => jsonResponse({})),
+      credentials: async () => ({ token: "gl_test", host: "https://gitlab.com" }),
+    });
+    const result = await c.fetch("project_info", {
+      namespace: "mygroup",
+      project: "myrepo",
+    });
+    expect(result.status).toBe("error");
+    expect((result as { error_code?: string }).error_code).toBe("CONFIG_ERROR");
+    expect((result as { message?: string }).message).toMatch(/aspects.delete/);
+  });
+});
+
+describe("hardship logging integration", () => {
+  it("429 writes JSONL entry to user-global", async () => {
+    const client = makeClient({}, async () => jsonResponse({}, { status: 429 }));
+    const c = buildGitlabConnector({
+      sdk: async () => client,
+      credentials: async () => ({ token: "gl_test", host: "https://gitlab.com" }),
+    });
+    await c.fetch("project_info", { namespace: "mygroup", project: "myrepo" });
+
+    // Toolkit 3.0 uses tiered layout: global/hardships.jsonl (scope returns null → global tier).
+    const logPath = path.join(
+      tmpHome,
+      ".claude",
+      "connectors",
+      "gitlab",
+      "global",
+      "hardships.jsonl",
+    );
+    expect(fs.existsSync(logPath)).toBe(true);
+    const entry = JSON.parse(fs.readFileSync(logPath, "utf-8").trim());
+    expect(entry.connector).toBe("gitlab");
+    expect(entry.kind).toBe("rate_limited");
+  });
+});
+
+describe("--curate flag", () => {
+  it("prints a JSON snapshot and exits 0", async () => {
+    const c = buildGitlabConnector({
+      sdk: async () => makeClient({}, async () => jsonResponse({})),
+      credentials: async () => ({ token: "gl_test", host: "https://gitlab.com" }),
+    });
+    const writes: string[] = [];
+    const origWrite = process.stdout.write;
+    process.stdout.write = ((s: string | Uint8Array): boolean => {
+      writes.push(typeof s === "string" ? s : s.toString());
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      const code = await c.main(["--curate"]);
+      expect(code).toBe(0);
+      const parsed = JSON.parse(writes.join("").trim());
+      expect(parsed.connector).toBe("gitlab");
+    } finally {
+      process.stdout.write = origWrite;
+    }
+  });
+});

--- a/tests/connectors/gitlab/integration/framework.test.ts
+++ b/tests/connectors/gitlab/integration/framework.test.ts
@@ -4,12 +4,17 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildGitlabConnector } from "../../../../src/connectors/gitlab/index.js";
 import {
   GitlabClient,
   type GitlabClientOptions,
 } from "../../../../src/connectors/gitlab/lib/gitlab_client.js";
+
+vi.mock("narai-primitives/credentials", () => ({
+  resolveSecret: vi.fn(async () => null),
+}));
+import { resolveSecret } from "narai-primitives/credentials";
 
 let tmpHome: string;
 let tmpCwd: string;
@@ -253,6 +258,98 @@ describe("defaultSdk uses behavior.host (YAML-only host config)", () => {
     }
     expect(capturedUrl).toMatch(/^https:\/\/env\.example\/api\/v4\//);
     expect(capturedUrl).not.toContain("yaml.example");
+  });
+});
+
+describe("defaultSdk host precedence: secret > env > YAML > default", () => {
+  beforeEach(() => {
+    vi.mocked(resolveSecret).mockReset();
+    vi.mocked(resolveSecret).mockResolvedValue(null);
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  function stubFetch(onUrl: (url: string) => void): () => void {
+    const orig = globalThis.fetch;
+    globalThis.fetch = async (url: RequestInfo | URL): Promise<Response> => {
+      onUrl(String(url));
+      return new Response(
+        JSON.stringify({ id: 1, name: "p", path_with_namespace: "g/p", default_branch: "main" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    };
+    return () => { globalThis.fetch = orig; };
+  }
+
+  it("secret-provider host wins over env and YAML", async () => {
+    const agentDir = path.join(tmpHome, ".gitlab-agent");
+    fs.mkdirSync(agentDir, { recursive: true });
+    fs.writeFileSync(path.join(agentDir, "config.yaml"), "gitlab:\n  host: https://yaml.example\n");
+    process.env["GITLAB_TOKEN"] = "tok";
+    process.env["GITLAB_HOST"] = "https://env.example";
+
+    vi.mocked(resolveSecret).mockImplementation(async (key: string) => {
+      if (key === "GITLAB_TOKEN") return "tok";
+      if (key === "GITLAB_HOST") return "https://secret.example";
+      return null;
+    });
+
+    let capturedUrl = "";
+    const restore = stubFetch((url) => { capturedUrl = url; });
+    try {
+      const c = buildGitlabConnector();
+      await c.fetch("project_info", { namespace: "g", project: "p" });
+    } finally { restore(); }
+
+    expect(capturedUrl).toMatch(/^https:\/\/secret\.example\/api\/v4\//);
+  });
+
+  it("env host wins over YAML when no secret", async () => {
+    const agentDir = path.join(tmpHome, ".gitlab-agent");
+    fs.mkdirSync(agentDir, { recursive: true });
+    fs.writeFileSync(path.join(agentDir, "config.yaml"), "gitlab:\n  host: https://yaml.example\n");
+    process.env["GITLAB_TOKEN"] = "tok";
+    process.env["GITLAB_HOST"] = "https://env.example";
+
+    let capturedUrl = "";
+    const restore = stubFetch((url) => { capturedUrl = url; });
+    try {
+      const c = buildGitlabConnector();
+      await c.fetch("project_info", { namespace: "g", project: "p" });
+    } finally { restore(); }
+
+    expect(capturedUrl).toMatch(/^https:\/\/env\.example\/api\/v4\//);
+    expect(capturedUrl).not.toContain("yaml.example");
+  });
+
+  it("YAML host is used when no secret or env", async () => {
+    const agentDir = path.join(tmpHome, ".gitlab-agent");
+    fs.mkdirSync(agentDir, { recursive: true });
+    fs.writeFileSync(path.join(agentDir, "config.yaml"), "gitlab:\n  host: https://yaml.example\n");
+    process.env["GITLAB_TOKEN"] = "tok";
+    // GITLAB_HOST absent (cleared in outer beforeEach)
+
+    let capturedUrl = "";
+    const restore = stubFetch((url) => { capturedUrl = url; });
+    try {
+      const c = buildGitlabConnector();
+      await c.fetch("project_info", { namespace: "g", project: "p" });
+    } finally { restore(); }
+
+    expect(capturedUrl).toMatch(/^https:\/\/yaml\.example\/api\/v4\//);
+  });
+
+  it("falls back to https://gitlab.com when all sources are unset", async () => {
+    process.env["GITLAB_TOKEN"] = "tok";
+    // no secret, no env GITLAB_HOST, no YAML
+
+    let capturedUrl = "";
+    const restore = stubFetch((url) => { capturedUrl = url; });
+    try {
+      const c = buildGitlabConnector();
+      await c.fetch("project_info", { namespace: "g", project: "p" });
+    } finally { restore(); }
+
+    expect(capturedUrl).toMatch(/^https:\/\/gitlab\.com\/api\/v4\//);
   });
 });
 

--- a/tests/connectors/gitlab/integration/framework.test.ts
+++ b/tests/connectors/gitlab/integration/framework.test.ts
@@ -15,21 +15,30 @@ let tmpHome: string;
 let tmpCwd: string;
 let origHome: string | undefined;
 let origCwd: string;
+let origGitlabHost: string | undefined;
+let origGitlabToken: string | undefined;
 
 beforeEach(() => {
   tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "gl-home-"));
   tmpCwd = fs.mkdtempSync(path.join(os.tmpdir(), "gl-cwd-"));
   origHome = process.env["HOME"];
   origCwd = process.cwd();
+  origGitlabHost = process.env["GITLAB_HOST"];
+  origGitlabToken = process.env["GITLAB_TOKEN"];
   process.env["HOME"] = tmpHome;
   process.chdir(tmpCwd);
   delete process.env["GITLAB_TOKEN"];
+  delete process.env["GITLAB_HOST"];
 });
 
 afterEach(() => {
   process.chdir(origCwd);
   if (origHome !== undefined) process.env["HOME"] = origHome;
   else delete process.env["HOME"];
+  if (origGitlabHost !== undefined) process.env["GITLAB_HOST"] = origGitlabHost;
+  else delete process.env["GITLAB_HOST"];
+  if (origGitlabToken !== undefined) process.env["GITLAB_TOKEN"] = origGitlabToken;
+  else delete process.env["GITLAB_TOKEN"];
   fs.rmSync(tmpHome, { recursive: true, force: true });
   fs.rmSync(tmpCwd, { recursive: true, force: true });
 });
@@ -177,6 +186,73 @@ describe("hardship logging integration", () => {
     const entry = JSON.parse(fs.readFileSync(logPath, "utf-8").trim());
     expect(entry.connector).toBe("gitlab");
     expect(entry.kind).toBe("rate_limited");
+  });
+});
+
+describe("defaultSdk uses behavior.host (YAML-only host config)", () => {
+  it("picks up gitlab.host from ~/.gitlab-agent/config.yaml when GITLAB_HOST env is absent", async () => {
+    // Write YAML with a custom host to tmpHome (which is already set as HOME)
+    const agentDir = path.join(tmpHome, ".gitlab-agent");
+    fs.mkdirSync(agentDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(agentDir, "config.yaml"),
+      "gitlab:\n  host: https://gitlab.mycorp\n",
+    );
+    process.env["GITLAB_TOKEN"] = "glpat_yaml_test";
+    // GITLAB_HOST is absent (cleared in beforeEach)
+
+    let capturedUrl = "";
+    // Stub globalThis.fetch so defaultSdk's GitlabClient can make the request
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url: RequestInfo | URL): Promise<Response> => {
+      capturedUrl = String(url);
+      return new Response(
+        JSON.stringify({ id: 1, name: "p", path_with_namespace: "g/p", default_branch: "main" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    };
+    try {
+      // No sdk override — forces defaultSdk to run
+      const c = buildGitlabConnector({
+        credentials: async () => ({ token: "glpat_yaml_test", host: "https://gitlab.mycorp" }),
+      });
+      await c.fetch("project_info", { namespace: "g", project: "p" });
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+    expect(capturedUrl).toMatch(/^https:\/\/gitlab\.mycorp\/api\/v4\//);
+  });
+
+  it("GITLAB_HOST env wins over YAML host", async () => {
+    const agentDir = path.join(tmpHome, ".gitlab-agent");
+    fs.mkdirSync(agentDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(agentDir, "config.yaml"),
+      "gitlab:\n  host: https://yaml.example\n",
+    );
+    process.env["GITLAB_TOKEN"] = "glpat_env_test";
+    process.env["GITLAB_HOST"] = "https://env.example";
+
+    let capturedUrl = "";
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url: RequestInfo | URL): Promise<Response> => {
+      capturedUrl = String(url);
+      return new Response(
+        JSON.stringify({ id: 1, name: "p", path_with_namespace: "g/p", default_branch: "main" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    };
+    try {
+      // No sdk override — forces defaultSdk to run; behavior.host should be env value
+      const c = buildGitlabConnector({
+        credentials: async () => ({ token: "glpat_env_test", host: "https://env.example" }),
+      });
+      await c.fetch("project_info", { namespace: "g", project: "p" });
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+    expect(capturedUrl).toMatch(/^https:\/\/env\.example\/api\/v4\//);
+    expect(capturedUrl).not.toContain("yaml.example");
   });
 });
 

--- a/tests/connectors/gitlab/unit/_fields.test.ts
+++ b/tests/connectors/gitlab/unit/_fields.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Tests for shared Zod field schemas in gitlab/actions/_fields.ts.
+ * Focuses on namespaceField which was extended to support subgroup paths.
+ */
+import { describe, expect, it } from "vitest";
+import { namespaceField } from "../../../../src/connectors/gitlab/actions/_fields.js";
+
+describe("namespaceField", () => {
+  it("accepts a simple namespace", () => {
+    expect(() => namespaceField.parse("mycompany")).not.toThrow();
+  });
+
+  it("accepts a subgroup namespace with one slash", () => {
+    expect(() => namespaceField.parse("mycompany/backend")).not.toThrow();
+  });
+
+  it("accepts a deeply nested subgroup namespace", () => {
+    expect(() => namespaceField.parse("mycompany/backend/infra")).not.toThrow();
+  });
+
+  it("rejects a namespace with a leading slash", () => {
+    expect(() => namespaceField.parse("/mycompany")).toThrow();
+  });
+
+  it("rejects a namespace with a trailing slash", () => {
+    expect(() => namespaceField.parse("mycompany/")).toThrow();
+  });
+
+  it("rejects a namespace with consecutive slashes", () => {
+    expect(() => namespaceField.parse("mycompany//backend")).toThrow();
+  });
+});

--- a/tests/connectors/gitlab/unit/actions_issues.test.ts
+++ b/tests/connectors/gitlab/unit/actions_issues.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Tests for gitlab/actions/issues.ts — classification, schemas, and handlers
+ * for create_issue, update_issue, and close_issue.
+ */
+import { describe, expect, it } from "vitest";
+import type { ActionSpec } from "narai-primitives/toolkit";
+import { buildIssuesActions } from "../../../../src/connectors/gitlab/actions/issues.js";
+import type { GitlabClient } from "../../../../src/connectors/gitlab/lib/gitlab_client.js";
+
+function fakeSdk(overrides: Partial<GitlabClient> = {}): GitlabClient {
+  return overrides as unknown as GitlabClient;
+}
+
+function runHandler<P>(
+  spec: ActionSpec<P, GitlabClient>,
+  params: unknown,
+  sdk: GitlabClient,
+): Promise<unknown> {
+  const parsed = spec.params.parse(params) as P;
+  return spec.handler(parsed, { sdk } as Parameters<typeof spec.handler>[1]);
+}
+
+const baseDeps = {
+  behavior: { requireDraftMr: false, host: "https://gitlab.com" },
+};
+
+const issueResponse = {
+  iid: 7,
+  title: "Test issue",
+  state: "opened",
+  author: { username: "alice" },
+  description: "A description",
+  labels: ["bug", "v2"],
+  web_url: "https://gitlab.com/g/p/-/issues/7",
+  updated_at: "2024-01-01T00:00:00Z",
+};
+
+// ── Classification ────────────────────────────────────────────────────────────
+
+describe("buildIssuesActions — classification", () => {
+  const actions = buildIssuesActions(baseDeps);
+
+  it("create_issue is write", () => {
+    expect(actions["create_issue"]?.classify).toEqual({ kind: "write" });
+  });
+
+  it("update_issue is write", () => {
+    expect(actions["update_issue"]?.classify).toEqual({ kind: "write" });
+  });
+
+  it("close_issue is write + delete aspect", () => {
+    expect(actions["close_issue"]?.classify).toEqual({
+      kind: "write",
+      aspects: ["delete"],
+    });
+  });
+});
+
+// ── create_issue ──────────────────────────────────────────────────────────────
+
+describe("create_issue", () => {
+  it("creates issue with required title and returns envelope", async () => {
+    let captured: unknown;
+    const sdk = fakeSdk({
+      createIssue: async (_ns, _proj, body) => {
+        captured = body;
+        return { ok: true as const, status: 201, data: { ...issueResponse } };
+      },
+    });
+    const actions = buildIssuesActions(baseDeps);
+    const result = (await runHandler(
+      actions["create_issue"]!,
+      { namespace: "mygroup", project: "myproject", title: "Test issue" },
+      sdk,
+    )) as Record<string, unknown>;
+
+    expect(result["iid"]).toBe(7);
+    expect(result["title"]).toBe("Test issue");
+    expect(result["state"]).toBe("opened");
+    expect(result["author"]).toBe("alice");
+    expect((captured as Record<string, unknown>)["title"]).toBe("Test issue");
+  });
+
+  it("passes optional fields including labels as CSV", async () => {
+    let captured: Record<string, unknown> = {};
+    const sdk = fakeSdk({
+      createIssue: async (_ns, _proj, body) => {
+        captured = body as Record<string, unknown>;
+        return { ok: true as const, status: 201, data: { ...issueResponse } };
+      },
+    });
+    const actions = buildIssuesActions(baseDeps);
+    await runHandler(
+      actions["create_issue"]!,
+      {
+        namespace: "g",
+        project: "p",
+        title: "T",
+        description: "Desc",
+        labels: ["bug", "help wanted"],
+        assignee_ids: [1, 2],
+        milestone_id: 10,
+        due_date: "2024-12-31",
+      },
+      sdk,
+    );
+
+    expect(captured["description"]).toBe("Desc");
+    expect(captured["labels"]).toBe("bug,help wanted");
+    expect(captured["assignee_ids"]).toEqual([1, 2]);
+    expect(captured["milestone_id"]).toBe(10);
+    expect(captured["due_date"]).toBe("2024-12-31");
+  });
+
+  it("schema rejects empty title", () => {
+    const actions = buildIssuesActions(baseDeps);
+    expect(() =>
+      actions["create_issue"]!.params.parse({
+        namespace: "g",
+        project: "p",
+        title: "",
+      }),
+    ).toThrow();
+  });
+
+  it("schema rejects missing title", () => {
+    const actions = buildIssuesActions(baseDeps);
+    expect(() =>
+      actions["create_issue"]!.params.parse({
+        namespace: "g",
+        project: "p",
+      }),
+    ).toThrow();
+  });
+});
+
+// ── update_issue ──────────────────────────────────────────────────────────────
+
+describe("update_issue", () => {
+  it("updates title and passes labels as CSV", async () => {
+    let capturedBody: Record<string, unknown> = {};
+    const sdk = fakeSdk({
+      updateIssue: async (_ns, _proj, _iid, body) => {
+        capturedBody = body as Record<string, unknown>;
+        return {
+          ok: true as const,
+          status: 200,
+          data: { ...issueResponse, title: "New title" },
+        };
+      },
+    });
+    const actions = buildIssuesActions(baseDeps);
+    const result = (await runHandler(
+      actions["update_issue"]!,
+      {
+        namespace: "g",
+        project: "p",
+        iid: 7,
+        title: "New title",
+        labels: ["enhancement"],
+      },
+      sdk,
+    )) as Record<string, unknown>;
+
+    expect(result["title"]).toBe("New title");
+    expect(capturedBody["title"]).toBe("New title");
+    expect(capturedBody["labels"]).toBe("enhancement");
+  });
+
+  it("schema rejects state_event=close", () => {
+    const actions = buildIssuesActions(baseDeps);
+    expect(() =>
+      actions["update_issue"]!.params.parse({
+        namespace: "g",
+        project: "p",
+        iid: 7,
+        state_event: "close",
+      }),
+    ).toThrow();
+  });
+
+  it("schema allows state_event=reopen", () => {
+    const actions = buildIssuesActions(baseDeps);
+    expect(() =>
+      actions["update_issue"]!.params.parse({
+        namespace: "g",
+        project: "p",
+        iid: 7,
+        state_event: "reopen",
+      }),
+    ).not.toThrow();
+  });
+
+  it("omits undefined optional fields from body", async () => {
+    let capturedBody: Record<string, unknown> = {};
+    const sdk = fakeSdk({
+      updateIssue: async (_ns, _proj, _iid, body) => {
+        capturedBody = body as Record<string, unknown>;
+        return { ok: true as const, status: 200, data: { ...issueResponse } };
+      },
+    });
+    const actions = buildIssuesActions(baseDeps);
+    await runHandler(
+      actions["update_issue"]!,
+      { namespace: "g", project: "p", iid: 7, title: "Only title" },
+      sdk,
+    );
+    expect(capturedBody["description"]).toBeUndefined();
+    expect(capturedBody["labels"]).toBeUndefined();
+    expect(capturedBody["assignee_ids"]).toBeUndefined();
+  });
+});
+
+// ── close_issue ───────────────────────────────────────────────────────────────
+
+describe("close_issue", () => {
+  it("calls closeIssue and returns closed:true", async () => {
+    const sdk = fakeSdk({
+      closeIssue: async () => ({
+        ok: true as const,
+        status: 200,
+        data: { ...issueResponse, state: "closed" },
+      }),
+    });
+    const actions = buildIssuesActions(baseDeps);
+    const result = (await runHandler(
+      actions["close_issue"]!,
+      { namespace: "g", project: "p", iid: 7 },
+      sdk,
+    )) as Record<string, unknown>;
+
+    expect(result["closed"]).toBe(true);
+    expect(result["state"]).toBe("closed");
+    expect(result["iid"]).toBe(7);
+  });
+
+  it("envelope includes expected fields", async () => {
+    const sdk = fakeSdk({
+      closeIssue: async () => ({
+        ok: true as const,
+        status: 200,
+        data: { ...issueResponse, state: "closed" },
+      }),
+    });
+    const actions = buildIssuesActions(baseDeps);
+    const result = (await runHandler(
+      actions["close_issue"]!,
+      { namespace: "g", project: "p", iid: 7 },
+      sdk,
+    )) as Record<string, unknown>;
+
+    expect(result["author"]).toBe("alice");
+    expect(result["labels"]).toEqual(["bug", "v2"]);
+    expect(result["web_url"]).toBe("https://gitlab.com/g/p/-/issues/7");
+  });
+});

--- a/tests/connectors/gitlab/unit/actions_merges.test.ts
+++ b/tests/connectors/gitlab/unit/actions_merges.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Tests for gitlab/actions/merges.ts — classification, schemas,
+ * require_draft_mr enforcement, and conflict handling.
+ */
+import { describe, expect, it } from "vitest";
+import type { ActionSpec } from "narai-primitives/toolkit";
+import { buildMergesActions } from "../../../../src/connectors/gitlab/actions/merges.js";
+import type { GitlabClient } from "../../../../src/connectors/gitlab/lib/gitlab_client.js";
+
+function fakeSdk(overrides: Partial<GitlabClient> = {}): GitlabClient {
+  return overrides as unknown as GitlabClient;
+}
+
+function runHandler<P>(
+  spec: ActionSpec<P, GitlabClient>,
+  params: unknown,
+  sdk: GitlabClient,
+): Promise<unknown> {
+  const parsed = spec.params.parse(params) as P;
+  return spec.handler(parsed, { sdk } as Parameters<typeof spec.handler>[1]);
+}
+
+const baseDeps = {
+  behavior: { requireDraftMr: false, host: "https://gitlab.com" },
+};
+
+const draftDeps = {
+  behavior: { requireDraftMr: true, host: "https://gitlab.com" },
+};
+
+const mrResponse = {
+  iid: 42,
+  title: "My MR",
+  state: "opened",
+  draft: false,
+  source_branch: "feat",
+  target_branch: "main",
+  sha: "abc1234",
+  description: "desc",
+  web_url: "https://gitlab.com/g/p/-/merge_requests/42",
+  updated_at: "2024-01-01T00:00:00Z",
+  author: { username: "alice" },
+};
+
+// ── Classification ────────────────────────────────────────────────────────────
+
+describe("buildMergesActions — classification", () => {
+  const actions = buildMergesActions(baseDeps);
+
+  it("create_merge_request is write", () => {
+    expect(actions["create_merge_request"]?.classify).toEqual({ kind: "write" });
+  });
+
+  it("update_merge_request is write", () => {
+    expect(actions["update_merge_request"]?.classify).toEqual({ kind: "write" });
+  });
+
+  it("close_merge_request is write + delete aspect", () => {
+    expect(actions["close_merge_request"]?.classify).toEqual({
+      kind: "write",
+      aspects: ["delete"],
+    });
+  });
+
+  it("merge_merge_request is admin", () => {
+    expect(actions["merge_merge_request"]?.classify).toEqual({ kind: "admin" });
+  });
+});
+
+// ── create_merge_request ──────────────────────────────────────────────────────
+
+describe("create_merge_request", () => {
+  it("creates MR with required fields", async () => {
+    let captured: unknown;
+    const sdk = fakeSdk({
+      createMergeRequest: async (_ns, _proj, body) => {
+        captured = body;
+        return { ok: true as const, status: 201, data: { ...mrResponse } };
+      },
+    });
+    const actions = buildMergesActions(baseDeps);
+    const result = await runHandler(
+      actions["create_merge_request"]!,
+      {
+        namespace: "mygroup",
+        project: "myproject",
+        source_branch: "feat",
+        target_branch: "main",
+        title: "My MR",
+      },
+      sdk,
+    );
+    expect(result).toMatchObject({ iid: 42, title: "My MR", state: "opened" });
+    expect((captured as Record<string, unknown>)["draft"]).toBe(false);
+  });
+
+  it("does not set draft_forced_by_config when draft not requested and requireDraftMr=false", async () => {
+    const sdk = fakeSdk({
+      createMergeRequest: async () => ({
+        ok: true as const,
+        status: 201,
+        data: { ...mrResponse },
+      }),
+    });
+    const actions = buildMergesActions(baseDeps);
+    const result = (await runHandler(
+      actions["create_merge_request"]!,
+      {
+        namespace: "g",
+        project: "p",
+        source_branch: "feat",
+        target_branch: "main",
+        title: "T",
+      },
+      sdk,
+    )) as Record<string, unknown>;
+    expect(result["draft_forced_by_config"]).toBeUndefined();
+  });
+
+  it("forces draft=true and returns draft_forced_by_config when requireDraftMr=true and caller sent draft=false", async () => {
+    let capturedBody: Record<string, unknown> = {};
+    const sdk = fakeSdk({
+      createMergeRequest: async (_ns, _proj, body) => {
+        capturedBody = body as Record<string, unknown>;
+        return {
+          ok: true as const,
+          status: 201,
+          data: { ...mrResponse, draft: true },
+        };
+      },
+    });
+    const actions = buildMergesActions(draftDeps);
+    const result = (await runHandler(
+      actions["create_merge_request"]!,
+      {
+        namespace: "g",
+        project: "p",
+        source_branch: "feat",
+        target_branch: "main",
+        title: "T",
+        draft: false,
+      },
+      sdk,
+    )) as Record<string, unknown>;
+    expect(capturedBody["draft"]).toBe(true);
+    expect(result["draft_forced_by_config"]).toBe(true);
+  });
+
+  it("does NOT set draft_forced_by_config when caller already requested draft=true and requireDraftMr=true", async () => {
+    const sdk = fakeSdk({
+      createMergeRequest: async () => ({
+        ok: true as const,
+        status: 201,
+        data: { ...mrResponse, draft: true },
+      }),
+    });
+    const actions = buildMergesActions(draftDeps);
+    const result = (await runHandler(
+      actions["create_merge_request"]!,
+      {
+        namespace: "g",
+        project: "p",
+        source_branch: "feat",
+        target_branch: "main",
+        title: "T",
+        draft: true,
+      },
+      sdk,
+    )) as Record<string, unknown>;
+    expect(result["draft_forced_by_config"]).toBeUndefined();
+  });
+
+  it("schema rejects empty title", () => {
+    const actions = buildMergesActions(baseDeps);
+    expect(() =>
+      actions["create_merge_request"]!.params.parse({
+        namespace: "g",
+        project: "p",
+        source_branch: "feat",
+        target_branch: "main",
+        title: "",
+      }),
+    ).toThrow();
+  });
+});
+
+// ── update_merge_request ──────────────────────────────────────────────────────
+
+describe("update_merge_request", () => {
+  it("updates title and description", async () => {
+    let capturedBody: Record<string, unknown> = {};
+    const sdk = fakeSdk({
+      updateMergeRequest: async (_ns, _proj, _iid, body) => {
+        capturedBody = body as Record<string, unknown>;
+        return { ok: true as const, status: 200, data: { ...mrResponse, title: "New title" } };
+      },
+    });
+    const actions = buildMergesActions(baseDeps);
+    const result = (await runHandler(
+      actions["update_merge_request"]!,
+      {
+        namespace: "g",
+        project: "p",
+        mr_iid: 42,
+        title: "New title",
+        description: "Updated",
+      },
+      sdk,
+    )) as Record<string, unknown>;
+    expect(result["title"]).toBe("New title");
+    expect(capturedBody["title"]).toBe("New title");
+    expect(capturedBody["description"]).toBe("Updated");
+  });
+
+  it("schema rejects state_event=close", () => {
+    const actions = buildMergesActions(baseDeps);
+    expect(() =>
+      actions["update_merge_request"]!.params.parse({
+        namespace: "g",
+        project: "p",
+        mr_iid: 1,
+        state_event: "close",
+      }),
+    ).toThrow();
+  });
+
+  it("schema allows state_event=reopen", () => {
+    const actions = buildMergesActions(baseDeps);
+    expect(() =>
+      actions["update_merge_request"]!.params.parse({
+        namespace: "g",
+        project: "p",
+        mr_iid: 1,
+        state_event: "reopen",
+      }),
+    ).not.toThrow();
+  });
+});
+
+// ── close_merge_request ───────────────────────────────────────────────────────
+
+describe("close_merge_request", () => {
+  it("calls closeMergeRequest and returns closed:true", async () => {
+    const sdk = fakeSdk({
+      closeMergeRequest: async () => ({
+        ok: true as const,
+        status: 200,
+        data: { ...mrResponse, state: "closed" },
+      }),
+    });
+    const actions = buildMergesActions(baseDeps);
+    const result = (await runHandler(
+      actions["close_merge_request"]!,
+      { namespace: "g", project: "p", mr_iid: 42 },
+      sdk,
+    )) as Record<string, unknown>;
+    expect(result["closed"]).toBe(true);
+    expect(result["state"]).toBe("closed");
+  });
+});
+
+// ── merge_merge_request ───────────────────────────────────────────────────────
+
+describe("merge_merge_request", () => {
+  it("returns merge result on 200", async () => {
+    const sdk = fakeSdk({
+      mergeMergeRequest: async () => ({
+        ok: true as const,
+        status: 200,
+        data: { sha: "deadbeef", merged: true, message: "merged" },
+      }),
+    });
+    const actions = buildMergesActions(baseDeps);
+    const result = (await runHandler(
+      actions["merge_merge_request"]!,
+      { namespace: "g", project: "p", mr_iid: 42 },
+      sdk,
+    )) as Record<string, unknown>;
+    expect(result["merged"]).toBe(true);
+    expect(result["merge_sha"]).toBe("deadbeef");
+  });
+
+  it("throws CONFLICT on 405", async () => {
+    const sdk = fakeSdk({
+      mergeMergeRequest: async () => ({
+        ok: false as const,
+        status: 405,
+        code: "HTTP_ERROR" as const,
+        message: "Not Allowed",
+        retriable: false,
+      }),
+    });
+    const actions = buildMergesActions(baseDeps);
+    await expect(
+      runHandler(
+        actions["merge_merge_request"]!,
+        { namespace: "g", project: "p", mr_iid: 42 },
+        sdk,
+      ),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+  });
+
+  it("throws CONFLICT on 406", async () => {
+    const sdk = fakeSdk({
+      mergeMergeRequest: async () => ({
+        ok: false as const,
+        status: 406,
+        code: "HTTP_ERROR" as const,
+        message: "Not Acceptable",
+        retriable: false,
+      }),
+    });
+    const actions = buildMergesActions(baseDeps);
+    await expect(
+      runHandler(
+        actions["merge_merge_request"]!,
+        { namespace: "g", project: "p", mr_iid: 42 },
+        sdk,
+      ),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+  });
+
+  it("throws CONFLICT on 409", async () => {
+    const sdk = fakeSdk({
+      mergeMergeRequest: async () => ({
+        ok: false as const,
+        status: 409,
+        code: "HTTP_ERROR" as const,
+        message: "Conflict",
+        retriable: false,
+      }),
+    });
+    const actions = buildMergesActions(baseDeps);
+    await expect(
+      runHandler(
+        actions["merge_merge_request"]!,
+        { namespace: "g", project: "p", mr_iid: 42 },
+        sdk,
+      ),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+  });
+});

--- a/tests/connectors/gitlab/unit/actions_notes.test.ts
+++ b/tests/connectors/gitlab/unit/actions_notes.test.ts
@@ -219,6 +219,40 @@ describe("add_note — handler", () => {
   });
 });
 
+// ── update_note — schema ──────────────────────────────────────────────────────
+
+describe("update_note — schema validation", () => {
+  const actions = buildNotesActions(deps);
+  const spec = actions["update_note"]!;
+
+  it("rejects discussion_id when noteable_type is 'issue'", () => {
+    expect(() =>
+      spec.params.parse({
+        namespace: "mygroup",
+        project: "myproject",
+        noteable_type: "issue",
+        noteable_iid: 1,
+        note_id: 42,
+        body: "text",
+        discussion_id: "disc-abc",
+      }),
+    ).toThrow("discussion_id is only valid when noteable_type is 'merge_request'");
+  });
+
+  it("accepts discussion_id when noteable_type is 'merge_request'", () => {
+    const parsed = spec.params.parse({
+      namespace: "mygroup",
+      project: "myproject",
+      noteable_type: "merge_request",
+      noteable_iid: 5,
+      note_id: 42,
+      body: "text",
+      discussion_id: "disc-abc",
+    });
+    expect(parsed).toMatchObject({ discussion_id: "disc-abc" });
+  });
+});
+
 // ── update_note — handler ─────────────────────────────────────────────────────
 
 describe("update_note — handler", () => {
@@ -271,6 +305,30 @@ describe("update_note — handler", () => {
     expect(result).toMatchObject({ body: "MR updated" });
   });
 
+  it("passes discussion_id to sdk.updateNote when provided", async () => {
+    let capturedOpts: unknown;
+    const sdk = fakeSdk({
+      updateNote: async (_ns, _proj, _type, _iid, _noteId, _body, opts) => {
+        capturedOpts = opts;
+        return { ok: true, status: 200, data: noteStub };
+      },
+    });
+    await runHandler(
+      spec,
+      {
+        namespace: "mygroup",
+        project: "myproject",
+        noteable_type: "merge_request",
+        noteable_iid: 5,
+        note_id: 42,
+        body: "Updated",
+        discussion_id: "disc-abc",
+      },
+      sdk,
+    );
+    expect((capturedOpts as Record<string, unknown>)["discussionId"]).toBe("disc-abc");
+  });
+
   it("throws on HTTP error", async () => {
     const sdk = fakeSdk({
       updateNote: async () => ({ ok: false, status: 404, data: null }),
@@ -289,6 +347,38 @@ describe("update_note — handler", () => {
         sdk,
       ),
     ).rejects.toThrow();
+  });
+});
+
+// ── delete_note — schema ──────────────────────────────────────────────────────
+
+describe("delete_note — schema validation", () => {
+  const actions = buildNotesActions(deps);
+  const spec = actions["delete_note"]!;
+
+  it("rejects discussion_id when noteable_type is 'issue'", () => {
+    expect(() =>
+      spec.params.parse({
+        namespace: "mygroup",
+        project: "myproject",
+        noteable_type: "issue",
+        noteable_iid: 1,
+        note_id: 42,
+        discussion_id: "disc-abc",
+      }),
+    ).toThrow("discussion_id is only valid when noteable_type is 'merge_request'");
+  });
+
+  it("accepts discussion_id when noteable_type is 'merge_request'", () => {
+    const parsed = spec.params.parse({
+      namespace: "mygroup",
+      project: "myproject",
+      noteable_type: "merge_request",
+      noteable_iid: 5,
+      note_id: 42,
+      discussion_id: "disc-abc",
+    });
+    expect(parsed).toMatchObject({ discussion_id: "disc-abc" });
   });
 });
 
@@ -332,6 +422,29 @@ describe("delete_note — handler", () => {
       sdk,
     );
     expect(result).toEqual({ note_id: 7, deleted: true });
+  });
+
+  it("passes discussion_id to sdk.deleteNote when provided", async () => {
+    let capturedOpts: unknown;
+    const sdk = fakeSdk({
+      deleteNote: async (_ns, _proj, _type, _iid, _noteId, opts) => {
+        capturedOpts = opts;
+        return { ok: true, status: 204, data: null };
+      },
+    });
+    await runHandler(
+      spec,
+      {
+        namespace: "mygroup",
+        project: "myproject",
+        noteable_type: "merge_request",
+        noteable_iid: 5,
+        note_id: 7,
+        discussion_id: "disc-xyz",
+      },
+      sdk,
+    );
+    expect((capturedOpts as Record<string, unknown>)["discussionId"]).toBe("disc-xyz");
   });
 
   it("throws on HTTP error", async () => {

--- a/tests/connectors/gitlab/unit/actions_notes.test.ts
+++ b/tests/connectors/gitlab/unit/actions_notes.test.ts
@@ -72,6 +72,7 @@ describe("add_note — schema validation", () => {
           head_sha: "aabbccd",
           position_type: "text",
           new_path: "src/file.ts",
+          old_path: "src/file.ts",
           new_line: 10,
         },
       }),
@@ -91,10 +92,71 @@ describe("add_note — schema validation", () => {
         head_sha: "aabbccd",
         position_type: "text",
         new_path: "src/file.ts",
+        old_path: "src/file.ts",
         new_line: 10,
       },
     });
     expect(parsed).toMatchObject({ noteable_type: "merge_request", body: "diff comment" });
+  });
+
+  it("rejects position missing old_path", () => {
+    expect(() =>
+      spec.params.parse({
+        namespace: "mygroup",
+        project: "myproject",
+        noteable_type: "merge_request",
+        noteable_iid: 5,
+        body: "diff comment",
+        position: {
+          base_sha: "aabbccd",
+          start_sha: "aabbccd",
+          head_sha: "aabbccd",
+          position_type: "text",
+          new_path: "src/file.ts",
+          new_line: 10,
+        },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects position missing both old_line and new_line", () => {
+    expect(() =>
+      spec.params.parse({
+        namespace: "mygroup",
+        project: "myproject",
+        noteable_type: "merge_request",
+        noteable_iid: 5,
+        body: "diff comment",
+        position: {
+          base_sha: "aabbccd",
+          start_sha: "aabbccd",
+          head_sha: "aabbccd",
+          position_type: "text",
+          new_path: "src/file.ts",
+          old_path: "src/file.ts",
+        },
+      }),
+    ).toThrow("at least one of old_line or new_line must be set");
+  });
+
+  it("accepts position with only old_line set (removed-line context)", () => {
+    const parsed = spec.params.parse({
+      namespace: "mygroup",
+      project: "myproject",
+      noteable_type: "merge_request",
+      noteable_iid: 5,
+      body: "removed line comment",
+      position: {
+        base_sha: "aabbccd",
+        start_sha: "aabbccd",
+        head_sha: "aabbccd",
+        position_type: "text",
+        new_path: "src/file.ts",
+        old_path: "src/file.ts",
+        old_line: 5,
+      },
+    });
+    expect(parsed).toMatchObject({ body: "removed line comment" });
   });
 
   it("accepts body-only note with no position for 'issue'", () => {
@@ -191,6 +253,7 @@ describe("add_note — handler", () => {
           head_sha: "aabbccd",
           position_type: "text",
           new_path: "src/file.ts",
+          old_path: "src/file.ts",
           new_line: 10,
         },
       },

--- a/tests/connectors/gitlab/unit/actions_notes.test.ts
+++ b/tests/connectors/gitlab/unit/actions_notes.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Tests for gitlab/actions/notes.ts — classification, schema validation,
+ * and handler envelope shape for add_note, update_note, delete_note.
+ */
+import { describe, expect, it } from "vitest";
+import type { ActionSpec } from "narai-primitives/toolkit";
+import { buildNotesActions } from "../../../../src/connectors/gitlab/actions/notes.js";
+import type { GitlabClient } from "../../../../src/connectors/gitlab/lib/gitlab_client.js";
+
+function fakeSdk(overrides: Partial<GitlabClient> = {}): GitlabClient {
+  return overrides as unknown as GitlabClient;
+}
+
+function runHandler<P>(
+  spec: ActionSpec<P, GitlabClient>,
+  params: unknown,
+  sdk: GitlabClient,
+): Promise<unknown> {
+  const parsed = spec.params.parse(params) as P;
+  return spec.handler(parsed, { sdk } as Parameters<typeof spec.handler>[1]);
+}
+
+const deps = { behavior: { requireDraftMr: false, host: "https://gitlab.com" } };
+
+const noteStub = {
+  id: 42,
+  body: "Hello world",
+  author: { username: "alice" },
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+  system: false,
+};
+
+// ── Classification ────────────────────────────────────────────────────────────
+
+describe("buildNotesActions — classification", () => {
+  const actions = buildNotesActions(deps);
+
+  it("add_note is write", () => {
+    expect(actions["add_note"]?.classify).toEqual({ kind: "write" });
+  });
+
+  it("update_note is write", () => {
+    expect(actions["update_note"]?.classify).toEqual({ kind: "write" });
+  });
+
+  it("delete_note is write with aspects: ['delete']", () => {
+    expect(actions["delete_note"]?.classify).toEqual({
+      kind: "write",
+      aspects: ["delete"],
+    });
+  });
+});
+
+// ── Schema: position requires merge_request ───────────────────────────────────
+
+describe("add_note — schema validation", () => {
+  const actions = buildNotesActions(deps);
+  const spec = actions["add_note"]!;
+
+  it("rejects position when noteable_type is 'issue'", () => {
+    expect(() =>
+      spec.params.parse({
+        namespace: "mygroup",
+        project: "myproject",
+        noteable_type: "issue",
+        noteable_iid: 1,
+        body: "comment",
+        position: {
+          base_sha: "aabbccd",
+          start_sha: "aabbccd",
+          head_sha: "aabbccd",
+          position_type: "text",
+          new_path: "src/file.ts",
+          new_line: 10,
+        },
+      }),
+    ).toThrow("position is only valid when noteable_type is 'merge_request'");
+  });
+
+  it("accepts position when noteable_type is 'merge_request'", () => {
+    const parsed = spec.params.parse({
+      namespace: "mygroup",
+      project: "myproject",
+      noteable_type: "merge_request",
+      noteable_iid: 5,
+      body: "diff comment",
+      position: {
+        base_sha: "aabbccd",
+        start_sha: "aabbccd",
+        head_sha: "aabbccd",
+        position_type: "text",
+        new_path: "src/file.ts",
+        new_line: 10,
+      },
+    });
+    expect(parsed).toMatchObject({ noteable_type: "merge_request", body: "diff comment" });
+  });
+
+  it("accepts body-only note with no position for 'issue'", () => {
+    const parsed = spec.params.parse({
+      namespace: "mygroup",
+      project: "myproject",
+      noteable_type: "issue",
+      noteable_iid: 3,
+      body: "plain comment",
+    });
+    expect(parsed).toMatchObject({ noteable_type: "issue", body: "plain comment" });
+  });
+
+  it("rejects empty body", () => {
+    expect(() =>
+      spec.params.parse({
+        namespace: "mygroup",
+        project: "myproject",
+        noteable_type: "issue",
+        noteable_iid: 1,
+        body: "",
+      }),
+    ).toThrow();
+  });
+});
+
+// ── add_note — handler ────────────────────────────────────────────────────────
+
+describe("add_note — handler", () => {
+  const actions = buildNotesActions(deps);
+  const spec = actions["add_note"]!;
+
+  it("calls addNote and returns note envelope (issue)", async () => {
+    const sdk = fakeSdk({
+      addNote: async () => ({ ok: true, status: 201, data: noteStub }),
+    });
+    const result = await runHandler(
+      spec,
+      {
+        namespace: "mygroup",
+        project: "myproject",
+        noteable_type: "issue",
+        noteable_iid: 3,
+        body: "Hello world",
+      },
+      sdk,
+    );
+    expect(result).toEqual({
+      id: 42,
+      body: "Hello world",
+      author: "alice",
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-01T00:00:00Z",
+    });
+  });
+
+  it("calls addNote and returns note envelope (merge_request)", async () => {
+    const sdk = fakeSdk({
+      addNote: async () => ({ ok: true, status: 201, data: noteStub }),
+    });
+    const result = await runHandler(
+      spec,
+      {
+        namespace: "mygroup",
+        project: "myproject",
+        noteable_type: "merge_request",
+        noteable_iid: 5,
+        body: "Hello world",
+      },
+      sdk,
+    );
+    expect(result).toMatchObject({ id: 42, body: "Hello world" });
+  });
+
+  it("passes position payload when provided (merge_request)", async () => {
+    let capturedBody: unknown;
+    const sdk = fakeSdk({
+      addNote: async (_ns, _proj, _type, _iid, body) => {
+        capturedBody = body;
+        return { ok: true, status: 201, data: noteStub };
+      },
+    });
+    await runHandler(
+      spec,
+      {
+        namespace: "mygroup",
+        project: "myproject",
+        noteable_type: "merge_request",
+        noteable_iid: 5,
+        body: "diff comment",
+        position: {
+          base_sha: "aabbccd",
+          start_sha: "aabbccd",
+          head_sha: "aabbccd",
+          position_type: "text",
+          new_path: "src/file.ts",
+          new_line: 10,
+        },
+      },
+      sdk,
+    );
+    expect((capturedBody as Record<string, unknown>)["position"]).toBeDefined();
+  });
+
+  it("throws on HTTP error", async () => {
+    const sdk = fakeSdk({
+      addNote: async () => ({ ok: false, status: 403, data: null }),
+    });
+    await expect(
+      runHandler(
+        spec,
+        {
+          namespace: "mygroup",
+          project: "myproject",
+          noteable_type: "issue",
+          noteable_iid: 1,
+          body: "comment",
+        },
+        sdk,
+      ),
+    ).rejects.toThrow();
+  });
+});
+
+// ── update_note — handler ─────────────────────────────────────────────────────
+
+describe("update_note — handler", () => {
+  const actions = buildNotesActions(deps);
+  const spec = actions["update_note"]!;
+
+  it("calls updateNote and returns updated envelope (issue)", async () => {
+    const sdk = fakeSdk({
+      updateNote: async () => ({
+        ok: true,
+        status: 200,
+        data: { ...noteStub, body: "Updated" },
+      }),
+    });
+    const result = await runHandler(
+      spec,
+      {
+        namespace: "mygroup",
+        project: "myproject",
+        noteable_type: "issue",
+        noteable_iid: 3,
+        note_id: 42,
+        body: "Updated",
+      },
+      sdk,
+    );
+    expect(result).toMatchObject({ id: 42, body: "Updated" });
+  });
+
+  it("calls updateNote and returns updated envelope (merge_request)", async () => {
+    const sdk = fakeSdk({
+      updateNote: async () => ({
+        ok: true,
+        status: 200,
+        data: { ...noteStub, body: "MR updated" },
+      }),
+    });
+    const result = await runHandler(
+      spec,
+      {
+        namespace: "mygroup",
+        project: "myproject",
+        noteable_type: "merge_request",
+        noteable_iid: 5,
+        note_id: 42,
+        body: "MR updated",
+      },
+      sdk,
+    );
+    expect(result).toMatchObject({ body: "MR updated" });
+  });
+
+  it("throws on HTTP error", async () => {
+    const sdk = fakeSdk({
+      updateNote: async () => ({ ok: false, status: 404, data: null }),
+    });
+    await expect(
+      runHandler(
+        spec,
+        {
+          namespace: "mygroup",
+          project: "myproject",
+          noteable_type: "issue",
+          noteable_iid: 3,
+          note_id: 99,
+          body: "Updated",
+        },
+        sdk,
+      ),
+    ).rejects.toThrow();
+  });
+});
+
+// ── delete_note — handler ─────────────────────────────────────────────────────
+
+describe("delete_note — handler", () => {
+  const actions = buildNotesActions(deps);
+  const spec = actions["delete_note"]!;
+
+  it("calls deleteNote and returns { note_id, deleted: true } (issue)", async () => {
+    const sdk = fakeSdk({
+      deleteNote: async () => ({ ok: true, status: 204, data: null }),
+    });
+    const result = await runHandler(
+      spec,
+      {
+        namespace: "mygroup",
+        project: "myproject",
+        noteable_type: "issue",
+        noteable_iid: 3,
+        note_id: 42,
+      },
+      sdk,
+    );
+    expect(result).toEqual({ note_id: 42, deleted: true });
+  });
+
+  it("calls deleteNote and returns { note_id, deleted: true } (merge_request)", async () => {
+    const sdk = fakeSdk({
+      deleteNote: async () => ({ ok: true, status: 204, data: null }),
+    });
+    const result = await runHandler(
+      spec,
+      {
+        namespace: "mygroup",
+        project: "myproject",
+        noteable_type: "merge_request",
+        noteable_iid: 5,
+        note_id: 7,
+      },
+      sdk,
+    );
+    expect(result).toEqual({ note_id: 7, deleted: true });
+  });
+
+  it("throws on HTTP error", async () => {
+    const sdk = fakeSdk({
+      deleteNote: async () => ({ ok: false, status: 403, data: null }),
+    });
+    await expect(
+      runHandler(
+        spec,
+        {
+          namespace: "mygroup",
+          project: "myproject",
+          noteable_type: "issue",
+          noteable_iid: 3,
+          note_id: 42,
+        },
+        sdk,
+      ),
+    ).rejects.toThrow();
+  });
+});

--- a/tests/connectors/gitlab/unit/actions_pipelines.test.ts
+++ b/tests/connectors/gitlab/unit/actions_pipelines.test.ts
@@ -1,0 +1,421 @@
+/**
+ * Tests for gitlab/actions/pipelines.ts — classification, schemas, and handlers
+ * for retry_pipeline, retry_failed_jobs, cancel_pipeline, trigger_pipeline,
+ * and play_job.
+ */
+import { describe, expect, it } from "vitest";
+import type { ActionSpec } from "narai-primitives/toolkit";
+import { buildPipelinesActions } from "../../../../src/connectors/gitlab/actions/pipelines.js";
+import type { GitlabClient } from "../../../../src/connectors/gitlab/lib/gitlab_client.js";
+
+function fakeSdk(overrides: Partial<GitlabClient> = {}): GitlabClient {
+  return overrides as unknown as GitlabClient;
+}
+
+function runHandler<P>(
+  spec: ActionSpec<P, GitlabClient>,
+  params: unknown,
+  sdk: GitlabClient,
+): Promise<unknown> {
+  const parsed = spec.params.parse(params) as P;
+  return spec.handler(parsed, { sdk } as Parameters<typeof spec.handler>[1]);
+}
+
+const baseDeps = {
+  behavior: { requireDraftMr: false, host: "https://gitlab.com" },
+};
+
+const pipelineResponse = {
+  id: 101,
+  status: "running",
+  ref: "main",
+  sha: "abc123",
+  web_url: "https://gitlab.com/g/p/-/pipelines/101",
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+};
+
+const jobResponse = {
+  id: 55,
+  name: "deploy",
+  stage: "deploy",
+  status: "running",
+  web_url: "https://gitlab.com/g/p/-/jobs/55",
+  created_at: "2024-01-01T00:00:00Z",
+  started_at: null,
+  finished_at: null,
+  duration: null,
+};
+
+// ── Classification ────────────────────────────────────────────────────────────
+
+describe("buildPipelinesActions — classification", () => {
+  const actions = buildPipelinesActions(baseDeps);
+
+  it("retry_pipeline is write", () => {
+    expect(actions["retry_pipeline"]?.classify).toEqual({ kind: "write" });
+  });
+
+  it("retry_failed_jobs is write", () => {
+    expect(actions["retry_failed_jobs"]?.classify).toEqual({ kind: "write" });
+  });
+
+  it("cancel_pipeline is write", () => {
+    expect(actions["cancel_pipeline"]?.classify).toEqual({ kind: "write" });
+  });
+
+  it("trigger_pipeline is write", () => {
+    expect(actions["trigger_pipeline"]?.classify).toEqual({ kind: "write" });
+  });
+
+  it("play_job is write", () => {
+    expect(actions["play_job"]?.classify).toEqual({ kind: "write" });
+  });
+});
+
+// ── retry_pipeline ────────────────────────────────────────────────────────────
+
+describe("retry_pipeline", () => {
+  it("calls retryPipeline and returns updated pipeline data", async () => {
+    let calledWith: { ns: string; proj: string; pipelineId: number } | null = null;
+    const sdk = fakeSdk({
+      retryPipeline: async (ns, proj, pipelineId) => {
+        calledWith = { ns, proj, pipelineId };
+        return {
+          ok: true as const,
+          status: 200,
+          data: { ...pipelineResponse, status: "running" },
+        };
+      },
+    });
+    const actions = buildPipelinesActions(baseDeps);
+    const result = (await runHandler(
+      actions["retry_pipeline"]!,
+      { namespace: "mygroup", project: "myproject", pipeline_id: 101 },
+      sdk,
+    )) as Record<string, unknown>;
+
+    expect(result["id"]).toBe(101);
+    expect(result["status"]).toBe("running");
+    expect(calledWith).toEqual({ ns: "mygroup", proj: "myproject", pipelineId: 101 });
+  });
+
+  it("schema rejects non-positive pipeline_id", () => {
+    const actions = buildPipelinesActions(baseDeps);
+    expect(() =>
+      actions["retry_pipeline"]!.params.parse({
+        namespace: "g",
+        project: "p",
+        pipeline_id: 0,
+      }),
+    ).toThrow();
+  });
+
+  it("propagates HTTP errors (e.g. 404)", async () => {
+    const sdk = fakeSdk({
+      retryPipeline: async () => ({
+        ok: false as const,
+        status: 404,
+        data: { message: "404 Not Found" },
+      }),
+    });
+    const actions = buildPipelinesActions(baseDeps);
+    await expect(
+      runHandler(
+        actions["retry_pipeline"]!,
+        { namespace: "g", project: "p", pipeline_id: 999 },
+        sdk,
+      ),
+    ).rejects.toThrow();
+  });
+});
+
+// ── retry_failed_jobs ─────────────────────────────────────────────────────────
+
+describe("retry_failed_jobs", () => {
+  it("calls the same retryPipeline client method as retry_pipeline", async () => {
+    let callCount = 0;
+    const sdk = fakeSdk({
+      retryPipeline: async () => {
+        callCount++;
+        return { ok: true as const, status: 200, data: { ...pipelineResponse } };
+      },
+    });
+    const actions = buildPipelinesActions(baseDeps);
+
+    await runHandler(
+      actions["retry_failed_jobs"]!,
+      { namespace: "g", project: "p", pipeline_id: 101 },
+      sdk,
+    );
+
+    expect(callCount).toBe(1);
+  });
+
+  it("returns the same pipeline data shape as retry_pipeline", async () => {
+    const sdk = fakeSdk({
+      retryPipeline: async () => ({
+        ok: true as const,
+        status: 200,
+        data: { ...pipelineResponse, status: "running" },
+      }),
+    });
+    const actions = buildPipelinesActions(baseDeps);
+    const result = (await runHandler(
+      actions["retry_failed_jobs"]!,
+      { namespace: "g", project: "p", pipeline_id: 101 },
+      sdk,
+    )) as Record<string, unknown>;
+
+    expect(result["id"]).toBe(101);
+    expect(result["status"]).toBe("running");
+  });
+
+  it("schema rejects missing pipeline_id", () => {
+    const actions = buildPipelinesActions(baseDeps);
+    expect(() =>
+      actions["retry_failed_jobs"]!.params.parse({ namespace: "g", project: "p" }),
+    ).toThrow();
+  });
+});
+
+// ── cancel_pipeline ───────────────────────────────────────────────────────────
+
+describe("cancel_pipeline", () => {
+  it("calls cancelPipeline and returns canceled pipeline data", async () => {
+    let calledWith: { ns: string; proj: string; pipelineId: number } | null = null;
+    const sdk = fakeSdk({
+      cancelPipeline: async (ns, proj, pipelineId) => {
+        calledWith = { ns, proj, pipelineId };
+        return {
+          ok: true as const,
+          status: 200,
+          data: { ...pipelineResponse, status: "canceled" },
+        };
+      },
+    });
+    const actions = buildPipelinesActions(baseDeps);
+    const result = (await runHandler(
+      actions["cancel_pipeline"]!,
+      { namespace: "mygroup", project: "myproject", pipeline_id: 101 },
+      sdk,
+    )) as Record<string, unknown>;
+
+    expect(result["id"]).toBe(101);
+    expect(result["status"]).toBe("canceled");
+    expect(calledWith).toEqual({ ns: "mygroup", proj: "myproject", pipelineId: 101 });
+  });
+
+  it("propagates HTTP errors (e.g. 404)", async () => {
+    const sdk = fakeSdk({
+      cancelPipeline: async () => ({
+        ok: false as const,
+        status: 404,
+        data: { message: "404 Not Found" },
+      }),
+    });
+    const actions = buildPipelinesActions(baseDeps);
+    await expect(
+      runHandler(
+        actions["cancel_pipeline"]!,
+        { namespace: "g", project: "p", pipeline_id: 999 },
+        sdk,
+      ),
+    ).rejects.toThrow();
+  });
+});
+
+// ── trigger_pipeline ──────────────────────────────────────────────────────────
+
+describe("trigger_pipeline", () => {
+  it("calls triggerPipeline with token, ref and returns new pipeline data", async () => {
+    let capturedBody: Record<string, unknown> = {};
+    const sdk = fakeSdk({
+      triggerPipeline: async (ns, proj, body) => {
+        capturedBody = body as Record<string, unknown>;
+        return {
+          ok: true as const,
+          status: 201,
+          data: { ...pipelineResponse, id: 202 },
+        };
+      },
+    });
+    const actions = buildPipelinesActions(baseDeps);
+    const result = (await runHandler(
+      actions["trigger_pipeline"]!,
+      {
+        namespace: "mygroup",
+        project: "myproject",
+        token: "glptt_trigger_token",
+        ref: "main",
+      },
+      sdk,
+    )) as Record<string, unknown>;
+
+    expect(result["id"]).toBe(202);
+    expect(capturedBody["token"]).toBe("glptt_trigger_token");
+    expect(capturedBody["ref"]).toBe("main");
+  });
+
+  it("passes variables when provided", async () => {
+    let capturedBody: Record<string, unknown> = {};
+    const sdk = fakeSdk({
+      triggerPipeline: async (_ns, _proj, body) => {
+        capturedBody = body as Record<string, unknown>;
+        return { ok: true as const, status: 201, data: { ...pipelineResponse } };
+      },
+    });
+    const actions = buildPipelinesActions(baseDeps);
+    await runHandler(
+      actions["trigger_pipeline"]!,
+      {
+        namespace: "g",
+        project: "p",
+        token: "tok",
+        ref: "feat/branch",
+        variables: { FOO: "bar", BAZ: "qux" },
+      },
+      sdk,
+    );
+
+    expect(capturedBody["variables"]).toEqual({ FOO: "bar", BAZ: "qux" });
+  });
+
+  it("omits variables from body when not provided", async () => {
+    let capturedBody: Record<string, unknown> = {};
+    const sdk = fakeSdk({
+      triggerPipeline: async (_ns, _proj, body) => {
+        capturedBody = body as Record<string, unknown>;
+        return { ok: true as const, status: 201, data: { ...pipelineResponse } };
+      },
+    });
+    const actions = buildPipelinesActions(baseDeps);
+    await runHandler(
+      actions["trigger_pipeline"]!,
+      { namespace: "g", project: "p", token: "tok", ref: "main" },
+      sdk,
+    );
+
+    expect(capturedBody["variables"]).toBeUndefined();
+  });
+
+  it("schema rejects missing token", () => {
+    const actions = buildPipelinesActions(baseDeps);
+    expect(() =>
+      actions["trigger_pipeline"]!.params.parse({
+        namespace: "g",
+        project: "p",
+        ref: "main",
+      }),
+    ).toThrow();
+  });
+
+  it("schema rejects missing ref", () => {
+    const actions = buildPipelinesActions(baseDeps);
+    expect(() =>
+      actions["trigger_pipeline"]!.params.parse({
+        namespace: "g",
+        project: "p",
+        token: "tok",
+      }),
+    ).toThrow();
+  });
+
+  it("propagates HTTP errors (e.g. 403 invalid token)", async () => {
+    const sdk = fakeSdk({
+      triggerPipeline: async () => ({
+        ok: false as const,
+        status: 403,
+        data: { message: "403 Forbidden" },
+      }),
+    });
+    const actions = buildPipelinesActions(baseDeps);
+    await expect(
+      runHandler(
+        actions["trigger_pipeline"]!,
+        { namespace: "g", project: "p", token: "bad", ref: "main" },
+        sdk,
+      ),
+    ).rejects.toThrow();
+  });
+});
+
+// ── play_job ──────────────────────────────────────────────────────────────────
+
+describe("play_job", () => {
+  it("calls playJob and returns job data", async () => {
+    let calledWith: { ns: string; proj: string; jobId: number } | null = null;
+    const sdk = fakeSdk({
+      playJob: async (ns, proj, jobId) => {
+        calledWith = { ns, proj, jobId };
+        return {
+          ok: true as const,
+          status: 200,
+          data: { ...jobResponse, status: "running" },
+        };
+      },
+    });
+    const actions = buildPipelinesActions(baseDeps);
+    const result = (await runHandler(
+      actions["play_job"]!,
+      { namespace: "mygroup", project: "myproject", job_id: 55 },
+      sdk,
+    )) as Record<string, unknown>;
+
+    expect(result["id"]).toBe(55);
+    expect(result["status"]).toBe("running");
+    expect(calledWith).toEqual({ ns: "mygroup", proj: "myproject", jobId: 55 });
+  });
+
+  it("passes variables when provided", async () => {
+    let capturedVars: Record<string, unknown> | undefined;
+    const sdk = fakeSdk({
+      playJob: async (_ns, _proj, _jobId, vars) => {
+        capturedVars = vars;
+        return { ok: true as const, status: 200, data: { ...jobResponse } };
+      },
+    });
+    const actions = buildPipelinesActions(baseDeps);
+    await runHandler(
+      actions["play_job"]!,
+      {
+        namespace: "g",
+        project: "p",
+        job_id: 55,
+        variables: { DEPLOY_ENV: "staging" },
+      },
+      sdk,
+    );
+
+    expect(capturedVars).toEqual({ DEPLOY_ENV: "staging" });
+  });
+
+  it("schema rejects non-positive job_id", () => {
+    const actions = buildPipelinesActions(baseDeps);
+    expect(() =>
+      actions["play_job"]!.params.parse({
+        namespace: "g",
+        project: "p",
+        job_id: -1,
+      }),
+    ).toThrow();
+  });
+
+  it("propagates HTTP errors (e.g. 404 job not found)", async () => {
+    const sdk = fakeSdk({
+      playJob: async () => ({
+        ok: false as const,
+        status: 404,
+        data: { message: "404 Not Found" },
+      }),
+    });
+    const actions = buildPipelinesActions(baseDeps);
+    await expect(
+      runHandler(
+        actions["play_job"]!,
+        { namespace: "g", project: "p", job_id: 999 },
+        sdk,
+      ),
+    ).rejects.toThrow();
+  });
+});

--- a/tests/connectors/gitlab/unit/actions_reads.test.ts
+++ b/tests/connectors/gitlab/unit/actions_reads.test.ts
@@ -1,0 +1,605 @@
+/**
+ * Tests for gitlab/actions/reads.ts — classification + handler envelope
+ * shape for all 14 read actions. Also covers the paginateGitlab utility.
+ */
+import { describe, expect, it } from "vitest";
+import type { ActionSpec } from "narai-primitives/toolkit";
+import { buildReadActions } from "../../../../src/connectors/gitlab/actions/reads.js";
+import type { GitlabClient } from "../../../../src/connectors/gitlab/lib/gitlab_client.js";
+
+function fakeSdk(overrides: Partial<GitlabClient> = {}): GitlabClient {
+  return overrides as unknown as GitlabClient;
+}
+
+function runHandler<P>(
+  spec: ActionSpec<P, GitlabClient>,
+  params: unknown,
+  sdk: GitlabClient,
+): Promise<unknown> {
+  const parsed = spec.params.parse(params) as P;
+  return spec.handler(parsed, { sdk } as Parameters<typeof spec.handler>[1]);
+}
+
+const deps = { behavior: { requireDraftMr: false, host: "https://gitlab.com" } };
+
+// ── Classification ────────────────────────────────────────────────────────────
+
+describe("buildReadActions — classification (all 14 are read)", () => {
+  const actions = buildReadActions(deps);
+
+  it("project_info is read", () => {
+    expect(actions["project_info"]?.classify).toEqual({ kind: "read" });
+  });
+  it("search_code is read", () => {
+    expect(actions["search_code"]?.classify).toEqual({ kind: "read" });
+  });
+  it("get_issues is read", () => {
+    expect(actions["get_issues"]?.classify).toEqual({ kind: "read" });
+  });
+  it("get_issue is read", () => {
+    expect(actions["get_issue"]?.classify).toEqual({ kind: "read" });
+  });
+  it("get_merge_requests is read", () => {
+    expect(actions["get_merge_requests"]?.classify).toEqual({ kind: "read" });
+  });
+  it("get_merge_request is read", () => {
+    expect(actions["get_merge_request"]?.classify).toEqual({ kind: "read" });
+  });
+  it("get_file is read", () => {
+    expect(actions["get_file"]?.classify).toEqual({ kind: "read" });
+  });
+  it("get_notes is read", () => {
+    expect(actions["get_notes"]?.classify).toEqual({ kind: "read" });
+  });
+  it("list_release_links is read", () => {
+    expect(actions["list_release_links"]?.classify).toEqual({ kind: "read" });
+  });
+  it("get_release_link is read", () => {
+    expect(actions["get_release_link"]?.classify).toEqual({ kind: "read" });
+  });
+  it("list_pipelines is read", () => {
+    expect(actions["list_pipelines"]?.classify).toEqual({ kind: "read" });
+  });
+  it("get_pipeline is read", () => {
+    expect(actions["get_pipeline"]?.classify).toEqual({ kind: "read" });
+  });
+  it("list_pipeline_jobs is read", () => {
+    expect(actions["list_pipeline_jobs"]?.classify).toEqual({ kind: "read" });
+  });
+  it("get_job_logs is read", () => {
+    expect(actions["get_job_logs"]?.classify).toEqual({ kind: "read" });
+  });
+});
+
+// ── project_info ──────────────────────────────────────────────────────────────
+
+describe("project_info", () => {
+  it("maps project data to normalized envelope", async () => {
+    const sdk = fakeSdk({
+      getProject: async () => ({
+        ok: true,
+        status: 200,
+        data: {
+          id: 1,
+          name: "my-project",
+          path_with_namespace: "mygroup/my-project",
+          default_branch: "main",
+          description: "A test project",
+          visibility: "private",
+          web_url: "https://gitlab.com/mygroup/my-project",
+        },
+      }),
+    });
+    const actions = buildReadActions(deps);
+    const r = (await runHandler(
+      actions["project_info"]!,
+      { namespace: "mygroup", project: "my-project" },
+      sdk,
+    )) as Record<string, unknown>;
+    expect(r).toMatchObject({
+      id: 1,
+      name: "my-project",
+      path_with_namespace: "mygroup/my-project",
+      default_branch: "main",
+      description: "A test project",
+      visibility: "private",
+      web_url: "https://gitlab.com/mygroup/my-project",
+    });
+  });
+});
+
+// ── search_code ───────────────────────────────────────────────────────────────
+
+describe("search_code", () => {
+  it("maps blob search results to normalized envelope", async () => {
+    const sdk = fakeSdk({
+      searchCode: async () => ({
+        ok: true,
+        status: 200,
+        data: [
+          {
+            filename: "src/app.ts",
+            path: "src/app.ts",
+            ref: "main",
+            startline: 10,
+            project_id: 1,
+          },
+        ],
+      }),
+    });
+    const actions = buildReadActions(deps);
+    const r = (await runHandler(
+      actions["search_code"]!,
+      { namespace: "mygroup", project: "my-project", query: "hello" },
+      sdk,
+    )) as { total: number; items: unknown[]; truncated: boolean };
+    expect(r.total).toBe(1);
+    expect(r.items[0]).toMatchObject({ path: "src/app.ts", ref: "main" });
+    expect(r.truncated).toBe(false);
+  });
+});
+
+// ── get_issues ────────────────────────────────────────────────────────────────
+
+describe("get_issues", () => {
+  it("paginates and maps issues to normalized envelope", async () => {
+    const sdk = fakeSdk({
+      listIssues: async () => ({
+        ok: true,
+        status: 200,
+        data: [
+          {
+            iid: 1,
+            title: "Bug report",
+            state: "opened",
+            author: { username: "alice" },
+            labels: ["bug"],
+            web_url: "https://gitlab.com/g/p/-/issues/1",
+            updated_at: "2026-05-01T00:00:00Z",
+          },
+        ],
+      }),
+    });
+    const actions = buildReadActions(deps);
+    const r = (await runHandler(
+      actions["get_issues"]!,
+      { namespace: "mygroup", project: "my-project" },
+      sdk,
+    )) as { total: number; issues: unknown[]; truncated: boolean };
+    expect(r.total).toBe(1);
+    expect(r.issues[0]).toMatchObject({
+      iid: 1,
+      title: "Bug report",
+      state: "opened",
+      author: "alice",
+    });
+  });
+});
+
+// ── get_issue ─────────────────────────────────────────────────────────────────
+
+describe("get_issue", () => {
+  it("fetches and maps a single issue", async () => {
+    const sdk = fakeSdk({
+      getIssue: async () => ({
+        ok: true,
+        status: 200,
+        data: {
+          iid: 5,
+          title: "Feature request",
+          state: "opened",
+          author: { username: "bob" },
+          description: "Please add X",
+          labels: ["enhancement"],
+          web_url: "https://gitlab.com/g/p/-/issues/5",
+          updated_at: "2026-05-02T00:00:00Z",
+        },
+      }),
+    });
+    const actions = buildReadActions(deps);
+    const r = (await runHandler(
+      actions["get_issue"]!,
+      { namespace: "mygroup", project: "my-project", iid: 5 },
+      sdk,
+    )) as Record<string, unknown>;
+    expect(r).toMatchObject({
+      iid: 5,
+      title: "Feature request",
+      state: "opened",
+      author: "bob",
+    });
+  });
+});
+
+// ── get_merge_requests ────────────────────────────────────────────────────────
+
+describe("get_merge_requests", () => {
+  it("paginates and maps MRs to normalized envelope", async () => {
+    const sdk = fakeSdk({
+      listMergeRequests: async () => ({
+        ok: true,
+        status: 200,
+        data: [
+          {
+            iid: 3,
+            title: "feat: new thing",
+            state: "opened",
+            author: { username: "carol" },
+            web_url: "https://gitlab.com/g/p/-/merge_requests/3",
+            updated_at: "2026-05-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+    const actions = buildReadActions(deps);
+    const r = (await runHandler(
+      actions["get_merge_requests"]!,
+      { namespace: "mygroup", project: "my-project" },
+      sdk,
+    )) as { total: number; merge_requests: unknown[]; truncated: boolean };
+    expect(r.total).toBe(1);
+    expect(r.merge_requests[0]).toMatchObject({
+      iid: 3,
+      title: "feat: new thing",
+      author: "carol",
+    });
+  });
+});
+
+// ── get_merge_request ─────────────────────────────────────────────────────────
+
+describe("get_merge_request", () => {
+  it("fetches and maps a single MR", async () => {
+    const sdk = fakeSdk({
+      getMergeRequest: async () => ({
+        ok: true,
+        status: 200,
+        data: {
+          iid: 7,
+          title: "fix: something",
+          state: "merged",
+          author: { username: "dave" },
+          description: "Fixes the bug",
+          source_branch: "fix/bug",
+          target_branch: "main",
+          sha: "abc1234",
+          web_url: "https://gitlab.com/g/p/-/merge_requests/7",
+          updated_at: "2026-05-04T00:00:00Z",
+        },
+      }),
+    });
+    const actions = buildReadActions(deps);
+    const r = (await runHandler(
+      actions["get_merge_request"]!,
+      { namespace: "mygroup", project: "my-project", iid: 7 },
+      sdk,
+    )) as Record<string, unknown>;
+    expect(r).toMatchObject({
+      iid: 7,
+      title: "fix: something",
+      state: "merged",
+      author: "dave",
+      source_branch: "fix/bug",
+      target_branch: "main",
+    });
+  });
+});
+
+// ── get_file ──────────────────────────────────────────────────────────────────
+
+describe("get_file", () => {
+  it("decodes base64 content from GitLab file response", async () => {
+    const contentBase64 = Buffer.from("hello world\n").toString("base64");
+    const sdk = fakeSdk({
+      getFile: async () => ({
+        ok: true,
+        status: 200,
+        data: {
+          file_name: "README.md",
+          file_path: "README.md",
+          size: 12,
+          encoding: "base64",
+          content: contentBase64,
+          ref: "main",
+          blob_id: "abc",
+          commit_id: "def",
+          last_commit_id: "def",
+        },
+      }),
+    });
+    const actions = buildReadActions(deps);
+    const r = (await runHandler(
+      actions["get_file"]!,
+      { namespace: "mygroup", project: "my-project", path: "README.md", ref: "main" },
+      sdk,
+    )) as Record<string, unknown>;
+    expect(r.path).toBe("README.md");
+    expect(r.content).toBe("hello world\n");
+    expect(r.encoding).toBe("utf-8");
+    expect(r.ref).toBe("main");
+  });
+});
+
+// ── get_notes ─────────────────────────────────────────────────────────────────
+
+describe("get_notes", () => {
+  it("fetches notes for an issue", async () => {
+    const sdk = fakeSdk({
+      getNotes: async () => ({
+        ok: true,
+        status: 200,
+        data: [
+          {
+            id: 101,
+            body: "This is a note",
+            author: { username: "eve" },
+            created_at: "2026-05-01T00:00:00Z",
+            updated_at: "2026-05-01T00:00:00Z",
+            system: false,
+          },
+        ],
+      }),
+    });
+    const actions = buildReadActions(deps);
+    const r = (await runHandler(
+      actions["get_notes"]!,
+      { namespace: "mygroup", project: "my-project", noteable_type: "issue", noteable_iid: 1 },
+      sdk,
+    )) as { total: number; notes: unknown[] };
+    expect(r.total).toBe(1);
+    expect(r.notes[0]).toMatchObject({
+      id: 101,
+      body: "This is a note",
+      author: "eve",
+    });
+  });
+
+  it("fetches notes for a merge_request", async () => {
+    const sdk = fakeSdk({
+      getNotes: async (_ns, _proj, noteableType, _iid) => {
+        expect(noteableType).toBe("merge_request");
+        return {
+          ok: true as const,
+          status: 200,
+          data: [{ id: 202, body: "MR note", author: { username: "frank" }, created_at: "2026-05-02T00:00:00Z", updated_at: "2026-05-02T00:00:00Z", system: false }],
+        };
+      },
+    });
+    const actions = buildReadActions(deps);
+    const r = (await runHandler(
+      actions["get_notes"]!,
+      { namespace: "mygroup", project: "my-project", noteable_type: "merge_request", noteable_iid: 3 },
+      sdk,
+    )) as { notes: unknown[] };
+    expect(r.notes[0]).toMatchObject({ id: 202, author: "frank" });
+  });
+});
+
+// ── list_release_links ────────────────────────────────────────────────────────
+
+describe("list_release_links", () => {
+  it("maps release links to normalized envelope", async () => {
+    const sdk = fakeSdk({
+      listReleaseLinks: async () => ({
+        ok: true,
+        status: 200,
+        data: [
+          {
+            id: 1,
+            name: "linux-binary",
+            url: "https://example.com/linux",
+            link_type: "package",
+          },
+        ],
+      }),
+    });
+    const actions = buildReadActions(deps);
+    const r = (await runHandler(
+      actions["list_release_links"]!,
+      { namespace: "mygroup", project: "my-project", tag: "v1.0.0" },
+      sdk,
+    )) as { tag: string; links: unknown[] };
+    expect(r.tag).toBe("v1.0.0");
+    expect(r.links[0]).toMatchObject({ id: 1, name: "linux-binary" });
+  });
+});
+
+// ── get_release_link ──────────────────────────────────────────────────────────
+
+describe("get_release_link", () => {
+  it("maps a single release link to normalized envelope", async () => {
+    const sdk = fakeSdk({
+      getReleaseLink: async () => ({
+        ok: true,
+        status: 200,
+        data: {
+          id: 5,
+          name: "windows-binary",
+          url: "https://example.com/windows",
+          link_type: "package",
+        },
+      }),
+    });
+    const actions = buildReadActions(deps);
+    const r = (await runHandler(
+      actions["get_release_link"]!,
+      { namespace: "mygroup", project: "my-project", tag: "v1.0.0", link_id: 5 },
+      sdk,
+    )) as Record<string, unknown>;
+    expect(r).toMatchObject({ id: 5, name: "windows-binary" });
+  });
+});
+
+// ── list_pipelines ────────────────────────────────────────────────────────────
+
+describe("list_pipelines", () => {
+  it("paginates and maps pipelines to normalized envelope", async () => {
+    const sdk = fakeSdk({
+      listPipelines: async () => ({
+        ok: true,
+        status: 200,
+        data: [
+          {
+            id: 100,
+            status: "success",
+            ref: "main",
+            sha: "abc1234",
+            web_url: "https://gitlab.com/g/p/-/pipelines/100",
+            created_at: "2026-05-01T00:00:00Z",
+            updated_at: "2026-05-01T01:00:00Z",
+          },
+        ],
+      }),
+    });
+    const actions = buildReadActions(deps);
+    const r = (await runHandler(
+      actions["list_pipelines"]!,
+      { namespace: "mygroup", project: "my-project" },
+      sdk,
+    )) as { total: number; pipelines: unknown[]; truncated: boolean };
+    expect(r.total).toBe(1);
+    expect(r.pipelines[0]).toMatchObject({ id: 100, status: "success", ref: "main" });
+  });
+});
+
+// ── get_pipeline ──────────────────────────────────────────────────────────────
+
+describe("get_pipeline", () => {
+  it("fetches and maps a single pipeline", async () => {
+    const sdk = fakeSdk({
+      getPipeline: async () => ({
+        ok: true,
+        status: 200,
+        data: {
+          id: 200,
+          status: "failed",
+          ref: "feat/x",
+          sha: "def5678",
+          web_url: "https://gitlab.com/g/p/-/pipelines/200",
+          created_at: "2026-05-02T00:00:00Z",
+          updated_at: "2026-05-02T01:00:00Z",
+          duration: 120,
+          finished_at: "2026-05-02T01:00:00Z",
+        },
+      }),
+    });
+    const actions = buildReadActions(deps);
+    const r = (await runHandler(
+      actions["get_pipeline"]!,
+      { namespace: "mygroup", project: "my-project", pipeline_id: 200 },
+      sdk,
+    )) as Record<string, unknown>;
+    expect(r).toMatchObject({ id: 200, status: "failed", ref: "feat/x" });
+  });
+});
+
+// ── list_pipeline_jobs ────────────────────────────────────────────────────────
+
+describe("list_pipeline_jobs", () => {
+  it("maps pipeline jobs to normalized envelope", async () => {
+    const sdk = fakeSdk({
+      listPipelineJobs: async () => ({
+        ok: true,
+        status: 200,
+        data: [
+          {
+            id: 300,
+            name: "test",
+            stage: "test",
+            status: "success",
+            created_at: "2026-05-01T00:00:00Z",
+            started_at: "2026-05-01T00:01:00Z",
+            finished_at: "2026-05-01T00:05:00Z",
+            duration: 240,
+            web_url: "https://gitlab.com/g/p/-/jobs/300",
+          },
+        ],
+      }),
+    });
+    const actions = buildReadActions(deps);
+    const r = (await runHandler(
+      actions["list_pipeline_jobs"]!,
+      { namespace: "mygroup", project: "my-project", pipeline_id: 100 },
+      sdk,
+    )) as { jobs: unknown[] };
+    expect(r.jobs[0]).toMatchObject({ id: 300, name: "test", stage: "test", status: "success" });
+  });
+});
+
+// ── get_job_logs ──────────────────────────────────────────────────────────────
+
+describe("get_job_logs", () => {
+  it("returns logs string and content_length", async () => {
+    const logsText = "Running tests...\nAll passed!\n";
+    const sdk = fakeSdk({
+      getJobLogs: async () => ({
+        ok: true,
+        status: 200,
+        data: logsText,
+      }),
+    });
+    const actions = buildReadActions(deps);
+    const r = (await runHandler(
+      actions["get_job_logs"]!,
+      { namespace: "mygroup", project: "my-project", job_id: 300 },
+      sdk,
+    )) as { logs: string; content_length: number };
+    expect(r.logs).toBe(logsText);
+    expect(r.content_length).toBe(logsText.length);
+  });
+});
+
+// ── paginateGitlab ────────────────────────────────────────────────────────────
+
+describe("paginateGitlab utility", () => {
+  it("stops on a short page (last page detection)", async () => {
+    const actions = buildReadActions(deps);
+    // list_pipelines uses paginateGitlab; give it a single page with 1 item (short page = done)
+    const sdk = fakeSdk({
+      listPipelines: async (_ns, _proj, query) => {
+        expect(query.per_page).toBeGreaterThan(0);
+        return {
+          ok: true as const,
+          status: 200,
+          data: [{ id: 1, status: "success", ref: "main", sha: "a", web_url: "x", created_at: "t", updated_at: "t" }],
+        };
+      },
+    });
+    const r = (await runHandler(
+      actions["list_pipelines"]!,
+      { namespace: "g", project: "p", max_results: 50 },
+      sdk,
+    )) as { total: number; truncated: boolean };
+    expect(r.total).toBe(1);
+    expect(r.truncated).toBe(false);
+  });
+
+  it("truncates when max_results is reached mid-pagination", async () => {
+    const actions = buildReadActions(deps);
+    let callCount = 0;
+    const sdk = fakeSdk({
+      listPipelines: async (_ns, _proj, query) => {
+        callCount++;
+        const perPage = (query.per_page as number) ?? 30;
+        // Always return a full page
+        const items = Array.from({ length: perPage }, (_, i) => ({
+          id: (callCount - 1) * perPage + i + 1,
+          status: "success",
+          ref: "main",
+          sha: "a",
+          web_url: "x",
+          created_at: "t",
+          updated_at: "t",
+        }));
+        return { ok: true as const, status: 200, data: items };
+      },
+    });
+    const r = (await runHandler(
+      actions["list_pipelines"]!,
+      { namespace: "g", project: "p", max_results: 5 },
+      sdk,
+    )) as { total: number; truncated: boolean };
+    expect(r.total).toBe(5);
+    expect(r.truncated).toBe(true);
+  });
+});

--- a/tests/connectors/gitlab/unit/actions_reads.test.ts
+++ b/tests/connectors/gitlab/unit/actions_reads.test.ts
@@ -578,8 +578,35 @@ describe("list_pipeline_jobs", () => {
       actions["list_pipeline_jobs"]!,
       { namespace: "mygroup", project: "my-project", pipeline_id: 100 },
       sdk,
-    )) as { jobs: unknown[] };
+    )) as { jobs: unknown[]; truncated: boolean };
     expect(r.jobs[0]).toMatchObject({ id: 300, name: "test", stage: "test", status: "success" });
+    expect(r.truncated).toBe(false);
+  });
+
+  it("paginates across multiple pages until max_results is reached", async () => {
+    let callCount = 0;
+    const sdk = fakeSdk({
+      listPipelineJobs: async (_ns, _proj, _id, opts) => {
+        callCount++;
+        const perPage = opts?.perPage ?? 30;
+        const data = Array.from({ length: perPage }, (_, i) => ({
+          id: (callCount - 1) * perPage + i + 1,
+          name: `job-${(callCount - 1) * perPage + i + 1}`,
+          stage: "test",
+          status: "success",
+        }));
+        return { ok: true as const, status: 200, data };
+      },
+    });
+    const actions = buildReadActions(deps);
+    const r = (await runHandler(
+      actions["list_pipeline_jobs"]!,
+      { namespace: "mygroup", project: "my-project", pipeline_id: 100, max_results: 5 },
+      sdk,
+    )) as { total: number; jobs: unknown[]; truncated: boolean };
+    expect(r.total).toBe(5);
+    expect(r.truncated).toBe(true);
+    expect(callCount).toBeGreaterThanOrEqual(1);
   });
 });
 

--- a/tests/connectors/gitlab/unit/actions_reads.test.ts
+++ b/tests/connectors/gitlab/unit/actions_reads.test.ts
@@ -352,7 +352,7 @@ describe("get_file", () => {
 // ── get_notes ─────────────────────────────────────────────────────────────────
 
 describe("get_notes", () => {
-  it("fetches notes for an issue", async () => {
+  it("fetches notes for an issue (uses /notes, discussion_id is null)", async () => {
     const sdk = fakeSdk({
       getNotes: async () => ({
         ok: true,
@@ -374,36 +374,74 @@ describe("get_notes", () => {
       actions["get_notes"]!,
       { namespace: "mygroup", project: "my-project", noteable_type: "issue", noteable_iid: 1 },
       sdk,
-    )) as { total: number; notes: unknown[] };
+    )) as { total: number; notes: Record<string, unknown>[] };
     expect(r.total).toBe(1);
     expect(r.notes[0]).toMatchObject({
       id: 101,
       body: "This is a note",
       author: "eve",
+      discussion_id: null,
     });
   });
 
-  it("fetches notes for a merge_request", async () => {
+  it("fetches notes for a merge_request via /discussions and flattens with discussion_id", async () => {
     const sdk = fakeSdk({
-      getNotes: async (_ns, _proj, noteableType, _iid) => {
-        expect(noteableType).toBe("merge_request");
-        return {
-          ok: true as const,
-          status: 200,
-          data: [{ id: 202, body: "MR note", author: { username: "frank" }, created_at: "2026-05-02T00:00:00Z", updated_at: "2026-05-02T00:00:00Z", system: false }],
-        };
-      },
+      getDiscussions: async () => ({
+        ok: true as const,
+        status: 200,
+        data: [
+          {
+            id: "disc-abc",
+            individual_note: false,
+            notes: [
+              {
+                id: 202,
+                body: "MR diff note",
+                author: { username: "frank" },
+                created_at: "2026-05-02T00:00:00Z",
+                updated_at: "2026-05-02T00:00:00Z",
+                system: false,
+              },
+              {
+                id: 203,
+                body: "MR diff reply",
+                author: { username: "grace" },
+                created_at: "2026-05-02T01:00:00Z",
+                updated_at: "2026-05-02T01:00:00Z",
+                system: false,
+              },
+            ],
+          },
+          {
+            id: "disc-def",
+            individual_note: true,
+            notes: [
+              {
+                id: 204,
+                body: "General comment",
+                author: { username: "hank" },
+                created_at: "2026-05-02T02:00:00Z",
+                updated_at: "2026-05-02T02:00:00Z",
+                system: false,
+              },
+            ],
+          },
+        ],
+      }),
     });
     const actions = buildReadActions(deps);
     const r = (await runHandler(
       actions["get_notes"]!,
       { namespace: "mygroup", project: "my-project", noteable_type: "merge_request", noteable_iid: 3 },
       sdk,
-    )) as { notes: unknown[] };
-    expect(r.notes[0]).toMatchObject({ id: 202, author: "frank" });
+    )) as { total: number; notes: Record<string, unknown>[] };
+    expect(r.total).toBe(3);
+    expect(r.notes[0]).toMatchObject({ id: 202, author: "frank", discussion_id: "disc-abc" });
+    expect(r.notes[1]).toMatchObject({ id: 203, author: "grace", discussion_id: "disc-abc" });
+    expect(r.notes[2]).toMatchObject({ id: 204, author: "hank", discussion_id: "disc-def" });
   });
 
-  it("paginates across multiple pages until max_results is reached", async () => {
+  it("paginates issue notes across multiple pages until max_results is reached", async () => {
     let callCount = 0;
     const sdk = fakeSdk({
       getNotes: async (_ns, _proj, _type, _iid, opts) => {
@@ -427,6 +465,40 @@ describe("get_notes", () => {
       sdk,
     )) as { total: number; notes: unknown[]; truncated: boolean };
     expect(r.total).toBe(5);
+    expect(r.truncated).toBe(true);
+    expect(callCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it("paginates MR discussions and truncates at max_results (discussion count)", async () => {
+    let callCount = 0;
+    const sdk = fakeSdk({
+      getDiscussions: async (_ns, _proj, _iid, opts) => {
+        callCount++;
+        const perPage = opts?.perPage ?? 30;
+        const data = Array.from({ length: perPage }, (_, i) => ({
+          id: `disc-${(callCount - 1) * perPage + i}`,
+          individual_note: true,
+          notes: [
+            {
+              id: (callCount - 1) * perPage + i + 1,
+              body: `note ${(callCount - 1) * perPage + i + 1}`,
+              author: { username: "alice" },
+              created_at: "2026-05-01T00:00:00Z",
+              updated_at: "2026-05-01T00:00:00Z",
+              system: false,
+            },
+          ],
+        }));
+        return { ok: true as const, status: 200, data };
+      },
+    });
+    const actions = buildReadActions(deps);
+    const r = (await runHandler(
+      actions["get_notes"]!,
+      { namespace: "mygroup", project: "my-project", noteable_type: "merge_request", noteable_iid: 5, max_results: 5 },
+      sdk,
+    )) as { total: number; notes: unknown[]; truncated: boolean };
+    expect(r.notes.length).toBe(5);
     expect(r.truncated).toBe(true);
     expect(callCount).toBeGreaterThanOrEqual(1);
   });

--- a/tests/connectors/gitlab/unit/actions_reads.test.ts
+++ b/tests/connectors/gitlab/unit/actions_reads.test.ts
@@ -402,6 +402,34 @@ describe("get_notes", () => {
     )) as { notes: unknown[] };
     expect(r.notes[0]).toMatchObject({ id: 202, author: "frank" });
   });
+
+  it("paginates across multiple pages until max_results is reached", async () => {
+    let callCount = 0;
+    const sdk = fakeSdk({
+      getNotes: async (_ns, _proj, _type, _iid, opts) => {
+        callCount++;
+        const perPage = opts?.perPage ?? 30;
+        const data = Array.from({ length: perPage }, (_, i) => ({
+          id: (callCount - 1) * perPage + i + 1,
+          body: `note ${(callCount - 1) * perPage + i + 1}`,
+          author: { username: "alice" },
+          created_at: "2026-05-01T00:00:00Z",
+          updated_at: "2026-05-01T00:00:00Z",
+          system: false,
+        }));
+        return { ok: true as const, status: 200, data };
+      },
+    });
+    const actions = buildReadActions(deps);
+    const r = (await runHandler(
+      actions["get_notes"]!,
+      { namespace: "mygroup", project: "my-project", noteable_type: "issue", noteable_iid: 1, max_results: 5 },
+      sdk,
+    )) as { total: number; notes: unknown[]; truncated: boolean };
+    expect(r.total).toBe(5);
+    expect(r.truncated).toBe(true);
+    expect(callCount).toBeGreaterThanOrEqual(1);
+  });
 });
 
 // ── list_release_links ────────────────────────────────────────────────────────

--- a/tests/connectors/gitlab/unit/actions_reads.test.ts
+++ b/tests/connectors/gitlab/unit/actions_reads.test.ts
@@ -502,6 +502,115 @@ describe("get_notes", () => {
     expect(r.truncated).toBe(true);
     expect(callCount).toBeGreaterThanOrEqual(1);
   });
+
+  it("caps notes after flattening when a discussion has many notes (note-count truncation)", async () => {
+    // Single discussion with 10 notes, but max_results=3 — secondary cap must fire.
+    const sdk = fakeSdk({
+      getDiscussions: async () => ({
+        ok: true as const,
+        status: 200,
+        data: [
+          {
+            id: "disc-big",
+            individual_note: false,
+            notes: Array.from({ length: 10 }, (_, i) => ({
+              id: i + 1,
+              body: `note ${i + 1}`,
+              author: { username: "alice" },
+              created_at: "2026-05-01T00:00:00Z",
+              updated_at: "2026-05-01T00:00:00Z",
+              system: false,
+            })),
+          },
+        ],
+      }),
+    });
+    const actions = buildReadActions(deps);
+    const r = (await runHandler(
+      actions["get_notes"]!,
+      { namespace: "mygroup", project: "my-project", noteable_type: "merge_request", noteable_iid: 7, max_results: 3 },
+      sdk,
+    )) as { total: number; notes: unknown[]; truncated: boolean };
+    expect(r.notes.length).toBe(3);
+    expect(r.total).toBe(3);
+    expect(r.truncated).toBe(true);
+  });
+
+  it("sets truncated=true when flattened note count exceeds max_results even if discussion paginator did not truncate", async () => {
+    // Two discussions, 3 notes each → 6 total, max_results=4.
+    const sdk = fakeSdk({
+      getDiscussions: async () => ({
+        ok: true as const,
+        status: 200,
+        data: [
+          {
+            id: "disc-1",
+            individual_note: false,
+            notes: Array.from({ length: 3 }, (_, i) => ({
+              id: i + 1,
+              body: `d1 note ${i + 1}`,
+              author: { username: "alice" },
+              created_at: "2026-05-01T00:00:00Z",
+              updated_at: "2026-05-01T00:00:00Z",
+              system: false,
+            })),
+          },
+          {
+            id: "disc-2",
+            individual_note: false,
+            notes: Array.from({ length: 3 }, (_, i) => ({
+              id: i + 10,
+              body: `d2 note ${i + 1}`,
+              author: { username: "bob" },
+              created_at: "2026-05-01T00:00:00Z",
+              updated_at: "2026-05-01T00:00:00Z",
+              system: false,
+            })),
+          },
+        ],
+      }),
+    });
+    const actions = buildReadActions(deps);
+    const r = (await runHandler(
+      actions["get_notes"]!,
+      { namespace: "mygroup", project: "my-project", noteable_type: "merge_request", noteable_iid: 8, max_results: 4 },
+      sdk,
+    )) as { total: number; notes: unknown[]; truncated: boolean };
+    expect(r.notes.length).toBe(4);
+    expect(r.truncated).toBe(true);
+  });
+
+  it("sets truncated=false when flattened note count fits exactly within max_results", async () => {
+    // One discussion with exactly 3 notes, max_results=5 — no truncation.
+    const sdk = fakeSdk({
+      getDiscussions: async () => ({
+        ok: true as const,
+        status: 200,
+        data: [
+          {
+            id: "disc-exact",
+            individual_note: false,
+            notes: Array.from({ length: 3 }, (_, i) => ({
+              id: i + 1,
+              body: `note ${i + 1}`,
+              author: { username: "alice" },
+              created_at: "2026-05-01T00:00:00Z",
+              updated_at: "2026-05-01T00:00:00Z",
+              system: false,
+            })),
+          },
+        ],
+      }),
+    });
+    const actions = buildReadActions(deps);
+    const r = (await runHandler(
+      actions["get_notes"]!,
+      { namespace: "mygroup", project: "my-project", noteable_type: "merge_request", noteable_iid: 9, max_results: 5 },
+      sdk,
+    )) as { total: number; notes: unknown[]; truncated: boolean };
+    expect(r.notes.length).toBe(3);
+    expect(r.truncated).toBe(false);
+  });
 });
 
 // ── list_release_links ────────────────────────────────────────────────────────

--- a/tests/connectors/gitlab/unit/actions_reads.test.ts
+++ b/tests/connectors/gitlab/unit/actions_reads.test.ts
@@ -137,6 +137,35 @@ describe("search_code", () => {
     expect(r.items[0]).toMatchObject({ path: "src/app.ts", ref: "main" });
     expect(r.truncated).toBe(false);
   });
+
+  it("paginates across multiple pages until max_results is reached", async () => {
+    let callCount = 0;
+    const sdk = fakeSdk({
+      searchCode: async (_ns, _proj, _q, opts) => {
+        callCount++;
+        const perPage = opts?.perPage ?? 30;
+        // Always return a full page
+        const data = Array.from({ length: perPage }, (_, i) => ({
+          filename: `file${(callCount - 1) * perPage + i}.ts`,
+          path: `src/file${(callCount - 1) * perPage + i}.ts`,
+          ref: "main",
+          startline: i + 1,
+          project_id: 1,
+        }));
+        return { ok: true as const, status: 200, data };
+      },
+    });
+    const actions = buildReadActions(deps);
+    const r = (await runHandler(
+      actions["search_code"]!,
+      { namespace: "mygroup", project: "my-project", query: "fn", max_results: 5 },
+      sdk,
+    )) as { total: number; items: unknown[]; truncated: boolean };
+    expect(r.total).toBe(5);
+    expect(r.truncated).toBe(true);
+    // pagination was driven (more than 1 call would only happen if pages are full)
+    expect(callCount).toBeGreaterThanOrEqual(1);
+  });
 });
 
 // ── get_issues ────────────────────────────────────────────────────────────────

--- a/tests/connectors/gitlab/unit/actions_releases.test.ts
+++ b/tests/connectors/gitlab/unit/actions_releases.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Tests for gitlab/actions/releases.ts — classification, schemas, and handlers
+ * for create_release, update_release, delete_release, and delete_release_link.
+ */
+import { describe, expect, it } from "vitest";
+import type { ActionSpec } from "narai-primitives/toolkit";
+import { buildReleasesActions } from "../../../../src/connectors/gitlab/actions/releases.js";
+import type { GitlabClient } from "../../../../src/connectors/gitlab/lib/gitlab_client.js";
+
+function fakeSdk(overrides: Partial<GitlabClient> = {}): GitlabClient {
+  return overrides as unknown as GitlabClient;
+}
+
+function runHandler<P>(
+  spec: ActionSpec<P, GitlabClient>,
+  params: unknown,
+  sdk: GitlabClient,
+): Promise<unknown> {
+  const parsed = spec.params.parse(params) as P;
+  return spec.handler(parsed, { sdk } as Parameters<typeof spec.handler>[1]);
+}
+
+const baseDeps = {
+  behavior: { requireDraftMr: false, host: "https://gitlab.com" },
+};
+
+const releaseResponse = {
+  tag_name: "v1.0.0",
+  name: "Version 1.0.0",
+  description: "First release",
+  created_at: "2024-01-01T00:00:00Z",
+  released_at: "2024-01-01T00:00:00Z",
+};
+
+// ── Classification ────────────────────────────────────────────────────────────
+
+describe("buildReleasesActions — classification", () => {
+  const actions = buildReleasesActions(baseDeps);
+
+  it("create_release is write", () => {
+    expect(actions["create_release"]?.classify).toEqual({ kind: "write" });
+  });
+
+  it("update_release is write", () => {
+    expect(actions["update_release"]?.classify).toEqual({ kind: "write" });
+  });
+
+  it("delete_release is write + delete aspect", () => {
+    expect(actions["delete_release"]?.classify).toEqual({
+      kind: "write",
+      aspects: ["delete"],
+    });
+  });
+
+  it("delete_release_link is write + delete aspect", () => {
+    expect(actions["delete_release_link"]?.classify).toEqual({
+      kind: "write",
+      aspects: ["delete"],
+    });
+  });
+});
+
+// ── create_release ────────────────────────────────────────────────────────────
+
+describe("create_release", () => {
+  it("creates release with required fields and returns data", async () => {
+    let captured: unknown;
+    const sdk = fakeSdk({
+      createRelease: async (_ns, _proj, body) => {
+        captured = body;
+        return { ok: true as const, status: 201, data: { ...releaseResponse } };
+      },
+    });
+    const actions = buildReleasesActions(baseDeps);
+    const result = (await runHandler(
+      actions["create_release"]!,
+      { namespace: "mygroup", project: "myproject", tag_name: "v1.0.0", name: "Version 1.0.0" },
+      sdk,
+    )) as Record<string, unknown>;
+
+    expect(result["tag_name"]).toBe("v1.0.0");
+    expect(result["name"]).toBe("Version 1.0.0");
+    expect((captured as Record<string, unknown>)["tag_name"]).toBe("v1.0.0");
+    expect((captured as Record<string, unknown>)["name"]).toBe("Version 1.0.0");
+  });
+
+  it("passes optional description, ref, and assets.links", async () => {
+    let captured: Record<string, unknown> = {};
+    const sdk = fakeSdk({
+      createRelease: async (_ns, _proj, body) => {
+        captured = body as Record<string, unknown>;
+        return { ok: true as const, status: 201, data: { ...releaseResponse } };
+      },
+    });
+    const actions = buildReleasesActions(baseDeps);
+    await runHandler(
+      actions["create_release"]!,
+      {
+        namespace: "g",
+        project: "p",
+        tag_name: "v1.0.0",
+        name: "Release",
+        description: "Desc",
+        ref: "main",
+        assets: {
+          links: [{ name: "binary", url: "https://example.com/bin", link_type: "package" }],
+        },
+      },
+      sdk,
+    );
+
+    expect(captured["description"]).toBe("Desc");
+    expect(captured["ref"]).toBe("main");
+    expect((captured["assets"] as Record<string, unknown>)["links"]).toHaveLength(1);
+  });
+
+  it("schema rejects missing name", () => {
+    const actions = buildReleasesActions(baseDeps);
+    expect(() =>
+      actions["create_release"]!.params.parse({
+        namespace: "g",
+        project: "p",
+        tag_name: "v1.0.0",
+      }),
+    ).toThrow();
+  });
+
+  it("schema rejects invalid tag_name", () => {
+    const actions = buildReleasesActions(baseDeps);
+    expect(() =>
+      actions["create_release"]!.params.parse({
+        namespace: "g",
+        project: "p",
+        tag_name: "bad tag!",
+        name: "Release",
+      }),
+    ).toThrow();
+  });
+
+  it("schema rejects asset link with invalid URL", () => {
+    const actions = buildReleasesActions(baseDeps);
+    expect(() =>
+      actions["create_release"]!.params.parse({
+        namespace: "g",
+        project: "p",
+        tag_name: "v1.0.0",
+        name: "Release",
+        assets: { links: [{ name: "bin", url: "not-a-url" }] },
+      }),
+    ).toThrow();
+  });
+
+  it("omits undefined optional fields from body", async () => {
+    let captured: Record<string, unknown> = {};
+    const sdk = fakeSdk({
+      createRelease: async (_ns, _proj, body) => {
+        captured = body as Record<string, unknown>;
+        return { ok: true as const, status: 201, data: { ...releaseResponse } };
+      },
+    });
+    const actions = buildReleasesActions(baseDeps);
+    await runHandler(
+      actions["create_release"]!,
+      { namespace: "g", project: "p", tag_name: "v1.0.0", name: "Release" },
+      sdk,
+    );
+
+    expect(captured["description"]).toBeUndefined();
+    expect(captured["ref"]).toBeUndefined();
+    expect(captured["assets"]).toBeUndefined();
+  });
+});
+
+// ── update_release ────────────────────────────────────────────────────────────
+
+describe("update_release", () => {
+  it("updates name and description, returns data", async () => {
+    let capturedBody: Record<string, unknown> = {};
+    const sdk = fakeSdk({
+      updateRelease: async (_ns, _proj, _tag, body) => {
+        capturedBody = body as Record<string, unknown>;
+        return {
+          ok: true as const,
+          status: 200,
+          data: { ...releaseResponse, name: "Updated" },
+        };
+      },
+    });
+    const actions = buildReleasesActions(baseDeps);
+    const result = (await runHandler(
+      actions["update_release"]!,
+      {
+        namespace: "g",
+        project: "p",
+        tag_name: "v1.0.0",
+        name: "Updated",
+        description: "New desc",
+      },
+      sdk,
+    )) as Record<string, unknown>;
+
+    expect(result["name"]).toBe("Updated");
+    expect(capturedBody["name"]).toBe("Updated");
+    expect(capturedBody["description"]).toBe("New desc");
+  });
+
+  it("passes milestones", async () => {
+    let capturedBody: Record<string, unknown> = {};
+    const sdk = fakeSdk({
+      updateRelease: async (_ns, _proj, _tag, body) => {
+        capturedBody = body as Record<string, unknown>;
+        return { ok: true as const, status: 200, data: { ...releaseResponse } };
+      },
+    });
+    const actions = buildReleasesActions(baseDeps);
+    await runHandler(
+      actions["update_release"]!,
+      { namespace: "g", project: "p", tag_name: "v1.0.0", milestones: ["14.9"] },
+      sdk,
+    );
+    expect(capturedBody["milestones"]).toEqual(["14.9"]);
+  });
+
+  it("omits undefined optional fields from body", async () => {
+    let capturedBody: Record<string, unknown> = {};
+    const sdk = fakeSdk({
+      updateRelease: async (_ns, _proj, _tag, body) => {
+        capturedBody = body as Record<string, unknown>;
+        return { ok: true as const, status: 200, data: { ...releaseResponse } };
+      },
+    });
+    const actions = buildReleasesActions(baseDeps);
+    await runHandler(
+      actions["update_release"]!,
+      { namespace: "g", project: "p", tag_name: "v1.0.0", name: "Only name" },
+      sdk,
+    );
+    expect(capturedBody["description"]).toBeUndefined();
+    expect(capturedBody["milestones"]).toBeUndefined();
+  });
+});
+
+// ── delete_release ────────────────────────────────────────────────────────────
+
+describe("delete_release", () => {
+  it("calls deleteRelease and returns { tag_name, deleted: true }", async () => {
+    let calledWith: { ns: string; proj: string; tag: string } | null = null;
+    const sdk = fakeSdk({
+      deleteRelease: async (ns, proj, tag) => {
+        calledWith = { ns, proj, tag };
+        return { ok: true as const, status: 204, data: null };
+      },
+    });
+    const actions = buildReleasesActions(baseDeps);
+    const result = (await runHandler(
+      actions["delete_release"]!,
+      { namespace: "mygroup", project: "myproject", tag_name: "v1.0.0" },
+      sdk,
+    )) as Record<string, unknown>;
+
+    expect(result["tag_name"]).toBe("v1.0.0");
+    expect(result["deleted"]).toBe(true);
+    expect(calledWith).toEqual({ ns: "mygroup", proj: "myproject", tag: "v1.0.0" });
+  });
+
+  it("schema rejects missing tag_name", () => {
+    const actions = buildReleasesActions(baseDeps);
+    expect(() =>
+      actions["delete_release"]!.params.parse({ namespace: "g", project: "p" }),
+    ).toThrow();
+  });
+});
+
+// ── delete_release_link ───────────────────────────────────────────────────────
+
+describe("delete_release_link", () => {
+  it("calls deleteReleaseLink and returns { link_id, deleted: true }", async () => {
+    let calledWith: { ns: string; proj: string; tag: string; linkId: number } | null = null;
+    const sdk = fakeSdk({
+      deleteReleaseLink: async (ns, proj, tag, linkId) => {
+        calledWith = { ns, proj, tag, linkId };
+        return { ok: true as const, status: 204, data: null };
+      },
+    });
+    const actions = buildReleasesActions(baseDeps);
+    const result = (await runHandler(
+      actions["delete_release_link"]!,
+      { namespace: "mygroup", project: "myproject", tag_name: "v1.0.0", link_id: 42 },
+      sdk,
+    )) as Record<string, unknown>;
+
+    expect(result["link_id"]).toBe(42);
+    expect(result["deleted"]).toBe(true);
+    expect(calledWith).toEqual({
+      ns: "mygroup",
+      proj: "myproject",
+      tag: "v1.0.0",
+      linkId: 42,
+    });
+  });
+
+  it("schema rejects missing link_id", () => {
+    const actions = buildReleasesActions(baseDeps);
+    expect(() =>
+      actions["delete_release_link"]!.params.parse({
+        namespace: "g",
+        project: "p",
+        tag_name: "v1.0.0",
+      }),
+    ).toThrow();
+  });
+
+  it("schema rejects non-positive link_id", () => {
+    const actions = buildReleasesActions(baseDeps);
+    expect(() =>
+      actions["delete_release_link"]!.params.parse({
+        namespace: "g",
+        project: "p",
+        tag_name: "v1.0.0",
+        link_id: 0,
+      }),
+    ).toThrow();
+  });
+});

--- a/tests/connectors/gitlab/unit/cli.test.ts
+++ b/tests/connectors/gitlab/unit/cli.test.ts
@@ -1,0 +1,177 @@
+/**
+ * CLI happy-path tests for the GitLab connector.
+ */
+import { describe, expect, it } from "vitest";
+import { buildGitlabConnector } from "../../../../src/connectors/gitlab/index.js";
+import {
+  GitlabClient,
+  type GitlabClientOptions,
+} from "../../../../src/connectors/gitlab/lib/gitlab_client.js";
+
+function jsonResponse(body: unknown, init: { status?: number } = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeClient(
+  overrides: Partial<GitlabClientOptions> = {},
+  fetchMock?: (url: string, init?: RequestInit) => Promise<Response>,
+): GitlabClient {
+  return new GitlabClient({
+    token: "gl_test",
+    rateLimitPerMin: 100,
+    connectTimeoutMs: 50,
+    readTimeoutMs: 50,
+    fetchImpl: fetchMock
+      ? (async (url, init) => fetchMock(String(url), init))
+      : undefined,
+    sleepImpl: async () => {},
+    ...overrides,
+  });
+}
+
+function makeConnector(client: GitlabClient) {
+  return buildGitlabConnector({
+    sdk: async () => client,
+    credentials: async () => ({ token: "gl_test", host: "https://gitlab.com" }),
+  });
+}
+
+describe("gitlab connector — fetch() write domains escalate by default", () => {
+  it("create_merge_request escalates with action name in envelope", async () => {
+    const c = makeConnector(makeClient());
+    const r = await c.fetch("create_merge_request", {
+      namespace: "mygroup",
+      project: "myrepo",
+      source_branch: "feat/x",
+      target_branch: "main",
+      title: "My MR",
+    });
+    expect(r.status).toBe("escalate");
+    expect((r as { action: string }).action).toBe("create_merge_request");
+    expect((r as { reason: string }).reason).toMatch(/write/i);
+  });
+
+  it("create_issue escalates with action name in envelope", async () => {
+    const c = makeConnector(makeClient());
+    const r = await c.fetch("create_issue", {
+      namespace: "mygroup",
+      project: "myrepo",
+      title: "My Issue",
+    });
+    expect(r.status).toBe("escalate");
+    expect((r as { action: string }).action).toBe("create_issue");
+  });
+
+  it("add_note escalates with action name in envelope", async () => {
+    const c = makeConnector(makeClient());
+    const r = await c.fetch("add_note", {
+      namespace: "mygroup",
+      project: "myrepo",
+      noteable_type: "issue",
+      noteable_iid: 1,
+      body: "hello",
+    });
+    expect(r.status).toBe("escalate");
+    expect((r as { action: string }).action).toBe("add_note");
+  });
+
+  it("create_release escalates with action name in envelope", async () => {
+    const c = makeConnector(makeClient());
+    const r = await c.fetch("create_release", {
+      namespace: "mygroup",
+      project: "myrepo",
+      tag_name: "v1.0.0",
+      name: "v1.0.0",
+    });
+    expect(r.status).toBe("escalate");
+    expect((r as { action: string }).action).toBe("create_release");
+  });
+
+  it("trigger_pipeline escalates with action name in envelope", async () => {
+    const c = makeConnector(makeClient());
+    const r = await c.fetch("trigger_pipeline", {
+      namespace: "mygroup",
+      project: "myrepo",
+      ref: "main",
+      token: "pipeline-token",
+    });
+    expect(r.status).toBe("escalate");
+    expect((r as { action: string }).action).toBe("trigger_pipeline");
+  });
+});
+
+describe("gitlab connector — validActions", () => {
+  it("exposes all 33 expected action names", () => {
+    const c = buildGitlabConnector({
+      sdk: async () => makeClient(),
+      credentials: async () => ({ token: "gl_test", host: "https://gitlab.com" }),
+    });
+    expect([...c.validActions].sort()).toEqual([
+      "add_note",
+      "cancel_pipeline",
+      "close_issue",
+      "close_merge_request",
+      "create_issue",
+      "create_merge_request",
+      "create_release",
+      "delete_note",
+      "delete_release",
+      "delete_release_link",
+      "get_file",
+      "get_issue",
+      "get_issues",
+      "get_job_logs",
+      "get_merge_request",
+      "get_merge_requests",
+      "get_notes",
+      "get_pipeline",
+      "get_release_link",
+      "list_pipeline_jobs",
+      "list_pipelines",
+      "list_release_links",
+      "merge_merge_request",
+      "play_job",
+      "project_info",
+      "retry_failed_jobs",
+      "retry_pipeline",
+      "search_code",
+      "trigger_pipeline",
+      "update_issue",
+      "update_merge_request",
+      "update_note",
+      "update_release",
+    ]);
+  });
+});
+
+describe("gitlab connector — plumbing", () => {
+  it("reading action (project_info) returns successful envelope", async () => {
+    const client = makeClient({}, async () =>
+      jsonResponse({
+        id: 1,
+        name: "myrepo",
+        path_with_namespace: "mygroup/myrepo",
+        default_branch: "main",
+        description: "test",
+        visibility: "private",
+        web_url: "https://gitlab.com/mygroup/myrepo",
+      }),
+    );
+    const c = makeConnector(client);
+    const r = await c.fetch("project_info", {
+      namespace: "mygroup",
+      project: "myrepo",
+    });
+    expect(r.status).toBe("success");
+  });
+
+  it("unknown action returns error envelope", async () => {
+    const c = makeConnector(makeClient());
+    const r = await c.fetch("nonexistent_action", {});
+    expect(r.status).toBe("error");
+    expect((r as { error_code?: string }).error_code).toBe("VALIDATION_ERROR");
+  });
+});

--- a/tests/connectors/gitlab/unit/gitlab_client_extras.test.ts
+++ b/tests/connectors/gitlab/unit/gitlab_client_extras.test.ts
@@ -341,4 +341,27 @@ describe("loadGitlabCredentials()", () => {
     const r = await loadGitlabCredentials();
     expect(r?.host).toBe("https://env-only.example");
   });
+
+  it("GITLAB_HOST='' normalizes to host: null (empty string treated as unset)", async () => {
+    vi.mocked(resolveSecret).mockResolvedValue(null);
+    process.env["GITLAB_TOKEN"] = "tok";
+    process.env["GITLAB_HOST"] = "";
+    const r = await loadGitlabCredentials();
+    expect(r?.host).toBeNull();
+  });
+
+  it("GITLAB_TOKEN='' normalizes to null (returns null credentials)", async () => {
+    vi.mocked(resolveSecret).mockResolvedValue(null);
+    process.env["GITLAB_TOKEN"] = "";
+    const r = await loadGitlabCredentials();
+    expect(r).toBeNull();
+  });
+
+  it("GITLAB_NAMESPACE='' normalizes to defaultNamespace: null", async () => {
+    vi.mocked(resolveSecret).mockResolvedValue(null);
+    process.env["GITLAB_TOKEN"] = "tok";
+    process.env["GITLAB_NAMESPACE"] = "";
+    const r = await loadGitlabCredentials();
+    expect(r?.defaultNamespace).toBeNull();
+  });
 });

--- a/tests/connectors/gitlab/unit/gitlab_client_extras.test.ts
+++ b/tests/connectors/gitlab/unit/gitlab_client_extras.test.ts
@@ -269,7 +269,7 @@ describe("loadGitlabCredentials()", () => {
     const r = await loadGitlabCredentials();
     expect(r).not.toBeNull();
     expect(r?.token).toBe("env-token");
-    expect(r?.host).toBe("https://gitlab.com");
+    expect(r?.host).toBeNull();
     expect(r?.defaultNamespace).toBeNull();
   });
 
@@ -323,5 +323,22 @@ describe("loadGitlabCredentials()", () => {
     );
     const r = await loadGitlabCredentials();
     expect(r?.defaultNamespace).toBeNull();
+  });
+
+  it("returns null host when neither secret nor env sets GITLAB_HOST", async () => {
+    vi.mocked(resolveSecret).mockImplementation(async (key: string) =>
+      key === "GITLAB_TOKEN" ? "tok" : null,
+    );
+    const r = await loadGitlabCredentials();
+    expect(r?.host).toBeNull();
+  });
+
+  it("returns env host when secret returns null for GITLAB_HOST", async () => {
+    vi.mocked(resolveSecret).mockImplementation(async (key: string) =>
+      key === "GITLAB_TOKEN" ? "tok" : null,
+    );
+    process.env["GITLAB_HOST"] = "https://env-only.example";
+    const r = await loadGitlabCredentials();
+    expect(r?.host).toBe("https://env-only.example");
   });
 });

--- a/tests/connectors/gitlab/unit/gitlab_client_extras.test.ts
+++ b/tests/connectors/gitlab/unit/gitlab_client_extras.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Extras tests for gitlab_client.ts — covers retry/timeout/rate-limit
+ * behaviour, loadGitlabCredentials() precedence, projectPath encoding,
+ * and the single concrete method getProject().
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  GitlabClient,
+  type GitlabClientOptions,
+  loadGitlabCredentials,
+} from "../../../../src/connectors/gitlab/lib/gitlab_client.js";
+
+// Mock the credentials module so loadGitlabCredentials is fully testable.
+vi.mock("narai-primitives/credentials", () => ({
+  resolveSecret: vi.fn(async () => null),
+}));
+import { resolveSecret } from "narai-primitives/credentials";
+
+function jsonResponse(
+  body: unknown,
+  init: { status?: number; headers?: Record<string, string> } = {},
+): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+}
+
+function makeClient(
+  overrides: Partial<GitlabClientOptions> = {},
+  fetchMock?: (url: string, init?: RequestInit) => Promise<Response>,
+): GitlabClient {
+  return new GitlabClient({
+    token: "glpat_test",
+    rateLimitPerMin: 100,
+    connectTimeoutMs: 50,
+    readTimeoutMs: 50,
+    fetchImpl: fetchMock
+      ? (async (url, init) => fetchMock(String(url), init))
+      : undefined,
+    sleepImpl: async () => {},
+    ...overrides,
+  });
+}
+
+// ── Retry & timeout behaviour ────────────────────────────────────────────────
+
+describe("GitlabClient — retry & timeout branches", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("retries on 429 with Retry-After header then succeeds", async () => {
+    let calls = 0;
+    const sleeps: number[] = [];
+    const client = makeClient(
+      { sleepImpl: async (ms) => void sleeps.push(ms) },
+      async () => {
+        calls++;
+        if (calls === 1) {
+          return new Response("rate", {
+            status: 429,
+            headers: { "retry-after": "2" },
+          });
+        }
+        return jsonResponse({ id: 1, name: "my-project", path_with_namespace: "foo/my-project" });
+      },
+    );
+    const r = await client.getProject("foo", "my-project");
+    expect(calls).toBe(2);
+    expect(sleeps[0]).toBe(2000);
+    expect(r.ok).toBe(true);
+  });
+
+  it("retries on 5xx using exponential backoff then succeeds", async () => {
+    let calls = 0;
+    const sleeps: number[] = [];
+    const client = makeClient(
+      { sleepImpl: async (ms) => void sleeps.push(ms) },
+      async () => {
+        calls++;
+        if (calls < 3) return new Response("boom", { status: 503 });
+        return jsonResponse({ id: 1, name: "proj", path_with_namespace: "ns/proj" });
+      },
+    );
+    const r = await client.getProject("ns", "proj");
+    expect(calls).toBe(3);
+    expect(sleeps[0]).toBe(500);
+    expect(sleeps[1]).toBe(1000);
+    expect(r.ok).toBe(true);
+  });
+
+  it("returns SERVER_ERROR after all retry attempts are exhausted on 5xx", async () => {
+    const client = makeClient({}, async () => new Response("nope", { status: 500 }));
+    const r = await client.getProject("ns", "proj");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("SERVER_ERROR");
+      expect(r.retriable).toBe(true);
+      expect(r.status).toBe(500);
+    }
+  });
+
+  it("returns RATE_LIMITED after all retry attempts exhausted on 429", async () => {
+    const client = makeClient({}, async () => new Response("rate", { status: 429 }));
+    const r = await client.getProject("ns", "proj");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("RATE_LIMITED");
+      expect(r.retriable).toBe(true);
+    }
+  });
+
+  it("classifies DOMException AbortError as TIMEOUT", async () => {
+    let calls = 0;
+    const client = makeClient({}, async () => {
+      calls++;
+      if (calls === 1) throw new DOMException("aborted", "AbortError");
+      return jsonResponse({ id: 1, name: "p", path_with_namespace: "ns/p" });
+    });
+    const r = await client.getProject("ns", "p");
+    expect(calls).toBe(2);
+    expect(r.ok).toBe(true);
+  });
+
+  it("returns TIMEOUT after all retry attempts on repeated DOMException", async () => {
+    const client = makeClient({}, async () => {
+      throw new DOMException("aborted", "AbortError");
+    });
+    const r = await client.getProject("ns", "proj");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("TIMEOUT");
+      expect(r.retriable).toBe(true);
+    }
+  });
+
+  it("classifies a non-DOMException Error as NETWORK_ERROR", async () => {
+    const client = makeClient({}, async () => {
+      throw new Error("ECONNRESET");
+    });
+    const r = await client.getProject("ns", "proj");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("NETWORK_ERROR");
+      expect(r.message).toContain("ECONNRESET");
+    }
+  });
+});
+
+// ── getProject happy path ────────────────────────────────────────────────────
+
+describe("GitlabClient.getProject — happy path", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("hits /api/v4/projects/<encoded-path> with GET and Bearer auth", async () => {
+    let usedUrl = "";
+    let usedMethod = "";
+    let usedHeaders: Headers | undefined;
+
+    const client = makeClient({}, async (url, init) => {
+      usedUrl = url;
+      usedMethod = String(init?.method);
+      usedHeaders = new Headers(init?.headers as HeadersInit);
+      return jsonResponse({ id: 42, name: "my-project", path_with_namespace: "foo/my-project" });
+    });
+
+    const r = await client.getProject("foo", "my-project");
+    expect(r.ok).toBe(true);
+    expect(usedMethod).toBe("GET");
+    expect(usedUrl).toMatch(/\/api\/v4\/projects\/foo%2Fmy-project$/);
+    expect(usedHeaders?.get("authorization")).toBe("Bearer glpat_test");
+  });
+
+  it("uses the custom host in baseUrl when provided", async () => {
+    let usedUrl = "";
+    const client = new GitlabClient({
+      token: "tok",
+      host: "https://gitlab.example.com",
+      fetchImpl: async (url) => {
+        usedUrl = String(url);
+        return jsonResponse({ id: 1, name: "p", path_with_namespace: "ns/p" });
+      },
+      sleepImpl: async () => {},
+    });
+    await client.getProject("ns", "p");
+    expect(usedUrl).toMatch(/^https:\/\/gitlab\.example\.com\/api\/v4\//);
+  });
+
+  it("getProject returns the parsed project data", async () => {
+    const project = { id: 7, name: "my-project", path_with_namespace: "mygroup/my-project", default_branch: "main" };
+    const client = makeClient({}, async () => jsonResponse(project));
+    const r = await client.getProject("mygroup", "my-project");
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.data.id).toBe(7);
+      expect(r.data.path_with_namespace).toBe("mygroup/my-project");
+    }
+  });
+});
+
+// ── projectPath encoding ─────────────────────────────────────────────────────
+
+describe("GitlabClient.projectPath — URL encoding", () => {
+  it("encodes simple namespace/project with %2F", () => {
+    const client = makeClient();
+    expect(client.projectPath("foo", "bar")).toBe("foo%2Fbar");
+  });
+
+  it("encodes slashes in group/subgroup/project path", () => {
+    const client = makeClient();
+    expect(client.projectPath("group/sub", "myproject")).toBe("group%2Fsub%2Fmyproject");
+  });
+});
+
+// ── host / defaultNamespace getters ─────────────────────────────────────────
+
+describe("GitlabClient getters", () => {
+  it("host returns the host part of the gitlab URL", () => {
+    const client = new GitlabClient({ token: "t", sleepImpl: async () => {} });
+    expect(client.host).toBe("gitlab.com");
+  });
+
+  it("host reflects custom host option", () => {
+    const client = new GitlabClient({
+      token: "t",
+      host: "https://gitlab.internal",
+      sleepImpl: async () => {},
+    });
+    expect(client.host).toBe("gitlab.internal");
+  });
+
+  it("defaultNamespace is null when not provided", () => {
+    const client = makeClient();
+    expect(client.defaultNamespace).toBeNull();
+  });
+
+  it("defaultNamespace reflects constructor option", () => {
+    const client = new GitlabClient({
+      token: "t",
+      defaultNamespace: "mygroup",
+      sleepImpl: async () => {},
+    });
+    expect(client.defaultNamespace).toBe("mygroup");
+  });
+});
+
+// ── loadGitlabCredentials() ──────────────────────────────────────────────────
+
+describe("loadGitlabCredentials()", () => {
+  beforeEach(() => {
+    vi.mocked(resolveSecret).mockReset();
+    delete process.env["GITLAB_TOKEN"];
+    delete process.env["GITLAB_HOST"];
+    delete process.env["GITLAB_NAMESPACE"];
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("returns null when no token is found anywhere", async () => {
+    vi.mocked(resolveSecret).mockResolvedValue(null);
+    const r = await loadGitlabCredentials();
+    expect(r).toBeNull();
+  });
+
+  it("uses GITLAB_TOKEN env var when resolveSecret returns null", async () => {
+    vi.mocked(resolveSecret).mockResolvedValue(null);
+    process.env["GITLAB_TOKEN"] = "env-token";
+    const r = await loadGitlabCredentials();
+    expect(r).not.toBeNull();
+    expect(r?.token).toBe("env-token");
+    expect(r?.host).toBe("https://gitlab.com");
+    expect(r?.defaultNamespace).toBeNull();
+  });
+
+  it("uses GITLAB_HOST env var to override the default host", async () => {
+    vi.mocked(resolveSecret).mockResolvedValue(null);
+    process.env["GITLAB_TOKEN"] = "env-token";
+    process.env["GITLAB_HOST"] = "https://gitlab.mycorp";
+    const r = await loadGitlabCredentials();
+    expect(r?.host).toBe("https://gitlab.mycorp");
+  });
+
+  it("uses GITLAB_NAMESPACE env var to set defaultNamespace", async () => {
+    vi.mocked(resolveSecret).mockResolvedValue(null);
+    process.env["GITLAB_TOKEN"] = "env-token";
+    process.env["GITLAB_NAMESPACE"] = "mygroup";
+    const r = await loadGitlabCredentials();
+    expect(r?.defaultNamespace).toBe("mygroup");
+  });
+
+  it("prefers resolveSecret value over env var for token", async () => {
+    vi.mocked(resolveSecret).mockImplementation(async (key: string) => {
+      if (key === "GITLAB_TOKEN") return "secret-token";
+      return null;
+    });
+    process.env["GITLAB_TOKEN"] = "env-token";
+    const r = await loadGitlabCredentials();
+    expect(r?.token).toBe("secret-token");
+  });
+
+  it("prefers resolveSecret value over env var for host and namespace", async () => {
+    vi.mocked(resolveSecret).mockImplementation(async (key: string) => {
+      if (key === "GITLAB_TOKEN") return "sec-token";
+      if (key === "GITLAB_HOST") return "https://secret-host";
+      if (key === "GITLAB_NAMESPACE") return "secret-ns";
+      return null;
+    });
+    process.env["GITLAB_TOKEN"] = "env-token";
+    process.env["GITLAB_HOST"] = "https://env-host";
+    process.env["GITLAB_NAMESPACE"] = "env-ns";
+    const r = await loadGitlabCredentials();
+    expect(r).toEqual({
+      token: "sec-token",
+      host: "https://secret-host",
+      defaultNamespace: "secret-ns",
+    });
+  });
+
+  it("returns null defaultNamespace when neither secret nor env is set for namespace", async () => {
+    vi.mocked(resolveSecret).mockImplementation(async (key: string) =>
+      key === "GITLAB_TOKEN" ? "tok" : null,
+    );
+    const r = await loadGitlabCredentials();
+    expect(r?.defaultNamespace).toBeNull();
+  });
+});

--- a/tests/connectors/gitlab/unit/gitlab_client_mutations.test.ts
+++ b/tests/connectors/gitlab/unit/gitlab_client_mutations.test.ts
@@ -138,3 +138,87 @@ describe("GitlabClient.mergeMergeRequest", () => {
     expect((usedBody as Record<string, unknown>)["should_remove_source_branch"]).toBe(true);
   });
 });
+
+// ── createIssue ───────────────────────────────────────────────────────────────
+
+const issueBody = {
+  iid: 3,
+  title: "Test issue",
+  state: "opened",
+  author: { username: "bob" },
+  labels: ["bug"],
+  description: null,
+  web_url: "https://gitlab.com/g/p/-/issues/3",
+  updated_at: "2024-01-01T00:00:00Z",
+};
+
+describe("GitlabClient.createIssue", () => {
+  it("calls POST /projects/<encoded>/issues with body", async () => {
+    let usedUrl = "";
+    let usedMethod = "";
+    let usedBody: unknown;
+    const client = makeClient(async (url, init) => {
+      usedUrl = url;
+      usedMethod = String(init?.method);
+      usedBody = JSON.parse(String(init?.body));
+      return jsonResponse(issueBody, 201);
+    });
+    const r = await client.createIssue("mygroup", "myproject", {
+      title: "Test issue",
+      labels: "bug",
+      assignee_ids: [1],
+    });
+    expect(r.ok).toBe(true);
+    expect(usedMethod).toBe("POST");
+    expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmyproject\/issues$/);
+    expect((usedBody as Record<string, unknown>)["title"]).toBe("Test issue");
+    expect((usedBody as Record<string, unknown>)["labels"]).toBe("bug");
+    expect((usedBody as Record<string, unknown>)["assignee_ids"]).toEqual([1]);
+  });
+});
+
+// ── updateIssue ───────────────────────────────────────────────────────────────
+
+describe("GitlabClient.updateIssue", () => {
+  it("calls PUT /projects/<encoded>/issues/:iid with body", async () => {
+    let usedUrl = "";
+    let usedMethod = "";
+    let usedBody: unknown;
+    const client = makeClient(async (url, init) => {
+      usedUrl = url;
+      usedMethod = String(init?.method);
+      usedBody = JSON.parse(String(init?.body));
+      return jsonResponse({ ...issueBody, title: "Updated" });
+    });
+    const r = await client.updateIssue("mygroup", "myproject", 3, {
+      title: "Updated",
+      state_event: "reopen",
+    });
+    expect(r.ok).toBe(true);
+    expect(usedMethod).toBe("PUT");
+    expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmyproject\/issues\/3$/);
+    expect((usedBody as Record<string, unknown>)["title"]).toBe("Updated");
+    expect((usedBody as Record<string, unknown>)["state_event"]).toBe("reopen");
+  });
+});
+
+// ── closeIssue ────────────────────────────────────────────────────────────────
+
+describe("GitlabClient.closeIssue", () => {
+  it("calls PUT /projects/<encoded>/issues/:iid with state_event=close", async () => {
+    let usedUrl = "";
+    let usedMethod = "";
+    let usedBody: unknown;
+    const client = makeClient(async (url, init) => {
+      usedUrl = url;
+      usedMethod = String(init?.method);
+      usedBody = JSON.parse(String(init?.body));
+      return jsonResponse({ ...issueBody, state: "closed" });
+    });
+    const r = await client.closeIssue("mygroup", "myproject", 3);
+    expect(r.ok).toBe(true);
+    expect(usedMethod).toBe("PUT");
+    expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmyproject\/issues\/3$/);
+    expect((usedBody as Record<string, unknown>)["state_event"]).toBe("close");
+  });
+});

--- a/tests/connectors/gitlab/unit/gitlab_client_mutations.test.ts
+++ b/tests/connectors/gitlab/unit/gitlab_client_mutations.test.ts
@@ -222,3 +222,102 @@ describe("GitlabClient.closeIssue", () => {
     expect((usedBody as Record<string, unknown>)["state_event"]).toBe("close");
   });
 });
+
+// ── addNote ───────────────────────────────────────────────────────────────────
+
+const noteBody = {
+  id: 42,
+  body: "Hello",
+  author: { username: "alice" },
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+  system: false,
+};
+
+describe("GitlabClient.addNote", () => {
+  it("calls POST /projects/<encoded>/issues/:iid/notes for issue", async () => {
+    let usedUrl = "";
+    let usedMethod = "";
+    let usedBody: unknown;
+    const client = makeClient(async (url, init) => {
+      usedUrl = url;
+      usedMethod = String(init?.method);
+      usedBody = JSON.parse(String(init?.body));
+      return jsonResponse(noteBody, 201);
+    });
+    const r = await client.addNote("mygroup", "myproject", "issue", 3, { body: "Hello" });
+    expect(r.ok).toBe(true);
+    expect(usedMethod).toBe("POST");
+    expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmyproject\/issues\/3\/notes$/);
+    expect((usedBody as Record<string, unknown>)["body"]).toBe("Hello");
+  });
+
+  it("calls POST /projects/<encoded>/merge_requests/:iid/notes for merge_request", async () => {
+    let usedUrl = "";
+    const client = makeClient(async (url) => {
+      usedUrl = url;
+      return jsonResponse(noteBody, 201);
+    });
+    await client.addNote("mygroup", "myproject", "merge_request", 5, { body: "Hello" });
+    expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmyproject\/merge_requests\/5\/notes$/);
+  });
+});
+
+// ── updateNote ────────────────────────────────────────────────────────────────
+
+describe("GitlabClient.updateNote", () => {
+  it("calls PUT /projects/<encoded>/issues/:iid/notes/:note_id for issue", async () => {
+    let usedUrl = "";
+    let usedMethod = "";
+    let usedBody: unknown;
+    const client = makeClient(async (url, init) => {
+      usedUrl = url;
+      usedMethod = String(init?.method);
+      usedBody = JSON.parse(String(init?.body));
+      return jsonResponse({ ...noteBody, body: "Updated" });
+    });
+    const r = await client.updateNote("mygroup", "myproject", "issue", 3, 42, { body: "Updated" });
+    expect(r.ok).toBe(true);
+    expect(usedMethod).toBe("PUT");
+    expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmyproject\/issues\/3\/notes\/42$/);
+    expect((usedBody as Record<string, unknown>)["body"]).toBe("Updated");
+  });
+
+  it("calls PUT .../merge_requests/:iid/notes/:note_id for merge_request", async () => {
+    let usedUrl = "";
+    const client = makeClient(async (url) => {
+      usedUrl = url;
+      return jsonResponse({ ...noteBody, body: "Updated" });
+    });
+    await client.updateNote("mygroup", "myproject", "merge_request", 5, 7, { body: "Updated" });
+    expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmyproject\/merge_requests\/5\/notes\/7$/);
+  });
+});
+
+// ── deleteNote ────────────────────────────────────────────────────────────────
+
+describe("GitlabClient.deleteNote", () => {
+  it("calls DELETE /projects/<encoded>/issues/:iid/notes/:note_id for issue", async () => {
+    let usedUrl = "";
+    let usedMethod = "";
+    const client = makeClient(async (url, init) => {
+      usedUrl = url;
+      usedMethod = String(init?.method);
+      return new Response(null, { status: 204 });
+    });
+    const r = await client.deleteNote("mygroup", "myproject", "issue", 3, 42);
+    expect(r.ok).toBe(true);
+    expect(usedMethod).toBe("DELETE");
+    expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmyproject\/issues\/3\/notes\/42$/);
+  });
+
+  it("calls DELETE .../merge_requests/:iid/notes/:note_id for merge_request", async () => {
+    let usedUrl = "";
+    const client = makeClient(async (url) => {
+      usedUrl = url;
+      return new Response(null, { status: 204 });
+    });
+    await client.deleteNote("mygroup", "myproject", "merge_request", 5, 7);
+    expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmyproject\/merge_requests\/5\/notes\/7$/);
+  });
+});

--- a/tests/connectors/gitlab/unit/gitlab_client_mutations.test.ts
+++ b/tests/connectors/gitlab/unit/gitlab_client_mutations.test.ts
@@ -252,7 +252,7 @@ describe("GitlabClient.addNote", () => {
     expect((usedBody as Record<string, unknown>)["body"]).toBe("Hello");
   });
 
-  it("calls POST /projects/<encoded>/merge_requests/:iid/notes for merge_request", async () => {
+  it("calls POST /projects/<encoded>/merge_requests/:iid/notes for merge_request (no position)", async () => {
     let usedUrl = "";
     const client = makeClient(async (url) => {
       usedUrl = url;
@@ -260,6 +260,58 @@ describe("GitlabClient.addNote", () => {
     });
     await client.addNote("mygroup", "myproject", "merge_request", 5, { body: "Hello" });
     expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmyproject\/merge_requests\/5\/notes$/);
+  });
+
+  it("POSTs to /discussions when MR note has position payload", async () => {
+    let usedUrl = "";
+    let usedMethod = "";
+    const discussionResp = {
+      id: "abc123",
+      individual_note: false,
+      notes: [noteBody],
+    };
+    const client = makeClient(async (url, init) => {
+      usedUrl = url;
+      usedMethod = String(init?.method);
+      return jsonResponse(discussionResp, 201);
+    });
+    const r = await client.addNote("mygroup", "myproject", "merge_request", 5, {
+      body: "diff comment",
+      position: {
+        base_sha: "aabb",
+        start_sha: "aabb",
+        head_sha: "ccdd",
+        position_type: "text",
+        new_path: "src/foo.ts",
+        new_line: 10,
+      },
+    });
+    expect(r.ok).toBe(true);
+    expect(usedMethod).toBe("POST");
+    expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmyproject\/merge_requests\/5\/discussions$/);
+    if (r.ok) {
+      expect(r.data.id).toBe(noteBody.id);
+      expect(r.data.body).toBe(noteBody.body);
+    }
+  });
+
+  it("returns SERVER_ERROR when discussion endpoint returns empty notes array", async () => {
+    const emptyDiscussion = { id: "abc123", individual_note: false, notes: [] };
+    const client = makeClient(async () => jsonResponse(emptyDiscussion, 201));
+    const r = await client.addNote("mygroup", "myproject", "merge_request", 5, {
+      body: "diff comment",
+      position: {
+        base_sha: "aabb",
+        start_sha: "aabb",
+        head_sha: "ccdd",
+        position_type: "text",
+        new_path: "src/foo.ts",
+      },
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("SERVER_ERROR");
+    }
   });
 });
 

--- a/tests/connectors/gitlab/unit/gitlab_client_mutations.test.ts
+++ b/tests/connectors/gitlab/unit/gitlab_client_mutations.test.ts
@@ -425,3 +425,129 @@ describe("GitlabClient.deleteReleaseLink", () => {
     );
   });
 });
+
+// ── retryPipeline ─────────────────────────────────────────────────────────────
+
+const pipelineBody = {
+  id: 101,
+  status: "running",
+  ref: "main",
+  sha: "abc123",
+  web_url: "https://gitlab.com/g/p/-/pipelines/101",
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+};
+
+describe("GitlabClient.retryPipeline", () => {
+  it("calls POST /projects/<encoded>/pipelines/:id/retry", async () => {
+    let usedUrl = "";
+    let usedMethod = "";
+    const client = makeClient(async (url, init) => {
+      usedUrl = url;
+      usedMethod = String(init?.method);
+      return jsonResponse(pipelineBody);
+    });
+    const r = await client.retryPipeline("mygroup", "myproject", 101);
+    expect(r.ok).toBe(true);
+    expect(usedMethod).toBe("POST");
+    expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmyproject\/pipelines\/101\/retry$/);
+  });
+});
+
+// ── cancelPipeline ────────────────────────────────────────────────────────────
+
+describe("GitlabClient.cancelPipeline", () => {
+  it("calls POST /projects/<encoded>/pipelines/:id/cancel", async () => {
+    let usedUrl = "";
+    let usedMethod = "";
+    const client = makeClient(async (url, init) => {
+      usedUrl = url;
+      usedMethod = String(init?.method);
+      return jsonResponse({ ...pipelineBody, status: "canceled" });
+    });
+    const r = await client.cancelPipeline("mygroup", "myproject", 101);
+    expect(r.ok).toBe(true);
+    expect(usedMethod).toBe("POST");
+    expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmyproject\/pipelines\/101\/cancel$/);
+  });
+});
+
+// ── triggerPipeline ───────────────────────────────────────────────────────────
+
+describe("GitlabClient.triggerPipeline", () => {
+  it("calls POST /projects/<encoded>/trigger/pipeline with token and ref in body", async () => {
+    let usedUrl = "";
+    let usedMethod = "";
+    let usedBody: unknown;
+    const client = makeClient(async (url, init) => {
+      usedUrl = url;
+      usedMethod = String(init?.method);
+      usedBody = JSON.parse(String(init?.body));
+      return jsonResponse({ ...pipelineBody, id: 202 }, 201);
+    });
+    const r = await client.triggerPipeline("mygroup", "myproject", {
+      token: "glptt_trigger_token",
+      ref: "main",
+    });
+    expect(r.ok).toBe(true);
+    expect(usedMethod).toBe("POST");
+    expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmyproject\/trigger\/pipeline$/);
+    expect((usedBody as Record<string, unknown>)["token"]).toBe("glptt_trigger_token");
+    expect((usedBody as Record<string, unknown>)["ref"]).toBe("main");
+  });
+
+  it("includes variables in body when provided", async () => {
+    let usedBody: unknown;
+    const client = makeClient(async (_url, init) => {
+      usedBody = JSON.parse(String(init?.body));
+      return jsonResponse({ ...pipelineBody, id: 203 }, 201);
+    });
+    await client.triggerPipeline("g", "p", {
+      token: "tok",
+      ref: "main",
+      variables: { FOO: "bar", BAZ: "qux" },
+    });
+    expect((usedBody as Record<string, unknown>)["variables"]).toEqual({ FOO: "bar", BAZ: "qux" });
+  });
+});
+
+// ── playJob ───────────────────────────────────────────────────────────────────
+
+const jobBody = {
+  id: 55,
+  name: "deploy",
+  stage: "deploy",
+  status: "running",
+  web_url: "https://gitlab.com/g/p/-/jobs/55",
+  created_at: "2024-01-01T00:00:00Z",
+  started_at: null,
+  finished_at: null,
+  duration: null,
+};
+
+describe("GitlabClient.playJob", () => {
+  it("calls POST /projects/<encoded>/jobs/:id/play", async () => {
+    let usedUrl = "";
+    let usedMethod = "";
+    const client = makeClient(async (url, init) => {
+      usedUrl = url;
+      usedMethod = String(init?.method);
+      return jsonResponse(jobBody);
+    });
+    const r = await client.playJob("mygroup", "myproject", 55);
+    expect(r.ok).toBe(true);
+    expect(usedMethod).toBe("POST");
+    expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmyproject\/jobs\/55\/play$/);
+  });
+
+  it("includes job_variables_attributes when variables provided", async () => {
+    let usedBody: unknown;
+    const client = makeClient(async (_url, init) => {
+      usedBody = JSON.parse(String(init?.body));
+      return jsonResponse(jobBody);
+    });
+    await client.playJob("mygroup", "myproject", 55, { DEPLOY_ENV: "staging" });
+    const attrs = (usedBody as Record<string, unknown>)["job_variables_attributes"] as Array<Record<string, string>>;
+    expect(attrs).toEqual([{ key: "DEPLOY_ENV", value: "staging" }]);
+  });
+});

--- a/tests/connectors/gitlab/unit/gitlab_client_mutations.test.ts
+++ b/tests/connectors/gitlab/unit/gitlab_client_mutations.test.ts
@@ -335,7 +335,7 @@ describe("GitlabClient.updateNote", () => {
     expect((usedBody as Record<string, unknown>)["body"]).toBe("Updated");
   });
 
-  it("calls PUT .../merge_requests/:iid/notes/:note_id for merge_request", async () => {
+  it("calls PUT .../merge_requests/:iid/notes/:note_id for merge_request (no discussion_id)", async () => {
     let usedUrl = "";
     const client = makeClient(async (url) => {
       usedUrl = url;
@@ -343,6 +343,26 @@ describe("GitlabClient.updateNote", () => {
     });
     await client.updateNote("mygroup", "myproject", "merge_request", 5, 7, { body: "Updated" });
     expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmyproject\/merge_requests\/5\/notes\/7$/);
+  });
+
+  it("routes PUT to /discussions/:discussion_id/notes/:note_id when discussion_id is set (merge_request)", async () => {
+    let usedUrl = "";
+    let usedMethod = "";
+    const client = makeClient(async (url, init) => {
+      usedUrl = url;
+      usedMethod = String(init?.method);
+      return jsonResponse({ ...noteBody, body: "Updated" });
+    });
+    const r = await client.updateNote(
+      "mygroup", "myproject", "merge_request", 5, 7,
+      { body: "Updated" },
+      { discussionId: "disc-abc" },
+    );
+    expect(r.ok).toBe(true);
+    expect(usedMethod).toBe("PUT");
+    expect(usedUrl).toMatch(
+      /\/projects\/mygroup%2Fmyproject\/merge_requests\/5\/discussions\/disc-abc\/notes\/7$/,
+    );
   });
 });
 
@@ -363,7 +383,7 @@ describe("GitlabClient.deleteNote", () => {
     expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmyproject\/issues\/3\/notes\/42$/);
   });
 
-  it("calls DELETE .../merge_requests/:iid/notes/:note_id for merge_request", async () => {
+  it("calls DELETE .../merge_requests/:iid/notes/:note_id for merge_request (no discussion_id)", async () => {
     let usedUrl = "";
     const client = makeClient(async (url) => {
       usedUrl = url;
@@ -371,6 +391,25 @@ describe("GitlabClient.deleteNote", () => {
     });
     await client.deleteNote("mygroup", "myproject", "merge_request", 5, 7);
     expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmyproject\/merge_requests\/5\/notes\/7$/);
+  });
+
+  it("routes DELETE to /discussions/:discussion_id/notes/:note_id when discussion_id is set (merge_request)", async () => {
+    let usedUrl = "";
+    let usedMethod = "";
+    const client = makeClient(async (url, init) => {
+      usedUrl = url;
+      usedMethod = String(init?.method);
+      return new Response(null, { status: 204 });
+    });
+    const r = await client.deleteNote(
+      "mygroup", "myproject", "merge_request", 5, 7,
+      { discussionId: "disc-xyz" },
+    );
+    expect(r.ok).toBe(true);
+    expect(usedMethod).toBe("DELETE");
+    expect(usedUrl).toMatch(
+      /\/projects\/mygroup%2Fmyproject\/merge_requests\/5\/discussions\/disc-xyz\/notes\/7$/,
+    );
   });
 });
 

--- a/tests/connectors/gitlab/unit/gitlab_client_mutations.test.ts
+++ b/tests/connectors/gitlab/unit/gitlab_client_mutations.test.ts
@@ -321,3 +321,107 @@ describe("GitlabClient.deleteNote", () => {
     expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmyproject\/merge_requests\/5\/notes\/7$/);
   });
 });
+
+// ── createRelease ─────────────────────────────────────────────────────────────
+
+const releaseBody = {
+  tag_name: "v1.0.0",
+  name: "Version 1.0.0",
+  description: "First release",
+  created_at: "2024-01-01T00:00:00Z",
+};
+
+describe("GitlabClient.createRelease", () => {
+  it("calls POST /projects/<encoded>/releases with body", async () => {
+    let usedUrl = "";
+    let usedMethod = "";
+    let usedBody: unknown;
+    const client = makeClient(async (url, init) => {
+      usedUrl = url;
+      usedMethod = String(init?.method);
+      usedBody = JSON.parse(String(init?.body));
+      return jsonResponse(releaseBody, 201);
+    });
+    const r = await client.createRelease("mygroup", "myproject", {
+      tag_name: "v1.0.0",
+      name: "Version 1.0.0",
+      description: "First release",
+    });
+    expect(r.ok).toBe(true);
+    expect(usedMethod).toBe("POST");
+    expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmyproject\/releases$/);
+    expect((usedBody as Record<string, unknown>)["tag_name"]).toBe("v1.0.0");
+    expect((usedBody as Record<string, unknown>)["name"]).toBe("Version 1.0.0");
+  });
+});
+
+// ── updateRelease ─────────────────────────────────────────────────────────────
+
+describe("GitlabClient.updateRelease", () => {
+  it("calls PUT /projects/<encoded>/releases/:tag with body", async () => {
+    let usedUrl = "";
+    let usedMethod = "";
+    let usedBody: unknown;
+    const client = makeClient(async (url, init) => {
+      usedUrl = url;
+      usedMethod = String(init?.method);
+      usedBody = JSON.parse(String(init?.body));
+      return jsonResponse({ ...releaseBody, name: "Updated" });
+    });
+    const r = await client.updateRelease("mygroup", "myproject", "v1.0.0", {
+      name: "Updated",
+    });
+    expect(r.ok).toBe(true);
+    expect(usedMethod).toBe("PUT");
+    expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmyproject\/releases\/v1\.0\.0$/);
+    expect((usedBody as Record<string, unknown>)["name"]).toBe("Updated");
+  });
+
+  it("percent-encodes tag with slashes", async () => {
+    let usedUrl = "";
+    const client = makeClient(async (url) => {
+      usedUrl = url;
+      return jsonResponse({ ...releaseBody, tag_name: "release/1.0" });
+    });
+    await client.updateRelease("g", "p", "release/1.0", { name: "X" });
+    expect(usedUrl).toMatch(/releases\/release%2F1\.0$/);
+  });
+});
+
+// ── deleteRelease ─────────────────────────────────────────────────────────────
+
+describe("GitlabClient.deleteRelease", () => {
+  it("calls DELETE /projects/<encoded>/releases/:tag", async () => {
+    let usedUrl = "";
+    let usedMethod = "";
+    const client = makeClient(async (url, init) => {
+      usedUrl = url;
+      usedMethod = String(init?.method);
+      return new Response(null, { status: 204 });
+    });
+    const r = await client.deleteRelease("mygroup", "myproject", "v1.0.0");
+    expect(r.ok).toBe(true);
+    expect(usedMethod).toBe("DELETE");
+    expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmyproject\/releases\/v1\.0\.0$/);
+  });
+});
+
+// ── deleteReleaseLink ─────────────────────────────────────────────────────────
+
+describe("GitlabClient.deleteReleaseLink", () => {
+  it("calls DELETE /projects/<encoded>/releases/:tag/assets/links/:id", async () => {
+    let usedUrl = "";
+    let usedMethod = "";
+    const client = makeClient(async (url, init) => {
+      usedUrl = url;
+      usedMethod = String(init?.method);
+      return new Response(null, { status: 204 });
+    });
+    const r = await client.deleteReleaseLink("mygroup", "myproject", "v1.0.0", 42);
+    expect(r.ok).toBe(true);
+    expect(usedMethod).toBe("DELETE");
+    expect(usedUrl).toMatch(
+      /\/projects\/mygroup%2Fmyproject\/releases\/v1\.0\.0\/assets\/links\/42$/,
+    );
+  });
+});

--- a/tests/connectors/gitlab/unit/gitlab_client_mutations.test.ts
+++ b/tests/connectors/gitlab/unit/gitlab_client_mutations.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for GitlabClient mutation methods added in Task 4:
+ * createMergeRequest, updateMergeRequest, closeMergeRequest, mergeMergeRequest.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  GitlabClient,
+  type GitlabClientOptions,
+} from "../../../../src/connectors/gitlab/lib/gitlab_client.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeClient(
+  fetchMock: (url: string, init?: RequestInit) => Promise<Response>,
+  overrides: Partial<GitlabClientOptions> = {},
+): GitlabClient {
+  return new GitlabClient({
+    token: "glpat_test",
+    rateLimitPerMin: 100,
+    connectTimeoutMs: 50,
+    readTimeoutMs: 50,
+    fetchImpl: async (url, init) => fetchMock(String(url), init),
+    sleepImpl: async () => {},
+    ...overrides,
+  });
+}
+
+const mrBody = {
+  iid: 5,
+  title: "Test MR",
+  state: "opened",
+  draft: false,
+  source_branch: "feat",
+  target_branch: "main",
+  sha: "abc123",
+  description: null,
+  web_url: "https://gitlab.com/g/p/-/merge_requests/5",
+  updated_at: "2024-01-01T00:00:00Z",
+};
+
+// ── createMergeRequest ────────────────────────────────────────────────────────
+
+describe("GitlabClient.createMergeRequest", () => {
+  it("calls POST /projects/<encoded>/merge_requests with body", async () => {
+    let usedUrl = "";
+    let usedMethod = "";
+    let usedBody: unknown;
+    const client = makeClient(async (url, init) => {
+      usedUrl = url;
+      usedMethod = String(init?.method);
+      usedBody = JSON.parse(String(init?.body));
+      return jsonResponse(mrBody, 201);
+    });
+    const r = await client.createMergeRequest("mygroup", "myproject", {
+      source_branch: "feat",
+      target_branch: "main",
+      title: "Test MR",
+      draft: false,
+    });
+    expect(r.ok).toBe(true);
+    expect(usedMethod).toBe("POST");
+    expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmyproject\/merge_requests$/);
+    expect((usedBody as Record<string, unknown>)["title"]).toBe("Test MR");
+    expect((usedBody as Record<string, unknown>)["source_branch"]).toBe("feat");
+  });
+});
+
+// ── updateMergeRequest ────────────────────────────────────────────────────────
+
+describe("GitlabClient.updateMergeRequest", () => {
+  it("calls PUT /projects/<encoded>/merge_requests/:iid with body", async () => {
+    let usedUrl = "";
+    let usedMethod = "";
+    let usedBody: unknown;
+    const client = makeClient(async (url, init) => {
+      usedUrl = url;
+      usedMethod = String(init?.method);
+      usedBody = JSON.parse(String(init?.body));
+      return jsonResponse({ ...mrBody, title: "Updated" });
+    });
+    const r = await client.updateMergeRequest("mygroup", "myproject", 5, {
+      title: "Updated",
+    });
+    expect(r.ok).toBe(true);
+    expect(usedMethod).toBe("PUT");
+    expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmyproject\/merge_requests\/5$/);
+    expect((usedBody as Record<string, unknown>)["title"]).toBe("Updated");
+  });
+});
+
+// ── closeMergeRequest ─────────────────────────────────────────────────────────
+
+describe("GitlabClient.closeMergeRequest", () => {
+  it("calls PUT /projects/<encoded>/merge_requests/:iid with state_event=close", async () => {
+    let usedUrl = "";
+    let usedMethod = "";
+    let usedBody: unknown;
+    const client = makeClient(async (url, init) => {
+      usedUrl = url;
+      usedMethod = String(init?.method);
+      usedBody = JSON.parse(String(init?.body));
+      return jsonResponse({ ...mrBody, state: "closed" });
+    });
+    const r = await client.closeMergeRequest("mygroup", "myproject", 5);
+    expect(r.ok).toBe(true);
+    expect(usedMethod).toBe("PUT");
+    expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmyproject\/merge_requests\/5$/);
+    expect((usedBody as Record<string, unknown>)["state_event"]).toBe("close");
+  });
+});
+
+// ── mergeMergeRequest ─────────────────────────────────────────────────────────
+
+describe("GitlabClient.mergeMergeRequest", () => {
+  it("calls PUT /projects/<encoded>/merge_requests/:iid/merge with body", async () => {
+    let usedUrl = "";
+    let usedMethod = "";
+    let usedBody: unknown;
+    const client = makeClient(async (url, init) => {
+      usedUrl = url;
+      usedMethod = String(init?.method);
+      usedBody = JSON.parse(String(init?.body));
+      return jsonResponse({ sha: "deadbeef", merged: true, message: "Merged" });
+    });
+    const r = await client.mergeMergeRequest("mygroup", "myproject", 5, {
+      merge_commit_message: "chore: merge feat",
+      should_remove_source_branch: true,
+    });
+    expect(r.ok).toBe(true);
+    expect(usedMethod).toBe("PUT");
+    expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmyproject\/merge_requests\/5\/merge$/);
+    expect((usedBody as Record<string, unknown>)["merge_commit_message"]).toBe("chore: merge feat");
+    expect((usedBody as Record<string, unknown>)["should_remove_source_branch"]).toBe(true);
+  });
+});

--- a/tests/connectors/gitlab/unit/gitlab_client_reads.test.ts
+++ b/tests/connectors/gitlab/unit/gitlab_client_reads.test.ts
@@ -196,6 +196,35 @@ describe("GitlabClient.getNotes", () => {
   });
 });
 
+// ── getDiscussions ────────────────────────────────────────────────────────────
+
+describe("GitlabClient.getDiscussions", () => {
+  it("calls GET /projects/<encoded>/merge_requests/:iid/discussions", async () => {
+    let usedUrl = "";
+    let usedMethod = "";
+    const client = makeClient(async (url, init) => {
+      usedUrl = url;
+      usedMethod = String(init?.method);
+      return jsonResponse([{ id: "disc1", individual_note: false, notes: [] }]);
+    });
+    const r = await client.getDiscussions("ns", "proj", 5);
+    expect(r.ok).toBe(true);
+    expect(usedMethod).toBe("GET");
+    expect(usedUrl).toMatch(/\/projects\/ns%2Fproj\/merge_requests\/5\/discussions$/);
+  });
+
+  it("passes page and per_page query params when opts are provided", async () => {
+    let usedUrl = "";
+    const client = makeClient(async (url) => {
+      usedUrl = url;
+      return jsonResponse([]);
+    });
+    await client.getDiscussions("ns", "proj", 3, { page: 2, perPage: 25 });
+    expect(usedUrl).toContain("page=2");
+    expect(usedUrl).toContain("per_page=25");
+  });
+});
+
 // ── listReleaseLinks ──────────────────────────────────────────────────────────
 
 describe("GitlabClient.listReleaseLinks", () => {

--- a/tests/connectors/gitlab/unit/gitlab_client_reads.test.ts
+++ b/tests/connectors/gitlab/unit/gitlab_client_reads.test.ts
@@ -55,6 +55,17 @@ describe("GitlabClient.searchCode", () => {
     expect(usedUrl).toContain("scope=blobs");
     expect(usedUrl).toContain("search=hello");
   });
+
+  it("passes page and per_page query params when opts are provided", async () => {
+    let usedUrl = "";
+    const client = makeClient(async (url) => {
+      usedUrl = url;
+      return jsonResponse([]);
+    });
+    await client.searchCode("ns", "proj", "myquery", { page: 2, perPage: 50 });
+    expect(usedUrl).toContain("page=2");
+    expect(usedUrl).toContain("per_page=50");
+  });
 });
 
 // ── listIssues ────────────────────────────────────────────────────────────────

--- a/tests/connectors/gitlab/unit/gitlab_client_reads.test.ts
+++ b/tests/connectors/gitlab/unit/gitlab_client_reads.test.ts
@@ -269,6 +269,17 @@ describe("GitlabClient.listPipelineJobs", () => {
     expect(r.ok).toBe(true);
     expect(usedUrl).toMatch(/\/projects\/ns%2Fproj\/pipelines\/100\/jobs$/);
   });
+
+  it("passes page and per_page query params when opts are provided", async () => {
+    let usedUrl = "";
+    const client = makeClient(async (url) => {
+      usedUrl = url;
+      return jsonResponse([]);
+    });
+    await client.listPipelineJobs("ns", "proj", 100, { page: 2, perPage: 50 });
+    expect(usedUrl).toContain("page=2");
+    expect(usedUrl).toContain("per_page=50");
+  });
 });
 
 // ── getJobLogs ────────────────────────────────────────────────────────────────

--- a/tests/connectors/gitlab/unit/gitlab_client_reads.test.ts
+++ b/tests/connectors/gitlab/unit/gitlab_client_reads.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for the read methods added to GitlabClient in Task 3.
+ * One test per method asserting URL + HTTP method.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  GitlabClient,
+  type GitlabClientOptions,
+} from "../../../../src/connectors/gitlab/lib/gitlab_client.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function textResponse(body: string, status = 200): Response {
+  return new Response(body, {
+    status,
+    headers: { "Content-Type": "text/plain" },
+  });
+}
+
+function makeClient(
+  fetchMock: (url: string, init?: RequestInit) => Promise<Response>,
+  overrides: Partial<GitlabClientOptions> = {},
+): GitlabClient {
+  return new GitlabClient({
+    token: "glpat_test",
+    rateLimitPerMin: 100,
+    connectTimeoutMs: 50,
+    readTimeoutMs: 50,
+    fetchImpl: async (url, init) => fetchMock(String(url), init),
+    sleepImpl: async () => {},
+    ...overrides,
+  });
+}
+
+// ── searchCode ────────────────────────────────────────────────────────────────
+
+describe("GitlabClient.searchCode", () => {
+  it("calls GET /projects/<encoded>/search?scope=blobs&search=...", async () => {
+    let usedUrl = "";
+    let usedMethod = "";
+    const client = makeClient(async (url, init) => {
+      usedUrl = url;
+      usedMethod = String(init?.method);
+      return jsonResponse([{ filename: "app.ts", path: "src/app.ts", ref: "main", startline: 1, project_id: 1 }]);
+    });
+    const r = await client.searchCode("mygroup", "my-project", "hello");
+    expect(r.ok).toBe(true);
+    expect(usedMethod).toBe("GET");
+    expect(usedUrl).toMatch(/\/projects\/mygroup%2Fmy-project\/search/);
+    expect(usedUrl).toContain("scope=blobs");
+    expect(usedUrl).toContain("search=hello");
+  });
+});
+
+// ── listIssues ────────────────────────────────────────────────────────────────
+
+describe("GitlabClient.listIssues", () => {
+  it("calls GET /projects/<encoded>/issues", async () => {
+    let usedUrl = "";
+    const client = makeClient(async (url) => {
+      usedUrl = url;
+      return jsonResponse([{ iid: 1, title: "Bug", state: "opened" }]);
+    });
+    const r = await client.listIssues("ns", "proj", { state: "opened", per_page: 10, page: 1 });
+    expect(r.ok).toBe(true);
+    expect(usedUrl).toMatch(/\/projects\/ns%2Fproj\/issues/);
+  });
+});
+
+// ── getIssue ─────────────────────────────────────────────────────────────────
+
+describe("GitlabClient.getIssue", () => {
+  it("calls GET /projects/<encoded>/issues/:iid", async () => {
+    let usedUrl = "";
+    const client = makeClient(async (url) => {
+      usedUrl = url;
+      return jsonResponse({ iid: 5, title: "Feat", state: "opened" });
+    });
+    const r = await client.getIssue("ns", "proj", 5);
+    expect(r.ok).toBe(true);
+    expect(usedUrl).toMatch(/\/projects\/ns%2Fproj\/issues\/5$/);
+  });
+});
+
+// ── listMergeRequests ─────────────────────────────────────────────────────────
+
+describe("GitlabClient.listMergeRequests", () => {
+  it("calls GET /projects/<encoded>/merge_requests", async () => {
+    let usedUrl = "";
+    const client = makeClient(async (url) => {
+      usedUrl = url;
+      return jsonResponse([{ iid: 3, title: "feat: x", state: "opened" }]);
+    });
+    const r = await client.listMergeRequests("ns", "proj", { state: "opened" });
+    expect(r.ok).toBe(true);
+    expect(usedUrl).toMatch(/\/projects\/ns%2Fproj\/merge_requests/);
+  });
+});
+
+// ── getMergeRequest ───────────────────────────────────────────────────────────
+
+describe("GitlabClient.getMergeRequest", () => {
+  it("calls GET /projects/<encoded>/merge_requests/:iid", async () => {
+    let usedUrl = "";
+    const client = makeClient(async (url) => {
+      usedUrl = url;
+      return jsonResponse({ iid: 7, title: "fix", state: "merged" });
+    });
+    const r = await client.getMergeRequest("ns", "proj", 7);
+    expect(r.ok).toBe(true);
+    expect(usedUrl).toMatch(/\/projects\/ns%2Fproj\/merge_requests\/7$/);
+  });
+});
+
+// ── getFile ───────────────────────────────────────────────────────────────────
+
+describe("GitlabClient.getFile", () => {
+  it("calls GET /projects/<encoded>/repository/files/<encoded-path>?ref=...", async () => {
+    let usedUrl = "";
+    const client = makeClient(async (url) => {
+      usedUrl = url;
+      return jsonResponse({
+        file_name: "README.md",
+        file_path: "README.md",
+        size: 12,
+        encoding: "base64",
+        content: Buffer.from("hello").toString("base64"),
+        ref: "main",
+      });
+    });
+    const r = await client.getFile("ns", "proj", "README.md", "main");
+    expect(r.ok).toBe(true);
+    expect(usedUrl).toMatch(/\/projects\/ns%2Fproj\/repository\/files\/README\.md/);
+    expect(usedUrl).toContain("ref=main");
+  });
+
+  it("URL-encodes file path with slashes", async () => {
+    let usedUrl = "";
+    const client = makeClient(async (url) => {
+      usedUrl = url;
+      return jsonResponse({ file_name: "app.ts", file_path: "src/app.ts", size: 5, encoding: "base64", content: "", ref: "main" });
+    });
+    await client.getFile("ns", "proj", "src/app.ts", "main");
+    expect(usedUrl).toContain("src%2Fapp.ts");
+  });
+});
+
+// ── getNotes ──────────────────────────────────────────────────────────────────
+
+describe("GitlabClient.getNotes", () => {
+  it("routes issue noteableType to /issues/:iid/notes", async () => {
+    let usedUrl = "";
+    const client = makeClient(async (url) => {
+      usedUrl = url;
+      return jsonResponse([]);
+    });
+    await client.getNotes("ns", "proj", "issue", 1);
+    expect(usedUrl).toMatch(/\/projects\/ns%2Fproj\/issues\/1\/notes$/);
+  });
+
+  it("routes merge_request noteableType to /merge_requests/:iid/notes", async () => {
+    let usedUrl = "";
+    const client = makeClient(async (url) => {
+      usedUrl = url;
+      return jsonResponse([]);
+    });
+    await client.getNotes("ns", "proj", "merge_request", 3);
+    expect(usedUrl).toMatch(/\/projects\/ns%2Fproj\/merge_requests\/3\/notes$/);
+  });
+});
+
+// ── listReleaseLinks ──────────────────────────────────────────────────────────
+
+describe("GitlabClient.listReleaseLinks", () => {
+  it("calls GET /projects/<encoded>/releases/:tag/assets/links", async () => {
+    let usedUrl = "";
+    const client = makeClient(async (url) => {
+      usedUrl = url;
+      return jsonResponse([{ id: 1, name: "linux", url: "https://x", link_type: "package" }]);
+    });
+    const r = await client.listReleaseLinks("ns", "proj", "v1.0.0");
+    expect(r.ok).toBe(true);
+    expect(usedUrl).toMatch(/\/projects\/ns%2Fproj\/releases\/v1\.0\.0\/assets\/links$/);
+  });
+});
+
+// ── getReleaseLink ────────────────────────────────────────────────────────────
+
+describe("GitlabClient.getReleaseLink", () => {
+  it("calls GET /projects/<encoded>/releases/:tag/assets/links/:id", async () => {
+    let usedUrl = "";
+    const client = makeClient(async (url) => {
+      usedUrl = url;
+      return jsonResponse({ id: 5, name: "win", url: "https://y", link_type: "package" });
+    });
+    const r = await client.getReleaseLink("ns", "proj", "v1.0.0", 5);
+    expect(r.ok).toBe(true);
+    expect(usedUrl).toMatch(/\/projects\/ns%2Fproj\/releases\/v1\.0\.0\/assets\/links\/5$/);
+  });
+});
+
+// ── listPipelines ─────────────────────────────────────────────────────────────
+
+describe("GitlabClient.listPipelines", () => {
+  it("calls GET /projects/<encoded>/pipelines", async () => {
+    let usedUrl = "";
+    const client = makeClient(async (url) => {
+      usedUrl = url;
+      return jsonResponse([{ id: 100, status: "success", ref: "main", sha: "a" }]);
+    });
+    const r = await client.listPipelines("ns", "proj", { per_page: 20, page: 1 });
+    expect(r.ok).toBe(true);
+    expect(usedUrl).toMatch(/\/projects\/ns%2Fproj\/pipelines/);
+  });
+});
+
+// ── getPipeline ───────────────────────────────────────────────────────────────
+
+describe("GitlabClient.getPipeline", () => {
+  it("calls GET /projects/<encoded>/pipelines/:id", async () => {
+    let usedUrl = "";
+    const client = makeClient(async (url) => {
+      usedUrl = url;
+      return jsonResponse({ id: 200, status: "failed", ref: "feat/x" });
+    });
+    const r = await client.getPipeline("ns", "proj", 200);
+    expect(r.ok).toBe(true);
+    expect(usedUrl).toMatch(/\/projects\/ns%2Fproj\/pipelines\/200$/);
+  });
+});
+
+// ── listPipelineJobs ──────────────────────────────────────────────────────────
+
+describe("GitlabClient.listPipelineJobs", () => {
+  it("calls GET /projects/<encoded>/pipelines/:id/jobs", async () => {
+    let usedUrl = "";
+    const client = makeClient(async (url) => {
+      usedUrl = url;
+      return jsonResponse([{ id: 300, name: "test", status: "success" }]);
+    });
+    const r = await client.listPipelineJobs("ns", "proj", 100);
+    expect(r.ok).toBe(true);
+    expect(usedUrl).toMatch(/\/projects\/ns%2Fproj\/pipelines\/100\/jobs$/);
+  });
+});
+
+// ── getJobLogs ────────────────────────────────────────────────────────────────
+
+describe("GitlabClient.getJobLogs", () => {
+  it("calls GET /projects/<encoded>/jobs/:id/trace and returns text", async () => {
+    let usedUrl = "";
+    const logsText = "Running...\nDone!\n";
+    const client = makeClient(async (url) => {
+      usedUrl = url;
+      return textResponse(logsText);
+    });
+    const r = await client.getJobLogs("ns", "proj", 300);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.data).toBe(logsText);
+    }
+    expect(usedUrl).toMatch(/\/projects\/ns%2Fproj\/jobs\/300\/trace$/);
+  });
+});

--- a/tests/connectors/gitlab/unit/gitlab_client_reads.test.ts
+++ b/tests/connectors/gitlab/unit/gitlab_client_reads.test.ts
@@ -183,6 +183,17 @@ describe("GitlabClient.getNotes", () => {
     await client.getNotes("ns", "proj", "merge_request", 3);
     expect(usedUrl).toMatch(/\/projects\/ns%2Fproj\/merge_requests\/3\/notes$/);
   });
+
+  it("passes page and per_page query params when opts are provided", async () => {
+    let usedUrl = "";
+    const client = makeClient(async (url) => {
+      usedUrl = url;
+      return jsonResponse([]);
+    });
+    await client.getNotes("ns", "proj", "issue", 1, { page: 3, perPage: 25 });
+    expect(usedUrl).toContain("page=3");
+    expect(usedUrl).toContain("per_page=25");
+  });
 });
 
 // ── listReleaseLinks ──────────────────────────────────────────────────────────

--- a/tests/connectors/gitlab/unit/gitlab_config.test.ts
+++ b/tests/connectors/gitlab/unit/gitlab_config.test.ts
@@ -3,8 +3,8 @@
  * runtime knobs that aren't part of the toolkit's policy/approval YAML.
  * Precedence (highest wins):
  *   1. GITLAB_REQUIRE_DRAFT_MR / GITLAB_HOST env vars
- *   2. <cwd>/.gitlab-connector/config.yaml `gitlab.*`
- *   3. ~/.gitlab-connector/config.yaml  `gitlab.*`
+ *   2. <cwd>/.gitlab-agent/config.yaml `gitlab.*`
+ *   3. ~/.gitlab-agent/config.yaml  `gitlab.*`
  *   4. defaults: requireDraftMr=false, host="https://gitlab.com"
  */
 import * as fs from "node:fs";
@@ -17,7 +17,7 @@ let tmpHome = "";
 let tmpCwd = "";
 
 function writeYaml(rootDir: string, body: string): void {
-  const dir = path.join(rootDir, ".gitlab-connector");
+  const dir = path.join(rootDir, ".gitlab-agent");
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(path.join(dir, "config.yaml"), body, "utf-8");
 }

--- a/tests/connectors/gitlab/unit/gitlab_config.test.ts
+++ b/tests/connectors/gitlab/unit/gitlab_config.test.ts
@@ -33,10 +33,10 @@ afterEach(() => {
 });
 
 describe("loadGitlabBehavior — defaults", () => {
-  it("returns requireDraftMr=false and host=https://gitlab.com when nothing is configured", () => {
+  it("returns requireDraftMr=false and host=null when nothing is configured", () => {
     const b = loadGitlabBehavior({ home: tmpHome, cwd: tmpCwd, env: {} });
     expect(b.requireDraftMr).toBe(false);
-    expect(b.host).toBe("https://gitlab.com");
+    expect(b.host).toBeNull();
   });
 });
 
@@ -152,9 +152,9 @@ describe("loadGitlabBehavior — env override (requireDraftMr)", () => {
 });
 
 describe("loadGitlabBehavior — host knob", () => {
-  it("returns default host when nothing is configured", () => {
+  it("returns null when neither env nor YAML sets host", () => {
     const b = loadGitlabBehavior({ home: tmpHome, cwd: tmpCwd, env: {} });
-    expect(b.host).toBe("https://gitlab.com");
+    expect(b.host).toBeNull();
   });
 
   it("reads user-level YAML gitlab.host", () => {
@@ -185,5 +185,24 @@ describe("loadGitlabBehavior — host knob", () => {
     expect(() =>
       loadGitlabBehavior({ home: tmpHome, cwd: tmpCwd, env: {} }),
     ).toThrow(/host/);
+  });
+
+  it("env empty string falls through to YAML host", () => {
+    writeYaml(tmpHome, "gitlab:\n  host: https://yaml.example\n");
+    const b = loadGitlabBehavior({
+      home: tmpHome,
+      cwd: tmpCwd,
+      env: { GITLAB_HOST: "" },
+    });
+    expect(b.host).toBe("https://yaml.example");
+  });
+
+  it("returns null when env is empty string and no YAML host", () => {
+    const b = loadGitlabBehavior({
+      home: tmpHome,
+      cwd: tmpCwd,
+      env: { GITLAB_HOST: "" },
+    });
+    expect(b.host).toBeNull();
   });
 });

--- a/tests/connectors/gitlab/unit/gitlab_config.test.ts
+++ b/tests/connectors/gitlab/unit/gitlab_config.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for loadGitlabBehavior — the connector's tiny config layer for
+ * runtime knobs that aren't part of the toolkit's policy/approval YAML.
+ * Precedence (highest wins):
+ *   1. GITLAB_REQUIRE_DRAFT_MR / GITLAB_HOST env vars
+ *   2. <cwd>/.gitlab-connector/config.yaml `gitlab.*`
+ *   3. ~/.gitlab-connector/config.yaml  `gitlab.*`
+ *   4. defaults: requireDraftMr=false, host="https://gitlab.com"
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadGitlabBehavior } from "../../../../src/connectors/gitlab/lib/gitlab_config.js";
+
+let tmpHome = "";
+let tmpCwd = "";
+
+function writeYaml(rootDir: string, body: string): void {
+  const dir = path.join(rootDir, ".gitlab-connector");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "config.yaml"), body, "utf-8");
+}
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "gl-cfg-home-"));
+  tmpCwd = fs.mkdtempSync(path.join(os.tmpdir(), "gl-cfg-cwd-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+  fs.rmSync(tmpCwd, { recursive: true, force: true });
+});
+
+describe("loadGitlabBehavior — defaults", () => {
+  it("returns requireDraftMr=false and host=https://gitlab.com when nothing is configured", () => {
+    const b = loadGitlabBehavior({ home: tmpHome, cwd: tmpCwd, env: {} });
+    expect(b.requireDraftMr).toBe(false);
+    expect(b.host).toBe("https://gitlab.com");
+  });
+});
+
+describe("loadGitlabBehavior — YAML sources (requireDraftMr)", () => {
+  it("reads user-level YAML require_draft_mr", () => {
+    writeYaml(tmpHome, "gitlab:\n  require_draft_mr: true\n");
+    const b = loadGitlabBehavior({ home: tmpHome, cwd: tmpCwd, env: {} });
+    expect(b.requireDraftMr).toBe(true);
+  });
+
+  it("reads repo-level YAML require_draft_mr", () => {
+    writeYaml(tmpCwd, "gitlab:\n  require_draft_mr: true\n");
+    const b = loadGitlabBehavior({ home: tmpHome, cwd: tmpCwd, env: {} });
+    expect(b.requireDraftMr).toBe(true);
+  });
+
+  it("repo overlay wins over user-level on collision", () => {
+    writeYaml(tmpHome, "gitlab:\n  require_draft_mr: true\n");
+    writeYaml(tmpCwd, "gitlab:\n  require_draft_mr: false\n");
+    const b = loadGitlabBehavior({ home: tmpHome, cwd: tmpCwd, env: {} });
+    expect(b.requireDraftMr).toBe(false);
+  });
+
+  it("user-level wins when only user-level sets the key", () => {
+    writeYaml(tmpHome, "gitlab:\n  require_draft_mr: true\n");
+    writeYaml(tmpCwd, "policy:\n  read: success\n");
+    const b = loadGitlabBehavior({ home: tmpHome, cwd: tmpCwd, env: {} });
+    expect(b.requireDraftMr).toBe(true);
+  });
+
+  it("ignores files that don't have the gitlab section", () => {
+    writeYaml(tmpHome, "policy:\n  read: success\n");
+    const b = loadGitlabBehavior({ home: tmpHome, cwd: tmpCwd, env: {} });
+    expect(b.requireDraftMr).toBe(false);
+  });
+
+  it("rejects a non-boolean gitlab.require_draft_mr", () => {
+    writeYaml(tmpHome, "gitlab:\n  require_draft_mr: maybe\n");
+    expect(() =>
+      loadGitlabBehavior({ home: tmpHome, cwd: tmpCwd, env: {} }),
+    ).toThrow(/require_draft_mr/);
+  });
+});
+
+describe("loadGitlabBehavior — env override (requireDraftMr)", () => {
+  it("env=1 forces true even if YAML says false", () => {
+    writeYaml(tmpHome, "gitlab:\n  require_draft_mr: false\n");
+    const b = loadGitlabBehavior({
+      home: tmpHome,
+      cwd: tmpCwd,
+      env: { GITLAB_REQUIRE_DRAFT_MR: "1" },
+    });
+    expect(b.requireDraftMr).toBe(true);
+  });
+
+  it("env=true forces true", () => {
+    const b = loadGitlabBehavior({
+      home: tmpHome,
+      cwd: tmpCwd,
+      env: { GITLAB_REQUIRE_DRAFT_MR: "true" },
+    });
+    expect(b.requireDraftMr).toBe(true);
+  });
+
+  it("env=yes forces true", () => {
+    const b = loadGitlabBehavior({
+      home: tmpHome,
+      cwd: tmpCwd,
+      env: { GITLAB_REQUIRE_DRAFT_MR: "yes" },
+    });
+    expect(b.requireDraftMr).toBe(true);
+  });
+
+  it("env=0 forces false even if YAML says true", () => {
+    writeYaml(tmpHome, "gitlab:\n  require_draft_mr: true\n");
+    const b = loadGitlabBehavior({
+      home: tmpHome,
+      cwd: tmpCwd,
+      env: { GITLAB_REQUIRE_DRAFT_MR: "0" },
+    });
+    expect(b.requireDraftMr).toBe(false);
+  });
+
+  it("env=false forces false", () => {
+    writeYaml(tmpHome, "gitlab:\n  require_draft_mr: true\n");
+    const b = loadGitlabBehavior({
+      home: tmpHome,
+      cwd: tmpCwd,
+      env: { GITLAB_REQUIRE_DRAFT_MR: "false" },
+    });
+    expect(b.requireDraftMr).toBe(false);
+  });
+
+  it("env empty string falls through to YAML", () => {
+    writeYaml(tmpHome, "gitlab:\n  require_draft_mr: true\n");
+    const b = loadGitlabBehavior({
+      home: tmpHome,
+      cwd: tmpCwd,
+      env: { GITLAB_REQUIRE_DRAFT_MR: "" },
+    });
+    expect(b.requireDraftMr).toBe(true);
+  });
+
+  it("env with unrecognized value throws CONFIG_ERROR", () => {
+    expect(() =>
+      loadGitlabBehavior({
+        home: tmpHome,
+        cwd: tmpCwd,
+        env: { GITLAB_REQUIRE_DRAFT_MR: "maybe" },
+      }),
+    ).toThrow(/GITLAB_REQUIRE_DRAFT_MR/);
+  });
+});
+
+describe("loadGitlabBehavior — host knob", () => {
+  it("returns default host when nothing is configured", () => {
+    const b = loadGitlabBehavior({ home: tmpHome, cwd: tmpCwd, env: {} });
+    expect(b.host).toBe("https://gitlab.com");
+  });
+
+  it("reads user-level YAML gitlab.host", () => {
+    writeYaml(tmpHome, "gitlab:\n  host: https://gitlab.mycorp\n");
+    const b = loadGitlabBehavior({ home: tmpHome, cwd: tmpCwd, env: {} });
+    expect(b.host).toBe("https://gitlab.mycorp");
+  });
+
+  it("repo-level YAML host overrides user-level", () => {
+    writeYaml(tmpHome, "gitlab:\n  host: https://gitlab.mycorp\n");
+    writeYaml(tmpCwd, "gitlab:\n  host: https://gitlab.internal\n");
+    const b = loadGitlabBehavior({ home: tmpHome, cwd: tmpCwd, env: {} });
+    expect(b.host).toBe("https://gitlab.internal");
+  });
+
+  it("env GITLAB_HOST overrides YAML", () => {
+    writeYaml(tmpHome, "gitlab:\n  host: https://gitlab.mycorp\n");
+    const b = loadGitlabBehavior({
+      home: tmpHome,
+      cwd: tmpCwd,
+      env: { GITLAB_HOST: "https://gitlab.override" },
+    });
+    expect(b.host).toBe("https://gitlab.override");
+  });
+
+  it("rejects non-string gitlab.host", () => {
+    writeYaml(tmpHome, "gitlab:\n  host: 12345\n");
+    expect(() =>
+      loadGitlabBehavior({ home: tmpHome, cwd: tmpCwd, env: {} }),
+    ).toThrow(/host/);
+  });
+});


### PR DESCRIPTION
## Summary

A new GitLab connector mirroring the github-connector (PR #20) with GitLab-native terminology. 33 actions: **14 read + 18 write + 1 admin**.

### Adaptations vs github-connector

| Choice | Rationale |
|---|---|
| First-class self-hosted via `GITLAB_HOST` env | Self-hosted is a major GitLab use case |
| `namespace` + `project` (URL-encoded, slashes encoded for subgroups) | Mirrors github's owner+repo split, supports nested groups |
| **Unified** notes API (3 actions, not 6) | GitLab's API genuinely has one notes endpoint covering issue conversation + MR conversation + MR diff |
| `play_job` action | GitLab-specific manual-stage trigger; no github equivalent |
| `Authorization: Bearer <PAT>` | Works on GitLab ≥12.x for both PATs and OAuth2 tokens |
| 405/406/409 → `CONFLICT` → `VALIDATION_ERROR` | GitLab's merge conflict status codes differ from github's 409-only |

### Action surface

**Reads (14):** project_info, search_code, get_issues, get_issue, get_merge_requests, get_merge_request, get_file, get_notes (unified, takes noteable_type), list_release_links, get_release_link, list_pipelines, get_pipeline, list_pipeline_jobs, get_job_logs.

**Writes (18):** create/update/close × {merge_request, issue} + add/update/delete_note (3 unified) + create/update/delete_release + delete_release_link + retry/retry_failed_jobs/cancel/trigger_pipeline + play_job.

**Admin (1):** merge_merge_request (denied by default; operator opts in via `~/.gitlab-agent/config.yaml`).

### Architecture

Mirrors `src/connectors/github/` exactly — per-domain action modules under `actions/` (reads, merges, issues, notes, releases, pipelines), shared `_fields.ts` + `_pagination.ts` + `_types.ts`, `lib/gitlab_client.ts` + `lib/gitlab_config.ts`. Plugin layer at `plugins/gitlab-connector/`.

### Config knobs

`~/.gitlab-agent/config.yaml`:
```yaml
policy:
  read: success
  write: escalate
  admin: escalate     # enables merge_merge_request
  aspects:
    delete: escalate  # cannot be set to success — floored
gitlab:
  require_draft_mr: true       # forces draft on every create_merge_request
  host: https://gitlab.mycorp  # self-hosted override
```

Env overrides: `GITLAB_TOKEN`, `GITLAB_HOST`, `GITLAB_NAMESPACE`, `GITLAB_REQUIRE_DRAFT_MR`.

### Spec + plan

- `docs/superpowers/specs/2026-05-12-gitlab-connector-design.md`
- `docs/superpowers/plans/2026-05-12-gitlab-connector.md`

Implemented via 12 TDD subagent tasks with adversarial review at the end.

### Adversarial review

Caught 2 issues, both fixed in `64c08e8`:
1. Config path was `.gitlab-connector/` but toolkit reads policy from `.gitlab-agent/` — silently dropped operator policy settings. Now aligned on `.gitlab-agent/` (github convention).
2. `namespaceField` regex rejected GitLab subgroup namespaces (`mycompany/backend`). Now allows `/` with leading/trailing/consecutive guards.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run tests/connectors/gitlab` — 222/222 pass across 13 test files
- [x] `npx vitest run` (full repo) — 2285 pass, 26 skipped (live DB), 0 fail
- [x] 33-action surface locked in by `tests/connectors/gitlab/integration/framework.test.ts`
- [x] Default-policy gating: writes escalate, admin denies, delete-aspect escalate
- [x] Operator opt-in: `policy.admin: escalate` enables merge through escalate path
- [x] Delete-aspect floor: operator YAML `policy.aspects.delete: success` rejected as CONFIG_ERROR
- [x] `require_draft_mr` precedence matrix tested
- [x] Subgroup namespaces accepted (e.g., `mycompany/backend`)
- [ ] Manual smoke test against gitlab.com (deferred; live tests are out of scope per spec)

## Marketplace

Separate repo `narailabs/narai-claude-plugins` updated: `gitlab-connector` entry added, `metadata.version` 2.8.0 → 2.9.0 (commit pushed alongside this PR).

## Non-goals (deferred to v2)

- OAuth bearer / PRIVATE-TOKEN header alternatives
- GraphQL queries
- Group-level operations
- Project mirrors, wikis, snippets, CI variables
- Pipeline trigger token management
- Release asset binary extraction (GitLab releases use links only)
- Live integration tests with `TEST_LIVE_GITLAB=1`