### PR TITLE
fix(linear): add missing PreToolUse hook to dispatcher

### DIFF
--- a/plugins/linear-connector/hooks/hooks.json
+++ b/plugins/linear-connector/hooks/hooks.json
@@ -14,6 +14,17 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/dispatcher.mjs\" pre-tool-use"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Bash",


### PR DESCRIPTION
## Summary
- Adds the missing `PreToolUse:Bash` block to `plugins/linear-connector/hooks/hooks.json` so the shared dispatcher's gate evaluation runs on Bash invocations for linear-connector, matching every other full connector (aws, confluence, gcp, github, gitlab, jira, notion).
- Without this hook, `gates.json` rules and any future deny/ask rules registered via the dispatcher have no effect inside linear-connector sessions.

## Test plan
- [x] JSON is valid (`python3 -m json.tool` clean parse).
- [x] File is byte-identical to `plugins/github-connector/hooks/hooks.json` (canonical reference).
- [ ] Smoke: in a session with linear-connector active, run a Bash command and confirm `dispatcher.mjs pre-tool-use` fires (no regression vs. peer connectors).