### PR TITLE
🛡️ Sentinel: [Security Enhancement] Redact bearer tokens in audit logs

### DIFF
--- a/src/connectors/db/lib/audit.ts
+++ b/src/connectors/db/lib/audit.ts
@@ -94,9 +94,9 @@ export interface LogQueryParams {
  * out of scope.
  */
 const _SENSITIVE_LITERAL_SQUOTE_RE =
-  /\b(password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth)\s*=\s*'[^']*'/gi;
+  /\b(password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth|bearer)\s*=\s*'[^']*'/gi;
 const _SENSITIVE_LITERAL_DQUOTE_RE =
-  /\b(password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth)\s*=\s*"[^"]*"/gi;
+  /\b(password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth|bearer)\s*=\s*"[^"]*"/gi;
 
 export function scrubSqlSecrets(sql: string): string {
   return sql

--- a/src/toolkit/audit/writer.ts
+++ b/src/toolkit/audit/writer.ts
@@ -23,9 +23,9 @@ export interface AuditWriterOptions {
 
 /** Redact common credential-bearing `key='value'` literals in a string. */
 const SENSITIVE_SQUOTE_RE =
-  /\b(password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth)\s*=\s*'[^']*'/gi;
+  /\b(password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth|bearer)\s*=\s*'[^']*'/gi;
 const SENSITIVE_DQUOTE_RE =
-  /\b(password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth)\s*=\s*"[^"]*"/gi;
+  /\b(password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth|bearer)\s*=\s*"[^"]*"/gi;
 
 export function scrubSecrets(text: string): string {
   return text

--- a/src/toolkit/audit/writer.ts
+++ b/src/toolkit/audit/writer.ts
@@ -26,18 +26,11 @@ const SENSITIVE_SQUOTE_RE =
   /\b(password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth|bearer)\s*=\s*'[^']*'/gi;
 const SENSITIVE_DQUOTE_RE =
   /\b(password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth|bearer)\s*=\s*"[^"]*"/gi;
-// Authorization-header form: `Bearer <token>` / `Basic <base64>`. This is the
-// exact shape produced by `HttpClientOptions.authHeader`; the key='value'
-// regexes above cannot match it (no `=`, no quotes). Length floor avoids
-// redacting prose like "Bearer bonds". scrubSecrets runs only on connector
-// error message strings, so over-redaction risk is negligible.
-const AUTH_SCHEME_RE = /\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{8,}/g;
 
 export function scrubSecrets(text: string): string {
   return text
     .replace(SENSITIVE_SQUOTE_RE, (_m, key: string) => `${key}='[REDACTED]'`)
-    .replace(SENSITIVE_DQUOTE_RE, (_m, key: string) => `${key}="[REDACTED]"`)
-    .replace(AUTH_SCHEME_RE, (_m, scheme: string) => `${scheme} [REDACTED]`);
+    .replace(SENSITIVE_DQUOTE_RE, (_m, key: string) => `${key}="[REDACTED]"`);
 }
 
 function isoTimestamp(): string {

--- a/src/toolkit/audit/writer.ts
+++ b/src/toolkit/audit/writer.ts
@@ -26,11 +26,18 @@ const SENSITIVE_SQUOTE_RE =
   /\b(password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth|bearer)\s*=\s*'[^']*'/gi;
 const SENSITIVE_DQUOTE_RE =
   /\b(password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth|bearer)\s*=\s*"[^"]*"/gi;
+// Authorization-header form: `Bearer <token>` / `Basic <base64>`. This is the
+// exact shape produced by `HttpClientOptions.authHeader`; the key='value'
+// regexes above cannot match it (no `=`, no quotes). Length floor avoids
+// redacting prose like "Bearer bonds". scrubSecrets runs only on connector
+// error message strings, so over-redaction risk is negligible.
+const AUTH_SCHEME_RE = /\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{8,}/g;
 
 export function scrubSecrets(text: string): string {
   return text
     .replace(SENSITIVE_SQUOTE_RE, (_m, key: string) => `${key}='[REDACTED]'`)
-    .replace(SENSITIVE_DQUOTE_RE, (_m, key: string) => `${key}="[REDACTED]"`);
+    .replace(SENSITIVE_DQUOTE_RE, (_m, key: string) => `${key}="[REDACTED]"`)
+    .replace(AUTH_SCHEME_RE, (_m, scheme: string) => `${scheme} [REDACTED]`);
 }
 
 function isoTimestamp(): string {

--- a/tests/connectors/db/audit.test.ts
+++ b/tests/connectors/db/audit.test.ts
@@ -214,20 +214,14 @@ describe("wiki_db.audit", () => {
     expect(scrubSqlSecrets("WHERE api_key = 'k1' OR api-key = 'k2'")).toBe(
       "WHERE api_key='[REDACTED]' OR api-key='[REDACTED]'",
     );
+    expect(scrubSqlSecrets("WHERE bearer = 'token'")).toBe(
+      "WHERE bearer='[REDACTED]'",
+    );
   });
 
   it("scrubSqlSecrets masks double-quoted credential literals", () => {
     expect(scrubSqlSecrets('WHERE secret = "s3cr3t"')).toBe(
       'WHERE secret="[REDACTED]"',
-    );
-  });
-
-  it("scrubSqlSecrets masks bearer literals", () => {
-    expect(scrubSqlSecrets("WHERE bearer = 'tok-abc123'")).toBe(
-      "WHERE bearer='[REDACTED]'",
-    );
-    expect(scrubSqlSecrets('WHERE bearer = "tok-abc123"')).toBe(
-      'WHERE bearer="[REDACTED]"',
     );
   });
 

--- a/tests/connectors/db/audit.test.ts
+++ b/tests/connectors/db/audit.test.ts
@@ -222,6 +222,15 @@ describe("wiki_db.audit", () => {
     );
   });
 
+  it("scrubSqlSecrets masks bearer literals", () => {
+    expect(scrubSqlSecrets("WHERE bearer = 'tok-abc123'")).toBe(
+      "WHERE bearer='[REDACTED]'",
+    );
+    expect(scrubSqlSecrets('WHERE bearer = "tok-abc123"')).toBe(
+      'WHERE bearer="[REDACTED]"',
+    );
+  });
+
   it("scrubSqlSecrets leaves non-credential literals alone", () => {
     expect(scrubSqlSecrets("SELECT name FROM u WHERE id = 1")).toBe(
       "SELECT name FROM u WHERE id = 1",

--- a/tests/toolkit/audit.test.ts
+++ b/tests/toolkit/audit.test.ts
@@ -26,34 +26,14 @@ describe("scrubSecrets", () => {
   });
 
   it("redacts common variants", () => {
-    const raw = `password='a' passwd='b' pwd='c' token='d' api-key='e' secret='f' auth='g'`;
+    const raw = `password='a' passwd='b' pwd='c' token='d' api-key='e' secret='f' auth='g' bearer="h"`;
     const scrubbed = scrubSecrets(raw);
     expect(scrubbed).not.toContain("'a'");
     expect(scrubbed).not.toContain("'b'");
     expect(scrubbed).not.toContain("'g'");
+    expect(scrubbed).not.toContain('"h"');
     expect(scrubbed).toMatch(/password='\[REDACTED\]'/);
-  });
-
-  it("redacts bearer literals", () => {
-    expect(scrubSecrets("bearer='abc.def.ghi'")).toBe(
-      "bearer='[REDACTED]'",
-    );
-    expect(scrubSecrets(`bearer="abc.def.ghi"`)).toBe(
-      `bearer="[REDACTED]"`,
-    );
-  });
-
-  it("redacts Authorization scheme header values", () => {
-    expect(
-      scrubSecrets("request failed: Authorization: Bearer abc123.def456"),
-    ).toBe("request failed: Authorization: Bearer [REDACTED]");
-    expect(scrubSecrets("Basic dXNlcjpwYXNzd29yZA==")).toBe(
-      "Basic [REDACTED]",
-    );
-  });
-
-  it("does not redact short prose after Bearer/Basic", () => {
-    expect(scrubSecrets("Bearer bonds")).toBe("Bearer bonds");
+    expect(scrubbed).toMatch(/bearer="\[REDACTED\]"/);
   });
 
   it("leaves unrelated strings untouched", () => {

--- a/tests/toolkit/audit.test.ts
+++ b/tests/toolkit/audit.test.ts
@@ -34,6 +34,15 @@ describe("scrubSecrets", () => {
     expect(scrubbed).toMatch(/password='\[REDACTED\]'/);
   });
 
+  it("redacts bearer literals", () => {
+    expect(scrubSecrets("bearer='abc.def.ghi'")).toBe(
+      "bearer='[REDACTED]'",
+    );
+    expect(scrubSecrets(`bearer="abc.def.ghi"`)).toBe(
+      `bearer="[REDACTED]"`,
+    );
+  });
+
   it("leaves unrelated strings untouched", () => {
     const raw = "SELECT * FROM users WHERE id = 42";
     expect(scrubSecrets(raw)).toBe(raw);

--- a/tests/toolkit/audit.test.ts
+++ b/tests/toolkit/audit.test.ts
@@ -43,6 +43,19 @@ describe("scrubSecrets", () => {
     );
   });
 
+  it("redacts Authorization scheme header values", () => {
+    expect(
+      scrubSecrets("request failed: Authorization: Bearer abc123.def456"),
+    ).toBe("request failed: Authorization: Bearer [REDACTED]");
+    expect(scrubSecrets("Basic dXNlcjpwYXNzd29yZA==")).toBe(
+      "Basic [REDACTED]",
+    );
+  });
+
+  it("does not redact short prose after Bearer/Basic", () => {
+    expect(scrubSecrets("Bearer bonds")).toBe("Bearer bonds");
+  });
+
   it("leaves unrelated strings untouched", () => {
     const raw = "SELECT * FROM users WHERE id = 42";
     expect(scrubSecrets(raw)).toBe(raw);


### PR DESCRIPTION
🚨 Severity: ENHANCEMENT
💡 Vulnerability: `bearer` tokens might have leaked into audit logs or DB query logs as they weren't explicitly scrubbed by `scrubSecrets` and `scrubSqlSecrets`.
🎯 Impact: Prevent potential leakage of sensitive bearer tokens in logs.
🔧 Fix: Added `bearer` to the regex that scrubs secrets from strings and SQL queries.
✅ Verification: Ran `pnpm test` and `pnpm lint` and `npm run typecheck` to verify no regressions were introduced.

---
*PR created automatically by Jules for task [18138762343096867795](https://jules.google.com/task/18138762343096867795) started by @rfv-code*