### PR TITLE
⚡ Bolt: optimize sqlite schema extraction with batched query

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Batch Schema Extraction
 **Learning:** For database schema extraction, querying columns table-by-table in a loop can cause an N+1 query problem, making it slow. The MySQL driver was optimized to use a batched query (`IN (?, ?, ...)`), but `sqlserver.ts` is still using a loop.
 **Action:** Optimize schema extraction in `sqlserver.ts` by using a single batched query to get columns for all tables, replacing the `for` loop over `tables` that executes a query for each.
+## 2024-05-16 - SQLite batched schema query requires alias for [notnull]
+**Learning:** When using SQLite's `pragma_table_info` function joined with `sqlite_master`, the `notnull` column is a reserved keyword in some contexts or causes syntax errors if accessed as `p.notnull as notnull`. We must escape it as `p.[notnull] as is_notnull` and use the alias.
+**Action:** Use bracket escaping and a clear alias like `is_notnull` when selecting `notnull` from `pragma_table_info`.

--- a/src/connectors/db/lib/drivers/sqlite.ts
+++ b/src/connectors/db/lib/drivers/sqlite.ts
@@ -120,17 +120,24 @@ export class SQLiteDriver extends DatabaseDriver {
       // G-SCHEMA-BATCH: Avoid N+1 query problem by fetching all table columns
       // in a single query using the pragma_table_info table-valued function.
       let baseQuery =
-        "SELECT m.name as table_name, p.name as column_name, p.type as data_type, " +
-        "p.[notnull] as is_notnull, p.dflt_value as dflt_value, p.pk as pk " +
+        "SELECT m.name as table_name, p.cid as cid, p.name as column_name, " +
+        "p.type as data_type, p.[notnull] as is_notnull, " +
+        "p.dflt_value as dflt_value, p.pk as pk " +
         "FROM sqlite_master m " +
         "JOIN pragma_table_info(m.name) p " +
         "WHERE m.type='table' AND m.name NOT LIKE 'sqlite_%'";
 
+      // Preserve declaration order: PRAGMA table_info yields rows in `cid`
+      // order, so without an explicit ORDER BY the join could reorder
+      // columns relative to the previous per-table loop.
+      const orderBy = " ORDER BY m.name, p.cid";
+
       let cursor;
       if (tableFilter !== null && tableFilter !== undefined) {
         baseQuery += " AND m.name LIKE ?";
-        cursor = db.prepare(baseQuery).all(tableFilter) as Array<{
+        cursor = db.prepare(baseQuery + orderBy).all(tableFilter) as Array<{
           table_name: string;
+          cid: number;
           column_name: string;
           data_type: string;
           is_notnull: number;
@@ -138,8 +145,9 @@ export class SQLiteDriver extends DatabaseDriver {
           pk: number;
         }>;
       } else {
-        cursor = db.prepare(baseQuery).all() as Array<{
+        cursor = db.prepare(baseQuery + orderBy).all() as Array<{
           table_name: string;
+          cid: number;
           column_name: string;
           data_type: string;
           is_notnull: number;

--- a/src/connectors/db/lib/drivers/sqlite.ts
+++ b/src/connectors/db/lib/drivers/sqlite.ts
@@ -64,8 +64,9 @@ export class SQLiteDriver extends DatabaseDriver {
           truncated: false,
         };
       }
-      const iter = stmt.iterate(...((params ?? []) as unknown[])) as
-        IterableIterator<Record<string, unknown>>;
+      const iter = stmt.iterate(
+        ...((params ?? []) as unknown[]),
+      ) as IterableIterator<Record<string, unknown>>;
       const rowsRaw: Record<string, unknown>[] = [];
       // Fetch one extra row to detect truncation.
       let truncated = false;
@@ -116,49 +117,85 @@ export class SQLiteDriver extends DatabaseDriver {
   ): Table[] {
     const db = conn as Database.Database;
     try {
-      let cursor;
+      // G-SCHEMA-BATCH: Avoid N+1 query problem by fetching all table columns
+      // in a single query using the pragma_table_info table-valued function.
       let baseQuery =
-        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'";
-      if (tableFilter !== null && tableFilter !== undefined) {
-        baseQuery += " AND name LIKE ?";
-        cursor = db.prepare(baseQuery).all(tableFilter) as Array<{
-          name: string;
-        }>;
-      } else {
-        cursor = db.prepare(baseQuery).all() as Array<{ name: string }>;
-      }
+        "SELECT m.name as table_name, p.name as column_name, p.type as data_type, " +
+        "p.[notnull] as is_notnull, p.dflt_value as dflt_value, p.pk as pk " +
+        "FROM sqlite_master m " +
+        "JOIN pragma_table_info(m.name) p " +
+        "WHERE m.type='table' AND m.name NOT LIKE 'sqlite_%'";
 
-      const tables: Table[] = [];
-      for (const row of cursor) {
-        const tableName = row.name;
-        // PRAGMA table_info returns rows shaped like:
-        //   {cid, name, type, notnull, dflt_value, pk}
-        const colCursor = db
-          .prepare(`PRAGMA table_info(${tableName})`)
-          .all() as Array<{
-          cid: number;
-          name: string;
-          type: string;
-          notnull: number;
+      let cursor;
+      if (tableFilter !== null && tableFilter !== undefined) {
+        baseQuery += " AND m.name LIKE ?";
+        cursor = db.prepare(baseQuery).all(tableFilter) as Array<{
+          table_name: string;
+          column_name: string;
+          data_type: string;
+          is_notnull: number;
           dflt_value: string | null;
           pk: number;
         }>;
-        const columns: Column[] = [];
-        for (const colRow of colCursor) {
-          columns.push(
-            new Column({
-              name: colRow.name,
-              data_type: colRow.type,
-              nullable: !colRow.notnull,
-              is_primary_key: Boolean(colRow.pk),
-              default: colRow.dflt_value,
-            }),
-          );
+      } else {
+        cursor = db.prepare(baseQuery).all() as Array<{
+          table_name: string;
+          column_name: string;
+          data_type: string;
+          is_notnull: number;
+          dflt_value: string | null;
+          pk: number;
+        }>;
+      }
+
+      const colsByTable = new Map<string, Column[]>();
+
+      for (const row of cursor) {
+        const tName = row.table_name;
+        let list = colsByTable.get(tName);
+        if (list === undefined) {
+          list = [];
+          colsByTable.set(tName, list);
         }
-        tables.push(
-          new Table({ name: tableName, schema: schemaName, columns }),
+        list.push(
+          new Column({
+            name: row.column_name,
+            data_type: row.data_type,
+            nullable: !row.is_notnull,
+            is_primary_key: Boolean(row.pk),
+            default: row.dflt_value,
+          }),
         );
       }
+
+      // Ensure empty tables without columns are captured by fetching
+      // just the table names separately. This guarantees we match prior behavior
+      // exactly, returning empty tables even if `pragma_table_info` returns no rows
+      // or omits them in the inner join.
+      let tablesQuery =
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'";
+      let tablesCursor;
+      if (tableFilter !== null && tableFilter !== undefined) {
+        tablesQuery += " AND name LIKE ?";
+        tablesCursor = db.prepare(tablesQuery).all(tableFilter) as Array<{
+          name: string;
+        }>;
+      } else {
+        tablesCursor = db.prepare(tablesQuery).all() as Array<{ name: string }>;
+      }
+
+      const tables: Table[] = [];
+      for (const row of tablesCursor) {
+        const tableName = row.name;
+        tables.push(
+          new Table({
+            name: tableName,
+            schema: schemaName,
+            columns: colsByTable.get(tableName) ?? [],
+          }),
+        );
+      }
+
       return tables;
     } catch {
       return [];

--- a/tests/connectors/db/drivers/sqlite.test.ts
+++ b/tests/connectors/db/drivers/sqlite.test.ts
@@ -97,6 +97,21 @@ describe("wiki_db.drivers.sqlite", () => {
       expect(colNames).toContain("email");
     });
 
+    it("test_preserves_column_declaration_order", () => {
+      const tables = driver.getSchema(conn);
+      const users = tables.filter((t) => t.name === "users")[0];
+      expect(users).toBeDefined();
+      expect(users!.columns.map((c) => c.name)).toEqual([
+        "id",
+        "name",
+        "email",
+      ]);
+      const id = users!.columns[0]!;
+      const email = users!.columns[2]!;
+      expect(id.is_primary_key).toBe(true);
+      expect(email.nullable).toBe(false);
+    });
+
     it("test_with_filter", () => {
       conn!.exec("CREATE TABLE orders (id INTEGER PRIMARY KEY)");
       const tables = driver.getSchema(conn, "", "user%");


### PR DESCRIPTION
💡 What: Replaced the loop of `PRAGMA table_info` queries in SQLite schema extraction with a single `JOIN pragma_table_info()` batched query.
🎯 Why: To fix the N+1 performance bottleneck that occurred when reading schemas for databases with many tables.
📊 Impact: Reduces database queries during schema extraction from N+1 to 2 (one for tables and columns, one to catch empty tables).
🔬 Measurement: Verify this by observing fewer round trips to the SQLite database during start-up or schema introspection workflows.

---
*PR created automatically by Jules for task [6584459286958860044](https://jules.google.com/task/6584459286958860044) started by @rfv-code*