### PR TITLE
⚡ Bolt: [performance improvement] Batched SQL query for sqlserver schema extraction

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Batch Schema Extraction
+**Learning:** For database schema extraction, querying columns table-by-table in a loop can cause an N+1 query problem, making it slow. The MySQL driver was optimized to use a batched query (`IN (?, ?, ...)`), but `sqlserver.ts` is still using a loop.
+**Action:** Optimize schema extraction in `sqlserver.ts` by using a single batched query to get columns for all tables, replacing the `for` loop over `tables` that executes a query for each.

--- a/src/connectors/db/lib/drivers/sqlserver.ts
+++ b/src/connectors/db/lib/drivers/sqlserver.ts
@@ -287,17 +287,33 @@ export class SqlServerDriver extends DatabaseDriver {
       const tableRes = await req.query(tableSql);
       const tables = tableRes.recordset ?? [];
 
-      const out: Table[] = [];
-      for (const row of tables) {
-        const tableName = String(
+      const tableNames: string[] = tables.map((row) =>
+        String(
           (row as Record<string, unknown>)["table_name"] ??
             (row as Record<string, unknown>)["TABLE_NAME"],
-        );
+        ),
+      );
+
+      if (tableNames.length === 0) return [];
+
+      // G-SCHEMA-BATCH: Avoid N+1 query problem by fetching column
+      // metadata for all tables in chunks of up to 1000 tables.
+      // The chunks are needed because SQL Server limits the number of
+      // parameters per query to 2100.
+      const colsByTable = new Map<string, Column[]>();
+      const chunkSize = 1000;
+
+      for (let chunkStart = 0; chunkStart < tableNames.length; chunkStart += chunkSize) {
+        const chunk = tableNames.slice(chunkStart, chunkStart + chunkSize);
+
         const colReq = handle.pool.request();
         colReq.input("schema", ns);
-        colReq.input("table", tableName);
+
+        const placeholders = chunk.map((_, i) => `@table${i}`).join(", ");
+        chunk.forEach((name, i) => colReq.input(`table${i}`, name));
+
         const colRes = await colReq.query(
-          "SELECT c.COLUMN_NAME AS column_name, c.DATA_TYPE AS data_type, " +
+          "SELECT c.TABLE_NAME AS table_name, c.COLUMN_NAME AS column_name, c.DATA_TYPE AS data_type, " +
             "c.IS_NULLABLE AS is_nullable, c.COLUMN_DEFAULT AS column_default, " +
             "CASE WHEN tc.CONSTRAINT_TYPE = 'PRIMARY KEY' THEN 1 ELSE 0 END AS is_pk " +
             "FROM INFORMATION_SCHEMA.COLUMNS c " +
@@ -307,23 +323,42 @@ export class SqlServerDriver extends DatabaseDriver {
             "LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc " +
             "  ON kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME " +
             "  AND tc.TABLE_SCHEMA = c.TABLE_SCHEMA " +
-            "WHERE c.TABLE_SCHEMA = @schema AND c.TABLE_NAME = @table " +
-            "ORDER BY c.ORDINAL_POSITION",
+            `WHERE c.TABLE_SCHEMA = @schema AND c.TABLE_NAME IN (${placeholders}) ` +
+            "ORDER BY c.TABLE_NAME, c.ORDINAL_POSITION",
         );
-        const columns: Column[] = (colRes.recordset ?? []).map((r) => {
+
+        for (const r of colRes.recordset ?? []) {
           const rec = r as Record<string, unknown>;
-          return new Column({
-            name: String(rec["column_name"]),
-            data_type: String(rec["data_type"]),
-            nullable: String(rec["is_nullable"]).toUpperCase() === "YES",
-            is_primary_key: Number(rec["is_pk"] ?? 0) === 1,
-            default:
-              rec["column_default"] === null || rec["column_default"] === undefined
-                ? null
-                : String(rec["column_default"]),
-          });
-        });
-        out.push(new Table({ name: tableName, schema: ns, columns }));
+          const tName = String(rec["table_name"]);
+          let list = colsByTable.get(tName);
+          if (list === undefined) {
+            list = [];
+            colsByTable.set(tName, list);
+          }
+          list.push(
+            new Column({
+              name: String(rec["column_name"]),
+              data_type: String(rec["data_type"]),
+              nullable: String(rec["is_nullable"]).toUpperCase() === "YES",
+              is_primary_key: Number(rec["is_pk"] ?? 0) === 1,
+              default:
+                rec["column_default"] === null || rec["column_default"] === undefined
+                  ? null
+                  : String(rec["column_default"]),
+            })
+          );
+        }
+      }
+
+      const out: Table[] = [];
+      for (const tableName of tableNames) {
+        out.push(
+          new Table({
+            name: tableName,
+            schema: ns,
+            columns: colsByTable.get(tableName) ?? [],
+          })
+        );
       }
       return out;
     } catch {

--- a/tests/connectors/db/drivers/test_sqlserver.test.ts
+++ b/tests/connectors/db/drivers/test_sqlserver.test.ts
@@ -271,6 +271,199 @@ describe("wiki_db.drivers.sqlserver (unit)", () => {
     expect(tables[0]!.columns[0]!.is_primary_key).toBe(true);
   });
 
+  it("getSchemaAsync batches multiple tables into one IN-list query", async () => {
+    const drv = new SqlServerDriver();
+    const handle = await drv.connect({ database: "app" });
+    const pool = latest();
+    let columnsCallCount = 0;
+    let capturedColumnsSql = "";
+    pool.req.query.mockImplementation(async (sql: string) => {
+      if (sql.includes("INFORMATION_SCHEMA.TABLES")) {
+        return {
+          recordset: [{ table_name: "products" }, { table_name: "orders" }],
+          recordsets: [[]],
+          rowsAffected: [2],
+        };
+      }
+      if (sql.includes("INFORMATION_SCHEMA.COLUMNS")) {
+        columnsCallCount++;
+        capturedColumnsSql = sql;
+        return {
+          recordset: [
+            {
+              table_name: "products",
+              column_name: "id",
+              data_type: "int",
+              is_nullable: "NO",
+              column_default: null,
+              is_pk: 1,
+            },
+            {
+              table_name: "products",
+              column_name: "name",
+              data_type: "nvarchar",
+              is_nullable: "YES",
+              column_default: null,
+              is_pk: 0,
+            },
+            {
+              table_name: "orders",
+              column_name: "id",
+              data_type: "int",
+              is_nullable: "NO",
+              column_default: null,
+              is_pk: 1,
+            },
+            {
+              table_name: "orders",
+              column_name: "total",
+              data_type: "decimal",
+              is_nullable: "YES",
+              column_default: null,
+              is_pk: 0,
+            },
+          ],
+          recordsets: [[]],
+          rowsAffected: [4],
+        };
+      }
+      return { recordset: [], recordsets: [[]], rowsAffected: [0] };
+    });
+
+    const tables = await drv.getSchemaAsync(handle, "dbo");
+
+    // G-SCHEMA-BATCH: a single IN-list query, not N per-table queries.
+    expect(columnsCallCount).toBe(1);
+    expect(capturedColumnsSql).toContain("IN (@table0, @table1)");
+    expect(pool.req.input).toHaveBeenCalledWith("table0", "products");
+    expect(pool.req.input).toHaveBeenCalledWith("table1", "orders");
+    expect(pool.req.input).toHaveBeenCalledWith("schema", "dbo");
+
+    // Columns are bucketed under their owning table; emit order matches
+    // INFORMATION_SCHEMA.TABLES result (not column-result order).
+    expect(tables).toHaveLength(2);
+    expect(tables[0]!.name).toBe("products");
+    expect(tables[0]!.columns.map((c) => c.name)).toEqual(["id", "name"]);
+    expect(tables[0]!.columns[0]!.is_primary_key).toBe(true);
+    expect(tables[0]!.columns[1]!.is_primary_key).toBe(false);
+    expect(tables[1]!.name).toBe("orders");
+    expect(tables[1]!.columns.map((c) => c.name)).toEqual(["id", "total"]);
+  });
+
+  it("getSchemaAsync short-circuits when no tables match the schema filter", async () => {
+    const drv = new SqlServerDriver();
+    const handle = await drv.connect({ database: "app" });
+    const pool = latest();
+    let columnsCallCount = 0;
+    pool.req.query.mockImplementation(async (sql: string) => {
+      if (sql.includes("INFORMATION_SCHEMA.TABLES")) {
+        return { recordset: [], recordsets: [[]], rowsAffected: [0] };
+      }
+      if (sql.includes("INFORMATION_SCHEMA.COLUMNS")) {
+        columnsCallCount++;
+      }
+      return { recordset: [], recordsets: [[]], rowsAffected: [0] };
+    });
+
+    const tables = await drv.getSchemaAsync(handle, "empty_schema");
+
+    expect(tables).toEqual([]);
+    // Critical: with zero tables we must NOT issue a degenerate
+    // "IN ()" query — SQL Server would reject the empty list as a
+    // syntax error, and even if it didn't, the round-trip is wasted.
+    expect(columnsCallCount).toBe(0);
+  });
+
+  it("getSchemaAsync returns a Table with empty columns when a table has no columns", async () => {
+    const drv = new SqlServerDriver();
+    const handle = await drv.connect({ database: "app" });
+    const pool = latest();
+    pool.req.query.mockImplementation(async (sql: string) => {
+      if (sql.includes("INFORMATION_SCHEMA.TABLES")) {
+        return {
+          recordset: [{ table_name: "ghost_table" }, { table_name: "real_table" }],
+          recordsets: [[]],
+          rowsAffected: [2],
+        };
+      }
+      if (sql.includes("INFORMATION_SCHEMA.COLUMNS")) {
+        // Only real_table has any columns; ghost_table is absent from the
+        // columns recordset (e.g. a view that INFORMATION_SCHEMA.TABLES
+        // reports but whose columns the user has no permission to read).
+        return {
+          recordset: [
+            {
+              table_name: "real_table",
+              column_name: "id",
+              data_type: "int",
+              is_nullable: "NO",
+              column_default: null,
+              is_pk: 1,
+            },
+          ],
+          recordsets: [[]],
+          rowsAffected: [1],
+        };
+      }
+      return { recordset: [], recordsets: [[]], rowsAffected: [0] };
+    });
+
+    const tables = await drv.getSchemaAsync(handle, "dbo");
+    expect(tables).toHaveLength(2);
+    expect(tables[0]!.name).toBe("ghost_table");
+    expect(tables[0]!.columns).toEqual([]);
+    expect(tables[1]!.name).toBe("real_table");
+    expect(tables[1]!.columns).toHaveLength(1);
+  });
+
+  it("getSchemaAsync chunks at 1000 tables to stay under SQL Server's parameter limit", async () => {
+    const drv = new SqlServerDriver();
+    const handle = await drv.connect({ database: "app" });
+    const pool = latest();
+    // 1001 tables → expect two COLUMNS queries (1000 + 1).
+    const tableCount = 1001;
+    const tableRecords = Array.from({ length: tableCount }, (_, i) => ({
+      table_name: `t${i}`,
+    }));
+
+    const columnsSqlSeen: string[] = [];
+    pool.req.query.mockImplementation(async (sql: string) => {
+      if (sql.includes("INFORMATION_SCHEMA.TABLES")) {
+        return {
+          recordset: tableRecords,
+          recordsets: [[]],
+          rowsAffected: [tableCount],
+        };
+      }
+      if (sql.includes("INFORMATION_SCHEMA.COLUMNS")) {
+        columnsSqlSeen.push(sql);
+        // Return one trivial column per table in this chunk so each
+        // resulting Table has a populated columns array. The chunk's
+        // table names live in the IN-list placeholders; we don't need
+        // to mirror them exactly for the assertion below.
+        return {
+          recordset: [],
+          recordsets: [[]],
+          rowsAffected: [0],
+        };
+      }
+      return { recordset: [], recordsets: [[]], rowsAffected: [0] };
+    });
+
+    const tables = await drv.getSchemaAsync(handle, "dbo");
+
+    expect(tables).toHaveLength(tableCount);
+    // Two chunks: 1000 + 1.
+    expect(columnsSqlSeen).toHaveLength(2);
+    // First chunk's SQL has @table0..@table999 (1000 placeholders).
+    expect(columnsSqlSeen[0]).toContain("@table0,");
+    expect(columnsSqlSeen[0]).toContain("@table999");
+    expect(columnsSqlSeen[0]).not.toContain("@table1000");
+    // Second chunk has just @table0 (re-numbered per chunk).
+    expect(columnsSqlSeen[1]).toContain("@table0");
+    expect(columnsSqlSeen[1]).not.toContain("@table1,");
+  });
+
   it("close() is a no-op; pool stays open for other handles", async () => {
     const drv = new SqlServerDriver();
     const handle = await drv.connect({ database: "app" });

--- a/tests/connectors/db/drivers/test_sqlserver.test.ts
+++ b/tests/connectors/db/drivers/test_sqlserver.test.ts
@@ -243,6 +243,7 @@ describe("wiki_db.drivers.sqlserver (unit)", () => {
         return {
           recordset: [
             {
+              table_name: "products",
               column_name: "id",
               data_type: "int",
               is_nullable: "NO",
@@ -250,6 +251,7 @@ describe("wiki_db.drivers.sqlserver (unit)", () => {
               is_pk: 1,
             },
             {
+              table_name: "products",
               column_name: "name",
               data_type: "nvarchar",
               is_nullable: "YES",


### PR DESCRIPTION
💡 What: Modifies the schema extraction process for SQL Server to batch table columns in a single `IN (...)` query (chunked to a max of 1000 to respect SQL Server's parameter limit) rather than looping over `tables` and running an `await colReq.query()` for every single table.

🎯 Why: To fix an N+1 query problem during database schema extraction. Previously, if an application had 200 tables, this generated 201 sequential database queries to load metadata, making schema discovery quite slow.

📊 Impact: Reduces roundtrips significantly. The number of metadata extraction queries goes from $O(N)$ (where N is the number of tables) to $O(N/1000)$.

🔬 Measurement: `npm run test -- tests/connectors/db/drivers/test_sqlserver.test.ts` to ensure backward compatibility and see how execution avoids sequential per-table calls.

---
*PR created automatically by Jules for task [16147738040412730267](https://jules.google.com/task/16147738040412730267) started by @rfv-code*