### PR TITLE
fix(db): verify TLS peer cert when ssl: true on postgres/mysql

### DIFF
--- a/src/connectors/db/lib/drivers/mysql.ts
+++ b/src/connectors/db/lib/drivers/mysql.ts
@@ -104,7 +104,7 @@ export class MysqlDriver extends DatabaseDriver {
           : undefined;
       const ssl =
         envConfig["ssl"] === true
-          ? { rejectUnauthorized: false }
+          ? { rejectUnauthorized: true }
           : typeof envConfig["ssl"] === "object" && envConfig["ssl"] !== null
             ? (envConfig["ssl"] as Record<string, unknown>)
             : undefined;

--- a/src/connectors/db/lib/drivers/postgresql.ts
+++ b/src/connectors/db/lib/drivers/postgresql.ts
@@ -113,7 +113,7 @@ export class PostgresDriver extends DatabaseDriver {
           : undefined;
       const ssl =
         envConfig["ssl"] === true
-          ? { rejectUnauthorized: false }
+          ? { rejectUnauthorized: true }
           : typeof envConfig["ssl"] === "object" && envConfig["ssl"] !== null
             ? (envConfig["ssl"] as Record<string, unknown>)
             : undefined;

--- a/tests/connectors/db/drivers/driver_config_extras.test.ts
+++ b/tests/connectors/db/drivers/driver_config_extras.test.ts
@@ -155,10 +155,10 @@ describe("MysqlDriver — connect config branches", () => {
     return p;
   }
 
-  it("ssl=true => { rejectUnauthorized: false }", async () => {
+  it("ssl=true => { rejectUnauthorized: true }", async () => {
     const drv = new MysqlDriver();
     await drv.connect({ database: "app", ssl: true });
-    expect(latest().config["ssl"]).toEqual({ rejectUnauthorized: false });
+    expect(latest().config["ssl"]).toEqual({ rejectUnauthorized: true });
   });
 
   it("ssl=object passes through", async () => {
@@ -232,10 +232,10 @@ describe("PostgresDriver — connect config branches", () => {
     return p;
   }
 
-  it("ssl=true => { rejectUnauthorized: false }", async () => {
+  it("ssl=true => { rejectUnauthorized: true }", async () => {
     const drv = new PostgresDriver();
     await drv.connect({ database: "app", ssl: true });
-    expect(latest().config["ssl"]).toEqual({ rejectUnauthorized: false });
+    expect(latest().config["ssl"]).toEqual({ rejectUnauthorized: true });
   });
 
   it("ssl=object passes through", async () => {

--- a/tests/connectors/db/drivers/test_postgresql.test.ts
+++ b/tests/connectors/db/drivers/test_postgresql.test.ts
@@ -96,7 +96,7 @@ describe("wiki_db.drivers.postgresql (unit)", () => {
     expect(pool.config["database"]).toBe("app");
     expect(pool.config["user"]).toBe("svc");
     expect(pool.config["password"]).toBe("secret");
-    expect(pool.config["ssl"]).toEqual({ rejectUnauthorized: false });
+    expect(pool.config["ssl"]).toEqual({ rejectUnauthorized: true });
     expect(handle.schema).toBe("public");
     expect(handle.client).toBe(lastClient());
     expect(pool.connectSpy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary

- Postgres and MySQL drivers translated \`ssl: true\` to \`{ rejectUnauthorized: false }\`, encrypting the connection but **not authenticating the server** — a deterministic on-path MITM exposure for any cloud DB (RDS, Cloud SQL, Neon, PlanetScale, etc.).
- Flip the default to \`{ rejectUnauthorized: true }\` so \`ssl: true\` means \"encrypt and verify\", aligning with the MSSQL driver and the user's intuitive expectation.
- The object-form passthrough (\`ssl: { rejectUnauthorized: false, ... }\`) is preserved so operators who genuinely need to skip verification must do so explicitly.
- Updated three test assertions that encoded the previous (buggy) behavior.

## Test plan

- [x] \`npx vitest run tests/connectors/db/drivers/\` — 219 passed / 26 skipped (live tests)
- [ ] Smoke-test a real Postgres/MySQL connection with \`ssl: true\` against a server with a valid cert
- [ ] Confirm \`ssl: { rejectUnauthorized: false }\` still works for self-signed dev DBs