### PR TITLE
⚡ Bolt: Optimize SQLite driver schema extraction by batching queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Batch Schema Extraction
 **Learning:** For database schema extraction, querying columns table-by-table in a loop can cause an N+1 query problem, making it slow. The MySQL driver was optimized to use a batched query (`IN (?, ?, ...)`), but `sqlserver.ts` is still using a loop.
 **Action:** Optimize schema extraction in `sqlserver.ts` by using a single batched query to get columns for all tables, replacing the `for` loop over `tables` that executes a query for each.
+## 2026-05-17 - Batched Schema Extraction in SQLite
+**Learning:** For database schema extraction, querying columns table-by-table in a loop can cause an N+1 query problem, making it slow. The SQLite driver was optimized to use a single query utilizing the `pragma_table_info` table-valued function joined with `sqlite_master`.
+**Action:** When extracting schemas from SQLite, use the `pragma_table_info(table_name)` table-valued function rather than looping over `PRAGMA table_info(table_name)`.

--- a/src/connectors/db/lib/drivers/sqlite.ts
+++ b/src/connectors/db/lib/drivers/sqlite.ts
@@ -64,8 +64,9 @@ export class SQLiteDriver extends DatabaseDriver {
           truncated: false,
         };
       }
-      const iter = stmt.iterate(...((params ?? []) as unknown[])) as
-        IterableIterator<Record<string, unknown>>;
+      const iter = stmt.iterate(
+        ...((params ?? []) as unknown[]),
+      ) as IterableIterator<Record<string, unknown>>;
       const rowsRaw: Record<string, unknown>[] = [];
       // Fetch one extra row to detect truncation.
       let truncated = false;
@@ -118,45 +119,66 @@ export class SQLiteDriver extends DatabaseDriver {
     try {
       let cursor;
       let baseQuery =
-        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'";
-      if (tableFilter !== null && tableFilter !== undefined) {
-        baseQuery += " AND name LIKE ?";
-        cursor = db.prepare(baseQuery).all(tableFilter) as Array<{
-          name: string;
-        }>;
-      } else {
-        cursor = db.prepare(baseQuery).all() as Array<{ name: string }>;
-      }
+        "SELECT m.name AS table_name, p.name AS col_name, p.type, p.[notnull], p.dflt_value, p.pk " +
+        "FROM sqlite_master m " +
+        "JOIN pragma_table_info(m.name) p " +
+        "WHERE m.type='table' AND m.name NOT LIKE 'sqlite_%'";
 
-      const tables: Table[] = [];
-      for (const row of cursor) {
-        const tableName = row.name;
-        // PRAGMA table_info returns rows shaped like:
-        //   {cid, name, type, notnull, dflt_value, pk}
-        const colCursor = db
-          .prepare(`PRAGMA table_info(${tableName})`)
-          .all() as Array<{
-          cid: number;
-          name: string;
+      if (tableFilter !== null && tableFilter !== undefined) {
+        baseQuery += " AND m.name LIKE ?";
+        cursor = db.prepare(baseQuery).all(tableFilter) as Array<{
+          table_name: string;
+          col_name: string;
           type: string;
           notnull: number;
           dflt_value: string | null;
           pk: number;
         }>;
-        const columns: Column[] = [];
-        for (const colRow of colCursor) {
-          columns.push(
-            new Column({
-              name: colRow.name,
-              data_type: colRow.type,
-              nullable: !colRow.notnull,
-              is_primary_key: Boolean(colRow.pk),
-              default: colRow.dflt_value,
-            }),
-          );
+      } else {
+        cursor = db.prepare(baseQuery).all() as Array<{
+          table_name: string;
+          col_name: string;
+          type: string;
+          notnull: number;
+          dflt_value: string | null;
+          pk: number;
+        }>;
+      }
+
+      // G-SCHEMA-BATCH: Avoid N+1 query problem by using the pragma_table_info
+      // table-valued function to fetch column metadata for all tables in a single query.
+      const colsByTable = new Map<string, Column[]>();
+      const tableNames = new Set<string>();
+
+      for (const row of cursor) {
+        const tableName = row.table_name;
+        tableNames.add(tableName);
+
+        let list = colsByTable.get(tableName);
+        if (list === undefined) {
+          list = [];
+          colsByTable.set(tableName, list);
         }
+
+        list.push(
+          new Column({
+            name: row.col_name,
+            data_type: row.type,
+            nullable: !row.notnull,
+            is_primary_key: Boolean(row.pk),
+            default: row.dflt_value,
+          }),
+        );
+      }
+
+      const tables: Table[] = [];
+      for (const tableName of tableNames) {
         tables.push(
-          new Table({ name: tableName, schema: schemaName, columns }),
+          new Table({
+            name: tableName,
+            schema: schemaName,
+            columns: colsByTable.get(tableName) ?? [],
+          }),
         );
       }
       return tables;


### PR DESCRIPTION
💡 What: Modified the SQLite driver schema extraction logic (`getSchema`) to perform a single query using `sqlite_master` joined with `pragma_table_info(table_name)`. Grouping of metadata into `Table` and `Column` models happens entirely in-memory.

🎯 Why: To fix an N+1 query bottleneck. Originally, retrieving the schema for `N` tables involved 1 query to get the tables and `N` individual `PRAGMA table_info(tableName)` queries inside a loop.

📊 Impact: Reduces database queries required for schema extraction from `O(N)` to `O(1)`, resulting in faster schema introspections, especially for databases with a large number of tables. Matches the strategy implemented in other drivers (`G-SCHEMA-BATCH`).

🔬 Measurement: `npm run test tests/connectors/db/drivers/sqlite.test.ts` executes correctly, ensuring that schema mapping functionality is perfectly preserved. The test passes efficiently without regression.

---
*PR created automatically by Jules for task [4316885738951791419](https://jules.google.com/task/4316885738951791419) started by @rfv-code*