### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix credential leak in JSON payloads and headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,4 @@
-## 2025-02-18 - [Fix JSON and HTTP Authorization log credential leak]
+## 2026-05-21 - [Fix JSON and HTTP Authorization log credential leak]
 **Vulnerability:** The existing `scrubSecrets` and `scrubSqlSecrets` functions only reacted to literal equality definitions (i.e., `password='xyz'`), meaning they missed credentials embedded within JSON (`"password":"xyz"`) or HTTP request header dictionaries (`Authorization: Bearer xyz`).
 **Learning:** Hard-coded regular expressions targeting a single language format (SQL string definitions) are insufficient for log files handling heterogeneous application contexts like REST APIs and JSON payload outputs.
 **Prevention:** Build comprehensive regular expressions that match arbitrary delimiter structures (`:` and `=`) and specific sensitive headers (like `Authorization`) while preserving context so formatting isn't mangled.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-18 - [Fix JSON and HTTP Authorization log credential leak]
+**Vulnerability:** The existing `scrubSecrets` and `scrubSqlSecrets` functions only reacted to literal equality definitions (i.e., `password='xyz'`), meaning they missed credentials embedded within JSON (`"password":"xyz"`) or HTTP request header dictionaries (`Authorization: Bearer xyz`).
+**Learning:** Hard-coded regular expressions targeting a single language format (SQL string definitions) are insufficient for log files handling heterogeneous application contexts like REST APIs and JSON payload outputs.
+**Prevention:** Build comprehensive regular expressions that match arbitrary delimiter structures (`:` and `=`) and specific sensitive headers (like `Authorization`) while preserving context so formatting isn't mangled.

--- a/src/connectors/db/lib/audit.ts
+++ b/src/connectors/db/lib/audit.ts
@@ -105,10 +105,16 @@ export interface LogQueryParams {
 // inside JSON-encoded values are skipped — without this, `"abc\"def"`
 // terminates at the escaped quote and leaks the tail.
 //
-// AUTH_RE alternates between quoted (closes at the matching outer quote,
-// handling JSON-escaped inner quotes) and unquoted (consumes to end-of-line)
-// so unescaped Digest parameters on plain log lines (`Digest username="u",
-// response="…"`) don't leak past the first internal quote.
+// AUTH redaction is split into two anchored patterns:
+//   QUOTED_RE — preceded by `"` or `'` (JSON key or string-value context);
+//     the unquoted-value branch's value class `[^"'\r\n]+` stops at any
+//     quote so it can't consume past the outer JSON closing quote.
+//   LINE_RE — anchored to `^` or `\r\n` (HTTP header / env line); value
+//     class is `[^\r\n]+` so Digest's embedded quoted params are
+//     fully consumed.
+// Anchoring avoids the regression where a mid-string match on
+// `{"message":"authorization: …"}` swallowed the trailing `"}` and
+// produced unterminated JSON.
 const _SENSITIVE_KEYS = "password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth";
 const _SENSITIVE_LITERAL_SQUOTE_RE = new RegExp(
   `("?\\b(?:${_SENSITIVE_KEYS})\\b"?)(\\s*[:=]\\s*)'(?:\\\\.|[^'\\\\])*'`,
@@ -118,8 +124,10 @@ const _SENSITIVE_LITERAL_DQUOTE_RE = new RegExp(
   `("?\\b(?:${_SENSITIVE_KEYS})\\b"?)(\\s*[:=]\\s*)"(?:\\\\.|[^"\\\\])*"`,
   "gi",
 );
-const _SENSITIVE_AUTH_RE =
-  /("?\bauthorization\b"?)(\s*[:=]\s*)(?:(["'])((?:bearer|basic)\s+)?(?:\\.|[^\r\n\\])*?\3|((?:bearer|basic)\s+)?[^\r\n]+)/gi;
+const _SENSITIVE_AUTH_QUOTED_RE =
+  /(?<=["'])(\bauthorization\b)("?)(\s*[:=]\s*)(?:(["'])((?:bearer|basic)\s+)?(?:\\.|[^\r\n\\])*?\4|((?:bearer|basic)\s+)?[^"'\r\n]+)/gi;
+const _SENSITIVE_AUTH_LINE_RE =
+  /(?:^|(?<=[\r\n]))(\bauthorization\b)(\s*[:=]\s*)((?:bearer|basic)\s+)?[^\r\n]+/gi;
 
 export function scrubSqlSecrets(sql: string): string {
   return sql
@@ -132,20 +140,26 @@ export function scrubSqlSecrets(sql: string): string {
       (_m, key: string, sep: string) => `${key}${sep}"[REDACTED]"`,
     )
     .replace(
-      _SENSITIVE_AUTH_RE,
+      _SENSITIVE_AUTH_QUOTED_RE,
       (
         _m,
-        key: string,
+        kw: string,
+        keyQuote: string,
         sep: string,
-        openQuote: string | undefined,
+        valQuote: string | undefined,
         schemeQ: string | undefined,
         schemeU: string | undefined,
       ) => {
-        if (openQuote !== undefined) {
-          return `${key}${sep}${openQuote}${schemeQ || ""}[REDACTED]${openQuote}`;
+        if (valQuote !== undefined) {
+          return `${kw}${keyQuote}${sep}${valQuote}${schemeQ || ""}[REDACTED]${valQuote}`;
         }
-        return `${key}${sep}${schemeU || ""}[REDACTED]`;
+        return `${kw}${keyQuote}${sep}${schemeU || ""}[REDACTED]`;
       },
+    )
+    .replace(
+      _SENSITIVE_AUTH_LINE_RE,
+      (_m, kw: string, sep: string, scheme: string | undefined) =>
+        `${kw}${sep}${scheme || ""}[REDACTED]`,
     );
 }
 

--- a/src/connectors/db/lib/audit.ts
+++ b/src/connectors/db/lib/audit.ts
@@ -97,8 +97,11 @@ const _SENSITIVE_LITERAL_SQUOTE_RE =
   /("?(?:password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth)"?\s*[:=]\s*)'[^']*'/gi;
 const _SENSITIVE_LITERAL_DQUOTE_RE =
   /("?(?:password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth)"?\s*[:=]\s*)"[^"]*"/gi;
+// Auth value match runs to the next quote or newline so schemes other than
+// Bearer/Basic (e.g. `Authorization: Token abc123`) get their whole credential
+// redacted instead of just the scheme word.
 const _SENSITIVE_AUTH_RE =
-  /("?authorization"?\s*[:=]\s*['"]?)((?:bearer|basic)\s+)?([^"'\s\\]+)/gi;
+  /("?authorization"?\s*[:=]\s*['"]?)((?:bearer|basic)\s+)?([^"'\n\\]+)/gi;
 
 export function scrubSqlSecrets(sql: string): string {
   return sql

--- a/src/connectors/db/lib/audit.ts
+++ b/src/connectors/db/lib/audit.ts
@@ -101,22 +101,25 @@ export interface LogQueryParams {
 // Leading/trailing `\b` keeps `mytoken='x'` and `notpassword='x'` from being
 // spuriously redacted just because they end in a sensitive keyword.
 //
-// AUTH_RE alternates between quoted (closes at matching quote, e.g. JSON
-// `"authorization":"Bearer x"`) and unquoted (consumes to end-of-line, e.g.
-// `Authorization: Digest username="u", response="…"`). The unquoted branch
-// must run to end-of-line so Digest's embedded quoted parameters don't
-// leak past the first internal quote.
+// Value classes use `(?:\\.|[^Q\\])*` so `\"` and other escape sequences
+// inside JSON-encoded values are skipped — without this, `"abc\"def"`
+// terminates at the escaped quote and leaks the tail.
+//
+// AUTH_RE alternates between quoted (closes at the matching outer quote,
+// handling JSON-escaped inner quotes) and unquoted (consumes to end-of-line)
+// so unescaped Digest parameters on plain log lines (`Digest username="u",
+// response="…"`) don't leak past the first internal quote.
 const _SENSITIVE_KEYS = "password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth";
 const _SENSITIVE_LITERAL_SQUOTE_RE = new RegExp(
-  `("?\\b(?:${_SENSITIVE_KEYS})\\b"?)(\\s*[:=]\\s*)'[^']*'`,
+  `("?\\b(?:${_SENSITIVE_KEYS})\\b"?)(\\s*[:=]\\s*)'(?:\\\\.|[^'\\\\])*'`,
   "gi",
 );
 const _SENSITIVE_LITERAL_DQUOTE_RE = new RegExp(
-  `("?\\b(?:${_SENSITIVE_KEYS})\\b"?)(\\s*[:=]\\s*)"[^"]*"`,
+  `("?\\b(?:${_SENSITIVE_KEYS})\\b"?)(\\s*[:=]\\s*)"(?:\\\\.|[^"\\\\])*"`,
   "gi",
 );
 const _SENSITIVE_AUTH_RE =
-  /("?\bauthorization\b"?)(\s*[:=]\s*)(?:(["'])((?:bearer|basic)\s+)?([^\r\n]*?)\3|((?:bearer|basic)\s+)?([^\r\n]+))/gi;
+  /("?\bauthorization\b"?)(\s*[:=]\s*)(?:(["'])((?:bearer|basic)\s+)?(?:\\.|[^\r\n\\])*?\3|((?:bearer|basic)\s+)?[^\r\n]+)/gi;
 
 export function scrubSqlSecrets(sql: string): string {
   return sql
@@ -136,7 +139,6 @@ export function scrubSqlSecrets(sql: string): string {
         sep: string,
         openQuote: string | undefined,
         schemeQ: string | undefined,
-        _valQ: string | undefined,
         schemeU: string | undefined,
       ) => {
         if (openQuote !== undefined) {

--- a/src/connectors/db/lib/audit.ts
+++ b/src/connectors/db/lib/audit.ts
@@ -94,14 +94,23 @@ export interface LogQueryParams {
  * out of scope.
  */
 const _SENSITIVE_LITERAL_SQUOTE_RE =
-  /\b(password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth)\s*=\s*'[^']*'/gi;
+  /("?(?:password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth)"?\s*[:=]\s*)'[^']*'/gi;
 const _SENSITIVE_LITERAL_DQUOTE_RE =
-  /\b(password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth)\s*=\s*"[^"]*"/gi;
+  /("?(?:password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth)"?\s*[:=]\s*)"[^"]*"/gi;
+const _SENSITIVE_AUTH_RE =
+  /("?authorization"?\s*[:=]\s*['"]?)((?:bearer|basic)\s+)?([^"'\s\\]+)/gi;
 
 export function scrubSqlSecrets(sql: string): string {
   return sql
-    .replace(_SENSITIVE_LITERAL_SQUOTE_RE, (_m, key: string) => `${key}='[REDACTED]'`)
-    .replace(_SENSITIVE_LITERAL_DQUOTE_RE, (_m, key: string) => `${key}="[REDACTED]"`);
+    .replace(_SENSITIVE_LITERAL_SQUOTE_RE, (_m, key: string) => {
+      const k = key.replace(/\s*[:=]\s*$/, "");
+      return `${k}='[REDACTED]'`;
+    })
+    .replace(_SENSITIVE_LITERAL_DQUOTE_RE, (_m, key: string) => {
+      const k = key.replace(/\s*[:=]\s*$/, "");
+      return `${k}="[REDACTED]"`;
+    })
+    .replace(_SENSITIVE_AUTH_RE, (_m, prefix: string, type: string | undefined, _val: string) => `${prefix}${type || ""}[REDACTED]`);
 }
 
 /** Log a query execution event. */

--- a/src/connectors/db/lib/audit.ts
+++ b/src/connectors/db/lib/audit.ts
@@ -93,24 +93,44 @@ export interface LogQueryParams {
  * single/double-quoted literals — partial or concatenated literals are
  * out of scope.
  */
-const _SENSITIVE_LITERAL_SQUOTE_RE =
-  /("?(?:password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth)"?\s*[:=]\s*)'[^']*'/gi;
-const _SENSITIVE_LITERAL_DQUOTE_RE =
-  /("?(?:password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth)"?\s*[:=]\s*)"[^"]*"/gi;
+// Key + separator are captured as distinct groups so the original separator
+// (e.g. `:` for JSON, `=` for SQL/env) is preserved verbatim. Hard-coding `=`
+// would mangle `{"password":"x"}` into `{"password"='[REDACTED]'}`, breaking
+// downstream consumers that parse events.jsonl as JSON-per-line.
+// AUTH value class is `[^"'\r\n]+` so non-Bearer/Basic schemes (Token,
+// APIKey, Negotiate, Digest, …) get their full credential redacted.
+const _SENSITIVE_KEYS = "password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth";
+const _SENSITIVE_LITERAL_SQUOTE_RE = new RegExp(
+  `("?(?:${_SENSITIVE_KEYS})"?)(\\s*[:=]\\s*)'[^']*'`,
+  "gi",
+);
+const _SENSITIVE_LITERAL_DQUOTE_RE = new RegExp(
+  `("?(?:${_SENSITIVE_KEYS})"?)(\\s*[:=]\\s*)"[^"]*"`,
+  "gi",
+);
 const _SENSITIVE_AUTH_RE =
-  /("?authorization"?\s*[:=]\s*['"]?)((?:bearer|basic)\s+)?([^"'\s\\]+)/gi;
+  /("?authorization"?)(\s*[:=]\s*)(['"]?)((?:bearer|basic)\s+)?([^"'\r\n]+)/gi;
 
 export function scrubSqlSecrets(sql: string): string {
   return sql
-    .replace(_SENSITIVE_LITERAL_SQUOTE_RE, (_m, key: string) => {
-      const k = key.replace(/\s*[:=]\s*$/, "");
-      return `${k}='[REDACTED]'`;
-    })
-    .replace(_SENSITIVE_LITERAL_DQUOTE_RE, (_m, key: string) => {
-      const k = key.replace(/\s*[:=]\s*$/, "");
-      return `${k}="[REDACTED]"`;
-    })
-    .replace(_SENSITIVE_AUTH_RE, (_m, prefix: string, type: string | undefined, _val: string) => `${prefix}${type || ""}[REDACTED]`);
+    .replace(
+      _SENSITIVE_LITERAL_SQUOTE_RE,
+      (_m, key: string, sep: string) => `${key}${sep}'[REDACTED]'`,
+    )
+    .replace(
+      _SENSITIVE_LITERAL_DQUOTE_RE,
+      (_m, key: string, sep: string) => `${key}${sep}"[REDACTED]"`,
+    )
+    .replace(
+      _SENSITIVE_AUTH_RE,
+      (
+        _m,
+        key: string,
+        sep: string,
+        quote: string,
+        scheme: string | undefined,
+      ) => `${key}${sep}${quote}${scheme || ""}[REDACTED]`,
+    );
 }
 
 /** Log a query execution event. */

--- a/src/connectors/db/lib/audit.ts
+++ b/src/connectors/db/lib/audit.ts
@@ -97,11 +97,8 @@ const _SENSITIVE_LITERAL_SQUOTE_RE =
   /("?(?:password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth)"?\s*[:=]\s*)'[^']*'/gi;
 const _SENSITIVE_LITERAL_DQUOTE_RE =
   /("?(?:password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth)"?\s*[:=]\s*)"[^"]*"/gi;
-// Auth value match runs to the next quote or newline so schemes other than
-// Bearer/Basic (e.g. `Authorization: Token abc123`) get their whole credential
-// redacted instead of just the scheme word.
 const _SENSITIVE_AUTH_RE =
-  /("?authorization"?\s*[:=]\s*['"]?)((?:bearer|basic)\s+)?([^"'\n\\]+)/gi;
+  /("?authorization"?\s*[:=]\s*['"]?)((?:bearer|basic)\s+)?([^"'\s\\]+)/gi;
 
 export function scrubSqlSecrets(sql: string): string {
   return sql

--- a/src/connectors/db/lib/audit.ts
+++ b/src/connectors/db/lib/audit.ts
@@ -93,23 +93,30 @@ export interface LogQueryParams {
  * single/double-quoted literals — partial or concatenated literals are
  * out of scope.
  */
-// Key + separator are captured as distinct groups so the original separator
-// (e.g. `:` for JSON, `=` for SQL/env) is preserved verbatim. Hard-coding `=`
-// would mangle `{"password":"x"}` into `{"password"='[REDACTED]'}`, breaking
-// downstream consumers that parse events.jsonl as JSON-per-line.
-// AUTH value class is `[^"'\r\n]+` so non-Bearer/Basic schemes (Token,
-// APIKey, Negotiate, Digest, …) get their full credential redacted.
+// Key/separator are captured as distinct groups so the original separator
+// (e.g. `:` for JSON, `=` for SQL/env) is preserved verbatim — hard-coding
+// `=` would mangle `{"password":"x"}` into `{"password"='[REDACTED]'}` and
+// break downstream consumers parsing events.jsonl as JSON-per-line.
+//
+// Leading/trailing `\b` keeps `mytoken='x'` and `notpassword='x'` from being
+// spuriously redacted just because they end in a sensitive keyword.
+//
+// AUTH_RE alternates between quoted (closes at matching quote, e.g. JSON
+// `"authorization":"Bearer x"`) and unquoted (consumes to end-of-line, e.g.
+// `Authorization: Digest username="u", response="…"`). The unquoted branch
+// must run to end-of-line so Digest's embedded quoted parameters don't
+// leak past the first internal quote.
 const _SENSITIVE_KEYS = "password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth";
 const _SENSITIVE_LITERAL_SQUOTE_RE = new RegExp(
-  `("?(?:${_SENSITIVE_KEYS})"?)(\\s*[:=]\\s*)'[^']*'`,
+  `("?\\b(?:${_SENSITIVE_KEYS})\\b"?)(\\s*[:=]\\s*)'[^']*'`,
   "gi",
 );
 const _SENSITIVE_LITERAL_DQUOTE_RE = new RegExp(
-  `("?(?:${_SENSITIVE_KEYS})"?)(\\s*[:=]\\s*)"[^"]*"`,
+  `("?\\b(?:${_SENSITIVE_KEYS})\\b"?)(\\s*[:=]\\s*)"[^"]*"`,
   "gi",
 );
 const _SENSITIVE_AUTH_RE =
-  /("?authorization"?)(\s*[:=]\s*)(['"]?)((?:bearer|basic)\s+)?([^"'\r\n]+)/gi;
+  /("?\bauthorization\b"?)(\s*[:=]\s*)(?:(["'])((?:bearer|basic)\s+)?([^\r\n]*?)\3|((?:bearer|basic)\s+)?([^\r\n]+))/gi;
 
 export function scrubSqlSecrets(sql: string): string {
   return sql
@@ -127,9 +134,16 @@ export function scrubSqlSecrets(sql: string): string {
         _m,
         key: string,
         sep: string,
-        quote: string,
-        scheme: string | undefined,
-      ) => `${key}${sep}${quote}${scheme || ""}[REDACTED]`,
+        openQuote: string | undefined,
+        schemeQ: string | undefined,
+        _valQ: string | undefined,
+        schemeU: string | undefined,
+      ) => {
+        if (openQuote !== undefined) {
+          return `${key}${sep}${openQuote}${schemeQ || ""}[REDACTED]${openQuote}`;
+        }
+        return `${key}${sep}${schemeU || ""}[REDACTED]`;
+      },
     );
 }
 

--- a/src/toolkit/audit/writer.ts
+++ b/src/toolkit/audit/writer.ts
@@ -29,21 +29,28 @@ export interface AuditWriterOptions {
  * verbatim — hard-coding `=` would mangle `{"password":"x"}` into
  * `{"password"='[REDACTED]'}` and break downstream JSON-per-line parsers.
  *
- * The leading/trailing `\b` ensures we only match the sensitive keyword as
- * a complete word (or wrapped in JSON quotes), so `mytoken='x'` and
+ * The `\b` boundaries ensure we only match the sensitive keyword as a
+ * complete word (or wrapped in JSON quotes), so `mytoken='x'` and
  * `notpassword='x'` don't get spuriously redacted.
  *
  * Value classes use `(?:\\.|[^Q\\])*` (Q = the active quote) so escape
  * sequences like `\"` inside JSON-encoded values are skipped rather than
- * treated as the closing quote — without this, `{"password":"abc\"def"}`
- * would leak `def"}` and `{"authorization":"Digest username=\"…\""}`
- * would leak the parameter tail.
+ * treated as the closing quote.
  *
- * AUTH_RE alternates between a quoted branch (closes at the matching outer
- * quote, handling JSON-escaped inner quotes) and an unquoted branch that
- * consumes to end-of-line — needed so unescaped Digest parameters
- * (`Digest username="u", response="…"`) don't leak past the first internal
- * quote on a plain log line.
+ * AUTH redaction uses two anchored patterns instead of one unanchored one:
+ *
+ *   QUOTED_RE — preceded by `"` or `'` (JSON key OR string-value context).
+ *     Value class is `[^"'\r\n]+` so the unquoted branch can't consume
+ *     past the JSON value's closing quote and mangle the outer payload.
+ *
+ *   LINE_RE — anchored to `^` or `\r\n` (HTTP-header / env form). Value
+ *     class is `[^\r\n]+` so Digest parameters with embedded quotes
+ *     (`Digest username="u", response="…"`) are fully consumed.
+ *
+ * Anchoring to a field boundary avoids the regression from a single
+ * unanchored pattern, where `{"message":"authorization: Bearer abc"}`
+ * matched mid-string and the greedy unquoted value class swallowed the
+ * trailing `"}`, producing unterminated JSON.
  */
 const SENSITIVE_KEYS = "password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth";
 const SENSITIVE_SQUOTE_RE = new RegExp(
@@ -54,8 +61,10 @@ const SENSITIVE_DQUOTE_RE = new RegExp(
   `("?\\b(?:${SENSITIVE_KEYS})\\b"?)(\\s*[:=]\\s*)"(?:\\\\.|[^"\\\\])*"`,
   "gi",
 );
-const SENSITIVE_AUTH_RE =
-  /("?\bauthorization\b"?)(\s*[:=]\s*)(?:(["'])((?:bearer|basic)\s+)?(?:\\.|[^\r\n\\])*?\3|((?:bearer|basic)\s+)?[^\r\n]+)/gi;
+const SENSITIVE_AUTH_QUOTED_RE =
+  /(?<=["'])(\bauthorization\b)("?)(\s*[:=]\s*)(?:(["'])((?:bearer|basic)\s+)?(?:\\.|[^\r\n\\])*?\4|((?:bearer|basic)\s+)?[^"'\r\n]+)/gi;
+const SENSITIVE_AUTH_LINE_RE =
+  /(?:^|(?<=[\r\n]))(\bauthorization\b)(\s*[:=]\s*)((?:bearer|basic)\s+)?[^\r\n]+/gi;
 
 export function scrubSecrets(text: string): string {
   return text
@@ -68,20 +77,26 @@ export function scrubSecrets(text: string): string {
       (_m, key: string, sep: string) => `${key}${sep}"[REDACTED]"`,
     )
     .replace(
-      SENSITIVE_AUTH_RE,
+      SENSITIVE_AUTH_QUOTED_RE,
       (
         _m,
-        key: string,
+        kw: string,
+        keyQuote: string,
         sep: string,
-        openQuote: string | undefined,
+        valQuote: string | undefined,
         schemeQ: string | undefined,
         schemeU: string | undefined,
       ) => {
-        if (openQuote !== undefined) {
-          return `${key}${sep}${openQuote}${schemeQ || ""}[REDACTED]${openQuote}`;
+        if (valQuote !== undefined) {
+          return `${kw}${keyQuote}${sep}${valQuote}${schemeQ || ""}[REDACTED]${valQuote}`;
         }
-        return `${key}${sep}${schemeU || ""}[REDACTED]`;
+        return `${kw}${keyQuote}${sep}${schemeU || ""}[REDACTED]`;
       },
+    )
+    .replace(
+      SENSITIVE_AUTH_LINE_RE,
+      (_m, kw: string, sep: string, scheme: string | undefined) =>
+        `${kw}${sep}${scheme || ""}[REDACTED]`,
     );
 }
 

--- a/src/toolkit/audit/writer.ts
+++ b/src/toolkit/audit/writer.ts
@@ -21,29 +21,50 @@ export interface AuditWriterOptions {
   sessionId?: string;
 }
 
-/** Redact common credential-bearing `key='value'` literals in a string. */
-const SENSITIVE_SQUOTE_RE =
-  /("?(?:password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth)"?\s*[:=]\s*)'[^']*'/gi;
-const SENSITIVE_DQUOTE_RE =
-  /("?(?:password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth)"?\s*[:=]\s*)"[^"]*"/gi;
+/**
+ * Redact common credential-bearing `key='value'` literals in a string.
+ *
+ * The key/separator are captured as distinct groups so the original separator
+ * (e.g. `:` for JSON payloads, `=` for SQL or env-style) and its whitespace
+ * are preserved verbatim in the output. Hard-coding `=` would mangle JSON
+ * like `{"password":"x"}` into `{"password"='[REDACTED]'}`.
+ *
+ * AUTH value class is `[^"'\r\n]+` so non-Bearer/Basic schemes (Token,
+ * APIKey, Negotiate, Digest, …) get their whole credential redacted —
+ * stopping at whitespace would leave the credential tail in the log.
+ */
+const SENSITIVE_KEYS = "password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth";
+const SENSITIVE_SQUOTE_RE = new RegExp(
+  `("?(?:${SENSITIVE_KEYS})"?)(\\s*[:=]\\s*)'[^']*'`,
+  "gi",
+);
+const SENSITIVE_DQUOTE_RE = new RegExp(
+  `("?(?:${SENSITIVE_KEYS})"?)(\\s*[:=]\\s*)"[^"]*"`,
+  "gi",
+);
 const SENSITIVE_AUTH_RE =
-  /("?authorization"?\s*[:=]\s*['"]?)((?:bearer|basic)\s+)?([^"'\s\\]+)/gi;
+  /("?authorization"?)(\s*[:=]\s*)(['"]?)((?:bearer|basic)\s+)?([^"'\r\n]+)/gi;
 
 export function scrubSecrets(text: string): string {
   return text
-    .replace(SENSITIVE_SQUOTE_RE, (match, key: string) => {
-      const k = key.replace(/\s*[:=]\s*$/, "");
-      const sepMatch = match.substring(k.length).match(/\s*[:=]\s*/);
-      const sep = sepMatch ? sepMatch[0] : "=";
-      return `${k}${sep}'[REDACTED]'`;
-    })
-    .replace(SENSITIVE_DQUOTE_RE, (match, key: string) => {
-      const k = key.replace(/\s*[:=]\s*$/, "");
-      const sepMatch = match.substring(k.length).match(/\s*[:=]\s*/);
-      const sep = sepMatch ? sepMatch[0] : "=";
-      return `${k}${sep}"[REDACTED]"`;
-    })
-    .replace(SENSITIVE_AUTH_RE, (_m, prefix: string, type: string | undefined, _val: string) => `${prefix}${type || ""}[REDACTED]`);
+    .replace(
+      SENSITIVE_SQUOTE_RE,
+      (_m, key: string, sep: string) => `${key}${sep}'[REDACTED]'`,
+    )
+    .replace(
+      SENSITIVE_DQUOTE_RE,
+      (_m, key: string, sep: string) => `${key}${sep}"[REDACTED]"`,
+    )
+    .replace(
+      SENSITIVE_AUTH_RE,
+      (
+        _m,
+        key: string,
+        sep: string,
+        quote: string,
+        scheme: string | undefined,
+      ) => `${key}${sep}${quote}${scheme || ""}[REDACTED]`,
+    );
 }
 
 function isoTimestamp(): string {

--- a/src/toolkit/audit/writer.ts
+++ b/src/toolkit/audit/writer.ts
@@ -23,14 +23,27 @@ export interface AuditWriterOptions {
 
 /** Redact common credential-bearing `key='value'` literals in a string. */
 const SENSITIVE_SQUOTE_RE =
-  /\b(password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth)\s*=\s*'[^']*'/gi;
+  /("?(?:password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth)"?\s*[:=]\s*)'[^']*'/gi;
 const SENSITIVE_DQUOTE_RE =
-  /\b(password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth)\s*=\s*"[^"]*"/gi;
+  /("?(?:password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth)"?\s*[:=]\s*)"[^"]*"/gi;
+const SENSITIVE_AUTH_RE =
+  /("?authorization"?\s*[:=]\s*['"]?)((?:bearer|basic)\s+)?([^"'\s\\]+)/gi;
 
 export function scrubSecrets(text: string): string {
   return text
-    .replace(SENSITIVE_SQUOTE_RE, (_m, key: string) => `${key}='[REDACTED]'`)
-    .replace(SENSITIVE_DQUOTE_RE, (_m, key: string) => `${key}="[REDACTED]"`);
+    .replace(SENSITIVE_SQUOTE_RE, (match, key: string) => {
+      const k = key.replace(/\s*[:=]\s*$/, "");
+      const sepMatch = match.substring(k.length).match(/\s*[:=]\s*/);
+      const sep = sepMatch ? sepMatch[0] : "=";
+      return `${k}${sep}'[REDACTED]'`;
+    })
+    .replace(SENSITIVE_DQUOTE_RE, (match, key: string) => {
+      const k = key.replace(/\s*[:=]\s*$/, "");
+      const sepMatch = match.substring(k.length).match(/\s*[:=]\s*/);
+      const sep = sepMatch ? sepMatch[0] : "=";
+      return `${k}${sep}"[REDACTED]"`;
+    })
+    .replace(SENSITIVE_AUTH_RE, (_m, prefix: string, type: string | undefined, _val: string) => `${prefix}${type || ""}[REDACTED]`);
 }
 
 function isoTimestamp(): string {

--- a/src/toolkit/audit/writer.ts
+++ b/src/toolkit/audit/writer.ts
@@ -26,8 +26,11 @@ const SENSITIVE_SQUOTE_RE =
   /("?(?:password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth)"?\s*[:=]\s*)'[^']*'/gi;
 const SENSITIVE_DQUOTE_RE =
   /("?(?:password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth)"?\s*[:=]\s*)"[^"]*"/gi;
+// Auth value match runs to the next quote or newline so schemes other than
+// Bearer/Basic (e.g. `Authorization: Token abc123`) get their whole credential
+// redacted instead of just the scheme word.
 const SENSITIVE_AUTH_RE =
-  /("?authorization"?\s*[:=]\s*['"]?)((?:bearer|basic)\s+)?([^"'\s\\]+)/gi;
+  /("?authorization"?\s*[:=]\s*['"]?)((?:bearer|basic)\s+)?([^"'\n\\]+)/gi;
 
 export function scrubSecrets(text: string): string {
   return text

--- a/src/toolkit/audit/writer.ts
+++ b/src/toolkit/audit/writer.ts
@@ -33,23 +33,29 @@ export interface AuditWriterOptions {
  * a complete word (or wrapped in JSON quotes), so `mytoken='x'` and
  * `notpassword='x'` don't get spuriously redacted.
  *
- * AUTH_RE uses an alternation: quoted form stops at the matching closing
- * quote (so JSON like `{"authorization":"Bearer x"}` round-trips), while
- * unquoted form consumes to end-of-line so schemes like Digest that
- * embed quoted parameters (`Digest username="u", response="…"`) don't
- * leak the parameter tail past the first internal quote.
+ * Value classes use `(?:\\.|[^Q\\])*` (Q = the active quote) so escape
+ * sequences like `\"` inside JSON-encoded values are skipped rather than
+ * treated as the closing quote — without this, `{"password":"abc\"def"}`
+ * would leak `def"}` and `{"authorization":"Digest username=\"…\""}`
+ * would leak the parameter tail.
+ *
+ * AUTH_RE alternates between a quoted branch (closes at the matching outer
+ * quote, handling JSON-escaped inner quotes) and an unquoted branch that
+ * consumes to end-of-line — needed so unescaped Digest parameters
+ * (`Digest username="u", response="…"`) don't leak past the first internal
+ * quote on a plain log line.
  */
 const SENSITIVE_KEYS = "password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth";
 const SENSITIVE_SQUOTE_RE = new RegExp(
-  `("?\\b(?:${SENSITIVE_KEYS})\\b"?)(\\s*[:=]\\s*)'[^']*'`,
+  `("?\\b(?:${SENSITIVE_KEYS})\\b"?)(\\s*[:=]\\s*)'(?:\\\\.|[^'\\\\])*'`,
   "gi",
 );
 const SENSITIVE_DQUOTE_RE = new RegExp(
-  `("?\\b(?:${SENSITIVE_KEYS})\\b"?)(\\s*[:=]\\s*)"[^"]*"`,
+  `("?\\b(?:${SENSITIVE_KEYS})\\b"?)(\\s*[:=]\\s*)"(?:\\\\.|[^"\\\\])*"`,
   "gi",
 );
 const SENSITIVE_AUTH_RE =
-  /("?\bauthorization\b"?)(\s*[:=]\s*)(?:(["'])((?:bearer|basic)\s+)?([^\r\n]*?)\3|((?:bearer|basic)\s+)?([^\r\n]+))/gi;
+  /("?\bauthorization\b"?)(\s*[:=]\s*)(?:(["'])((?:bearer|basic)\s+)?(?:\\.|[^\r\n\\])*?\3|((?:bearer|basic)\s+)?[^\r\n]+)/gi;
 
 export function scrubSecrets(text: string): string {
   return text
@@ -69,7 +75,6 @@ export function scrubSecrets(text: string): string {
         sep: string,
         openQuote: string | undefined,
         schemeQ: string | undefined,
-        _valQ: string | undefined,
         schemeU: string | undefined,
       ) => {
         if (openQuote !== undefined) {

--- a/src/toolkit/audit/writer.ts
+++ b/src/toolkit/audit/writer.ts
@@ -26,11 +26,8 @@ const SENSITIVE_SQUOTE_RE =
   /("?(?:password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth)"?\s*[:=]\s*)'[^']*'/gi;
 const SENSITIVE_DQUOTE_RE =
   /("?(?:password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth)"?\s*[:=]\s*)"[^"]*"/gi;
-// Auth value match runs to the next quote or newline so schemes other than
-// Bearer/Basic (e.g. `Authorization: Token abc123`) get their whole credential
-// redacted instead of just the scheme word.
 const SENSITIVE_AUTH_RE =
-  /("?authorization"?\s*[:=]\s*['"]?)((?:bearer|basic)\s+)?([^"'\n\\]+)/gi;
+  /("?authorization"?\s*[:=]\s*['"]?)((?:bearer|basic)\s+)?([^"'\s\\]+)/gi;
 
 export function scrubSecrets(text: string): string {
   return text

--- a/src/toolkit/audit/writer.ts
+++ b/src/toolkit/audit/writer.ts
@@ -24,26 +24,32 @@ export interface AuditWriterOptions {
 /**
  * Redact common credential-bearing `key='value'` literals in a string.
  *
- * The key/separator are captured as distinct groups so the original separator
- * (e.g. `:` for JSON payloads, `=` for SQL or env-style) and its whitespace
- * are preserved verbatim in the output. Hard-coding `=` would mangle JSON
- * like `{"password":"x"}` into `{"password"='[REDACTED]'}`.
+ * Key/separator are captured as distinct groups so the original separator
+ * (e.g. `:` for JSON payloads, `=` for SQL or env-style) is preserved
+ * verbatim — hard-coding `=` would mangle `{"password":"x"}` into
+ * `{"password"='[REDACTED]'}` and break downstream JSON-per-line parsers.
  *
- * AUTH value class is `[^"'\r\n]+` so non-Bearer/Basic schemes (Token,
- * APIKey, Negotiate, Digest, …) get their whole credential redacted —
- * stopping at whitespace would leave the credential tail in the log.
+ * The leading/trailing `\b` ensures we only match the sensitive keyword as
+ * a complete word (or wrapped in JSON quotes), so `mytoken='x'` and
+ * `notpassword='x'` don't get spuriously redacted.
+ *
+ * AUTH_RE uses an alternation: quoted form stops at the matching closing
+ * quote (so JSON like `{"authorization":"Bearer x"}` round-trips), while
+ * unquoted form consumes to end-of-line so schemes like Digest that
+ * embed quoted parameters (`Digest username="u", response="…"`) don't
+ * leak the parameter tail past the first internal quote.
  */
 const SENSITIVE_KEYS = "password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|auth";
 const SENSITIVE_SQUOTE_RE = new RegExp(
-  `("?(?:${SENSITIVE_KEYS})"?)(\\s*[:=]\\s*)'[^']*'`,
+  `("?\\b(?:${SENSITIVE_KEYS})\\b"?)(\\s*[:=]\\s*)'[^']*'`,
   "gi",
 );
 const SENSITIVE_DQUOTE_RE = new RegExp(
-  `("?(?:${SENSITIVE_KEYS})"?)(\\s*[:=]\\s*)"[^"]*"`,
+  `("?\\b(?:${SENSITIVE_KEYS})\\b"?)(\\s*[:=]\\s*)"[^"]*"`,
   "gi",
 );
 const SENSITIVE_AUTH_RE =
-  /("?authorization"?)(\s*[:=]\s*)(['"]?)((?:bearer|basic)\s+)?([^"'\r\n]+)/gi;
+  /("?\bauthorization\b"?)(\s*[:=]\s*)(?:(["'])((?:bearer|basic)\s+)?([^\r\n]*?)\3|((?:bearer|basic)\s+)?([^\r\n]+))/gi;
 
 export function scrubSecrets(text: string): string {
   return text
@@ -61,9 +67,16 @@ export function scrubSecrets(text: string): string {
         _m,
         key: string,
         sep: string,
-        quote: string,
-        scheme: string | undefined,
-      ) => `${key}${sep}${quote}${scheme || ""}[REDACTED]`,
+        openQuote: string | undefined,
+        schemeQ: string | undefined,
+        _valQ: string | undefined,
+        schemeU: string | undefined,
+      ) => {
+        if (openQuote !== undefined) {
+          return `${key}${sep}${openQuote}${schemeQ || ""}[REDACTED]${openQuote}`;
+        }
+        return `${key}${sep}${schemeU || ""}[REDACTED]`;
+      },
     );
 }
 

--- a/tests/connectors/db/audit.test.ts
+++ b/tests/connectors/db/audit.test.ts
@@ -207,18 +207,48 @@ describe("wiki_db.audit", () => {
   it("scrubSqlSecrets masks single-quoted credential literals", () => {
     expect(
       scrubSqlSecrets("SELECT * FROM u WHERE password = 'p4ss' AND id = 1"),
-    ).toBe("SELECT * FROM u WHERE password='[REDACTED]' AND id = 1");
+    ).toBe("SELECT * FROM u WHERE password = '[REDACTED]' AND id = 1");
     expect(scrubSqlSecrets("WHERE token='sk-abc123'")).toBe(
       "WHERE token='[REDACTED]'",
     );
     expect(scrubSqlSecrets("WHERE api_key = 'k1' OR api-key = 'k2'")).toBe(
-      "WHERE api_key='[REDACTED]' OR api-key='[REDACTED]'",
+      "WHERE api_key = '[REDACTED]' OR api-key = '[REDACTED]'",
     );
   });
 
   it("scrubSqlSecrets masks double-quoted credential literals", () => {
     expect(scrubSqlSecrets('WHERE secret = "s3cr3t"')).toBe(
-      'WHERE secret="[REDACTED]"',
+      'WHERE secret = "[REDACTED]"',
+    );
+  });
+
+  it("scrubSqlSecrets preserves the matched separator in JSON payloads", () => {
+    // Regression: replacement used to hard-code `=`, mangling JSON keys —
+    // `{"password":"x"}` became `{"password"='[REDACTED]'}` which breaks
+    // downstream consumers parsing events.jsonl as JSON-per-line.
+    expect(scrubSqlSecrets(`{"password":"hunter2"}`)).toBe(
+      `{"password":"[REDACTED]"}`,
+    );
+    expect(scrubSqlSecrets(`{"api_key": "abc"}`)).toBe(
+      `{"api_key": "[REDACTED]"}`,
+    );
+  });
+
+  it("scrubSqlSecrets redacts the full Authorization value regardless of scheme", () => {
+    // Bearer/Basic preserve the scheme name for log readability.
+    expect(scrubSqlSecrets("Authorization: Bearer abc.def.ghi")).toBe(
+      "Authorization: Bearer [REDACTED]",
+    );
+    expect(scrubSqlSecrets("Authorization: Basic dXNlcjpwYXNz")).toBe(
+      "Authorization: Basic [REDACTED]",
+    );
+    // Regression: previously `[^"'\s\\]+` stopped at the first space so
+    // `Authorization: Token abc123` left `abc123` in the audit log.
+    expect(scrubSqlSecrets("Authorization: Token abc123")).toBe(
+      "Authorization: [REDACTED]",
+    );
+    expect(scrubSqlSecrets(`{"authorization": "Token abc123"}`)).toBe(
+      `{"authorization": "[REDACTED]"}`,
     );
   });
 
@@ -244,7 +274,7 @@ describe("wiki_db.audit", () => {
     const line = fs.readFileSync(logPath, "utf-8").trim();
     const record = JSON.parse(line) as { query: string };
     expect(record.query).toBe(
-      "SELECT * FROM users WHERE password='[REDACTED]' LIMIT 1",
+      "SELECT * FROM users WHERE password = '[REDACTED]' LIMIT 1",
     );
     expect(record.query).not.toContain("leaked");
   });

--- a/tests/connectors/db/audit.test.ts
+++ b/tests/connectors/db/audit.test.ts
@@ -222,24 +222,6 @@ describe("wiki_db.audit", () => {
     );
   });
 
-  it("scrubSqlSecrets redacts the full Authorization value regardless of scheme", () => {
-    // Bearer/Basic preserve the scheme name.
-    expect(scrubSqlSecrets("Authorization: Bearer abc.def.ghi")).toBe(
-      "Authorization: Bearer [REDACTED]",
-    );
-    expect(scrubSqlSecrets("Authorization: Basic dXNlcjpwYXNz")).toBe(
-      "Authorization: Basic [REDACTED]",
-    );
-    // Regression: previously `[^"'\s\\]+` stopped at the first space so
-    // `Authorization: Token abc123` left `abc123` in the audit log.
-    expect(scrubSqlSecrets("Authorization: Token abc123")).toBe(
-      "Authorization: [REDACTED]",
-    );
-    expect(scrubSqlSecrets(`{"authorization": "Token abc123"}`)).toBe(
-      `{"authorization": "[REDACTED]"}`,
-    );
-  });
-
   it("scrubSqlSecrets leaves non-credential literals alone", () => {
     expect(scrubSqlSecrets("SELECT name FROM u WHERE id = 1")).toBe(
       "SELECT name FROM u WHERE id = 1",

--- a/tests/connectors/db/audit.test.ts
+++ b/tests/connectors/db/audit.test.ts
@@ -298,6 +298,30 @@ describe("wiki_db.audit", () => {
     expect(out).not.toContain("response");
   });
 
+  it("scrubSqlSecrets does not mangle JSON when 'authorization' appears inside a string value", () => {
+    // Regression (Codex P2 on 6e3bf0f): the unquoted AUTH branch's
+    // `[^\r\n]+` value class used to consume the JSON closing `"}` and
+    // produce unterminated JSON for inputs like
+    // `{"message":"authorization: Bearer abc"}`.
+    const input = `{"message":"authorization: Bearer abc"}`;
+    const out = scrubSqlSecrets(input);
+    expect(out).toBe(`{"message":"authorization: Bearer [REDACTED]"}`);
+    expect(out).not.toContain("abc");
+    expect(() => JSON.parse(out)).not.toThrow();
+  });
+
+  it("scrubSqlSecrets still redacts HTTP-style Authorization headers at line start", () => {
+    expect(scrubSqlSecrets("Authorization: Bearer abc")).toBe(
+      "Authorization: Bearer [REDACTED]",
+    );
+    const multiline =
+      "GET /api\nAuthorization: Bearer xyz\nHost: example.com";
+    const out = scrubSqlSecrets(multiline);
+    expect(out).toContain("Authorization: Bearer [REDACTED]");
+    expect(out).not.toContain("xyz");
+    expect(out).toContain("Host: example.com");
+  });
+
   it("scrubSqlSecrets leaves non-credential literals alone", () => {
     expect(scrubSqlSecrets("SELECT name FROM u WHERE id = 1")).toBe(
       "SELECT name FROM u WHERE id = 1",

--- a/tests/connectors/db/audit.test.ts
+++ b/tests/connectors/db/audit.test.ts
@@ -276,6 +276,28 @@ describe("wiki_db.audit", () => {
     expect(scrubSqlSecrets("WHERE token='x'")).toBe("WHERE token='[REDACTED]'");
   });
 
+  it("scrubSqlSecrets handles JSON-escaped quotes inside secret values", () => {
+    // Regression (Codex P1 on 683b907): `"[^"]*"` used to terminate at
+    // an escaped `\"`, leaking the value tail.
+    expect(scrubSqlSecrets(`{"password":"abc\\"def"}`)).toBe(
+      `{"password":"[REDACTED]"}`,
+    );
+    expect(scrubSqlSecrets(`{"token":"a\\"b\\"c"}`)).toBe(
+      `{"token":"[REDACTED]"}`,
+    );
+  });
+
+  it("scrubSqlSecrets handles JSON-escaped quotes in Authorization values", () => {
+    // Regression (Codex P1 on 683b907): the quoted-branch value class
+    // used to stop at the first inner `"`, even when it was an escaped
+    // `\"`, leaking the Digest `response=` parameter.
+    const input = `{"authorization":"Digest username=\\"u\\", response=\\"abc123\\""}`;
+    const out = scrubSqlSecrets(input);
+    expect(out).toBe(`{"authorization":"[REDACTED]"}`);
+    expect(out).not.toContain("abc123");
+    expect(out).not.toContain("response");
+  });
+
   it("scrubSqlSecrets leaves non-credential literals alone", () => {
     expect(scrubSqlSecrets("SELECT name FROM u WHERE id = 1")).toBe(
       "SELECT name FROM u WHERE id = 1",

--- a/tests/connectors/db/audit.test.ts
+++ b/tests/connectors/db/audit.test.ts
@@ -252,6 +252,30 @@ describe("wiki_db.audit", () => {
     );
   });
 
+  it("scrubSqlSecrets redacts Digest headers with quoted parameters", () => {
+    // Regression (Codex P1 on 0733e81): the unquoted-form branch must
+    // consume to end-of-line so Digest's embedded `username="u"` and
+    // `response="…"` don't terminate the value class early.
+    const out = scrubSqlSecrets(
+      'Authorization: Digest username="u", realm="r", response="abc123"',
+    );
+    expect(out).toBe("Authorization: [REDACTED]");
+    expect(out).not.toContain("abc123");
+    expect(out).not.toContain('response="');
+  });
+
+  it("scrubSqlSecrets does not redact non-sensitive keys that merely end in a sensitive token", () => {
+    // Regression (Codex P2 on 0733e81): `\b` keeps `mytoken='x'` and
+    // `notpassword='x'` from being clobbered by the `token`/`password`
+    // suffix match.
+    expect(scrubSqlSecrets("WHERE mytoken='x'")).toBe("WHERE mytoken='x'");
+    expect(scrubSqlSecrets("WHERE notpassword = 'x'")).toBe(
+      "WHERE notpassword = 'x'",
+    );
+    // The bare sensitive keyword still matches.
+    expect(scrubSqlSecrets("WHERE token='x'")).toBe("WHERE token='[REDACTED]'");
+  });
+
   it("scrubSqlSecrets leaves non-credential literals alone", () => {
     expect(scrubSqlSecrets("SELECT name FROM u WHERE id = 1")).toBe(
       "SELECT name FROM u WHERE id = 1",

--- a/tests/connectors/db/audit.test.ts
+++ b/tests/connectors/db/audit.test.ts
@@ -222,6 +222,24 @@ describe("wiki_db.audit", () => {
     );
   });
 
+  it("scrubSqlSecrets redacts the full Authorization value regardless of scheme", () => {
+    // Bearer/Basic preserve the scheme name.
+    expect(scrubSqlSecrets("Authorization: Bearer abc.def.ghi")).toBe(
+      "Authorization: Bearer [REDACTED]",
+    );
+    expect(scrubSqlSecrets("Authorization: Basic dXNlcjpwYXNz")).toBe(
+      "Authorization: Basic [REDACTED]",
+    );
+    // Regression: previously `[^"'\s\\]+` stopped at the first space so
+    // `Authorization: Token abc123` left `abc123` in the audit log.
+    expect(scrubSqlSecrets("Authorization: Token abc123")).toBe(
+      "Authorization: [REDACTED]",
+    );
+    expect(scrubSqlSecrets(`{"authorization": "Token abc123"}`)).toBe(
+      `{"authorization": "[REDACTED]"}`,
+    );
+  });
+
   it("scrubSqlSecrets leaves non-credential literals alone", () => {
     expect(scrubSqlSecrets("SELECT name FROM u WHERE id = 1")).toBe(
       "SELECT name FROM u WHERE id = 1",

--- a/tests/toolkit/audit.test.ts
+++ b/tests/toolkit/audit.test.ts
@@ -38,6 +38,35 @@ describe("scrubSecrets", () => {
     const raw = "SELECT * FROM users WHERE id = 42";
     expect(scrubSecrets(raw)).toBe(raw);
   });
+
+  it("redacts the full Authorization value for Bearer/Basic schemes", () => {
+    expect(scrubSecrets("Authorization: Bearer abc.def.ghi")).toBe(
+      "Authorization: Bearer [REDACTED]",
+    );
+    expect(scrubSecrets("Authorization: Basic dXNlcjpwYXNz")).toBe(
+      "Authorization: Basic [REDACTED]",
+    );
+  });
+
+  it("redacts the full Authorization value for non-Bearer/Basic schemes", () => {
+    // Regression: previously `[^"'\s\\]+` stopped at the first space so
+    // `Authorization: Token abc123` left `abc123` in the log.
+    expect(scrubSecrets("Authorization: Token abc123")).toBe(
+      "Authorization: [REDACTED]",
+    );
+    expect(scrubSecrets("authorization=APIKey foo-bar-baz")).toBe(
+      "authorization=[REDACTED]",
+    );
+  });
+
+  it("redacts quoted Authorization values inside JSON", () => {
+    expect(scrubSecrets(`{"authorization": "Token abc123"}`)).toBe(
+      `{"authorization": "[REDACTED]"}`,
+    );
+    expect(scrubSecrets(`{"authorization": "Bearer abc.def"}`)).toBe(
+      `{"authorization": "Bearer [REDACTED]"}`,
+    );
+  });
 });
 
 describe("AuditWriter", () => {

--- a/tests/toolkit/audit.test.ts
+++ b/tests/toolkit/audit.test.ts
@@ -121,6 +121,30 @@ describe("scrubSecrets", () => {
     // Hyphenated variants still match.
     expect(scrubSecrets("api-key='x'")).toBe("api-key='[REDACTED]'");
   });
+
+  it("handles JSON-escaped quotes inside double-quoted secret values", () => {
+    // Regression (Codex P1 on 683b907): `"[^"]*"` terminated at the escaped
+    // quote inside `"abc\"def"`, leaving `def"}` in the log.
+    expect(scrubSecrets(`{"password":"abc\\"def"}`)).toBe(
+      `{"password":"[REDACTED]"}`,
+    );
+    expect(scrubSecrets(`{"token":"a\\"b\\"c"}`)).toBe(
+      `{"token":"[REDACTED]"}`,
+    );
+    // Single-quoted form mirrored.
+    expect(scrubSecrets(`{password:'a\\'b'}`)).toBe(`{password:'[REDACTED]'}`);
+  });
+
+  it("handles JSON-escaped quotes inside quoted Authorization values", () => {
+    // Regression (Codex P1 on 683b907): the quoted branch's value class
+    // used to terminate at the first `"` even when it was escaped, so
+    // JSON-encoded Digest headers leaked their `response=` tail.
+    const input = `{"authorization":"Digest username=\\"u\\", response=\\"abc123\\""}`;
+    const out = scrubSecrets(input);
+    expect(out).toBe(`{"authorization":"[REDACTED]"}`);
+    expect(out).not.toContain("abc123");
+    expect(out).not.toContain("response");
+  });
 });
 
 describe("AuditWriter", () => {

--- a/tests/toolkit/audit.test.ts
+++ b/tests/toolkit/audit.test.ts
@@ -38,6 +38,64 @@ describe("scrubSecrets", () => {
     const raw = "SELECT * FROM users WHERE id = 42";
     expect(scrubSecrets(raw)).toBe(raw);
   });
+
+  it("preserves the matched separator in JSON-shaped payloads", () => {
+    // `:` must round-trip (don't rewrite to `=`) so events.jsonl stays
+    // parseable as JSON-per-line.
+    expect(scrubSecrets(`{"password":"hunter2"}`)).toBe(
+      `{"password":"[REDACTED]"}`,
+    );
+    expect(scrubSecrets(`{"api_key": "abc"}`)).toBe(
+      `{"api_key": "[REDACTED]"}`,
+    );
+    expect(scrubSecrets(`{"token":"sk-abc"}`)).toBe(`{"token":"[REDACTED]"}`);
+  });
+
+  it("redacts the full Authorization value for Bearer/Basic schemes", () => {
+    expect(scrubSecrets("Authorization: Bearer abc.def.ghi")).toBe(
+      "Authorization: Bearer [REDACTED]",
+    );
+    expect(scrubSecrets("Authorization: Basic dXNlcjpwYXNz")).toBe(
+      "Authorization: Basic [REDACTED]",
+    );
+  });
+
+  it("redacts the full Authorization value for non-Bearer/Basic schemes", () => {
+    // Regression: previously `[^"'\s\\]+` stopped at the first space so
+    // `Authorization: Token abc123` left `abc123` in the log.
+    expect(scrubSecrets("Authorization: Token abc123")).toBe(
+      "Authorization: [REDACTED]",
+    );
+    expect(scrubSecrets("authorization=APIKey foo-bar-baz")).toBe(
+      "authorization=[REDACTED]",
+    );
+    expect(scrubSecrets("Authorization: Digest username=u, realm=r")).toBe(
+      "Authorization: [REDACTED]",
+    );
+  });
+
+  it("redacts quoted Authorization values inside JSON", () => {
+    // The closing quote sits outside the regex match, so it is preserved.
+    expect(scrubSecrets(`{"authorization": "Token abc123"}`)).toBe(
+      `{"authorization": "[REDACTED]"}`,
+    );
+    expect(scrubSecrets(`{"authorization": "Bearer abc.def"}`)).toBe(
+      `{"authorization": "Bearer [REDACTED]"}`,
+    );
+  });
+
+  it("over-redacts multi-credential lines (safe failure mode)", () => {
+    // `[^"'\r\n]+` is greedy across commas — the first Authorization match
+    // consumes everything to end-of-line, redacting both credentials. We
+    // accept the structure loss because the alternative (under-redacting)
+    // leaks the second credential.
+    const out = scrubSecrets(
+      "Authorization: Bearer aaa,Authorization: Basic bbb",
+    );
+    expect(out).not.toContain("aaa");
+    expect(out).not.toContain("bbb");
+    expect(out).toContain("[REDACTED]");
+  });
 });
 
 describe("AuditWriter", () => {

--- a/tests/toolkit/audit.test.ts
+++ b/tests/toolkit/audit.test.ts
@@ -85,16 +85,41 @@ describe("scrubSecrets", () => {
   });
 
   it("over-redacts multi-credential lines (safe failure mode)", () => {
-    // `[^"'\r\n]+` is greedy across commas — the first Authorization match
-    // consumes everything to end-of-line, redacting both credentials. We
-    // accept the structure loss because the alternative (under-redacting)
-    // leaks the second credential.
+    // The unquoted branch consumes to end-of-line — the first Authorization
+    // match swallows the second one. We accept the structure loss because
+    // the alternative (excluding commas) would leak Digest's comma-separated
+    // quoted parameters past the first one.
     const out = scrubSecrets(
       "Authorization: Bearer aaa,Authorization: Basic bbb",
     );
     expect(out).not.toContain("aaa");
     expect(out).not.toContain("bbb");
     expect(out).toContain("[REDACTED]");
+  });
+
+  it("redacts Digest headers with quoted parameters", () => {
+    // Regression (Codex P1 on 0733e81): an internal `"` in
+    // `Digest username="u", response="…"` used to terminate the value
+    // class, leaving the response= tail in the log.
+    const out = scrubSecrets(
+      'Authorization: Digest username="u", realm="r", response="abc123"',
+    );
+    expect(out).toBe("Authorization: [REDACTED]");
+    expect(out).not.toContain("abc123");
+    expect(out).not.toContain('response="');
+  });
+
+  it("does not redact non-sensitive keys that merely end in a sensitive token", () => {
+    // Regression (Codex P2 on 0733e81): removing `\b` caused
+    // `mytoken='x'` / `notpassword='x'` to match the `token`/`password`
+    // suffix and erase unrelated debug context.
+    expect(scrubSecrets("mytoken='x'")).toBe("mytoken='x'");
+    expect(scrubSecrets("notpassword='x'")).toBe("notpassword='x'");
+    expect(scrubSecrets('xsecret="y"')).toBe('xsecret="y"');
+    // The bare sensitive keyword still matches.
+    expect(scrubSecrets("token='x'")).toBe("token='[REDACTED]'");
+    // Hyphenated variants still match.
+    expect(scrubSecrets("api-key='x'")).toBe("api-key='[REDACTED]'");
   });
 });
 

--- a/tests/toolkit/audit.test.ts
+++ b/tests/toolkit/audit.test.ts
@@ -38,35 +38,6 @@ describe("scrubSecrets", () => {
     const raw = "SELECT * FROM users WHERE id = 42";
     expect(scrubSecrets(raw)).toBe(raw);
   });
-
-  it("redacts the full Authorization value for Bearer/Basic schemes", () => {
-    expect(scrubSecrets("Authorization: Bearer abc.def.ghi")).toBe(
-      "Authorization: Bearer [REDACTED]",
-    );
-    expect(scrubSecrets("Authorization: Basic dXNlcjpwYXNz")).toBe(
-      "Authorization: Basic [REDACTED]",
-    );
-  });
-
-  it("redacts the full Authorization value for non-Bearer/Basic schemes", () => {
-    // Regression: previously `[^"'\s\\]+` stopped at the first space so
-    // `Authorization: Token abc123` left `abc123` in the log.
-    expect(scrubSecrets("Authorization: Token abc123")).toBe(
-      "Authorization: [REDACTED]",
-    );
-    expect(scrubSecrets("authorization=APIKey foo-bar-baz")).toBe(
-      "authorization=[REDACTED]",
-    );
-  });
-
-  it("redacts quoted Authorization values inside JSON", () => {
-    expect(scrubSecrets(`{"authorization": "Token abc123"}`)).toBe(
-      `{"authorization": "[REDACTED]"}`,
-    );
-    expect(scrubSecrets(`{"authorization": "Bearer abc.def"}`)).toBe(
-      `{"authorization": "Bearer [REDACTED]"}`,
-    );
-  });
 });
 
 describe("AuditWriter", () => {

--- a/tests/toolkit/audit.test.ts
+++ b/tests/toolkit/audit.test.ts
@@ -145,6 +145,35 @@ describe("scrubSecrets", () => {
     expect(out).not.toContain("abc123");
     expect(out).not.toContain("response");
   });
+
+  it("does not mangle JSON when 'authorization' appears inside a string value", () => {
+    // Regression (Codex P2 on 6e3bf0f): the unquoted AUTH branch's
+    // `[^\r\n]+` value class used to consume the JSON closing `"` and
+    // `}`, producing unterminated JSON for inputs like
+    // `{"message":"authorization: Bearer abc"}`.
+    const input = `{"message":"authorization: Bearer abc"}`;
+    const out = scrubSecrets(input);
+    // The credential must still be redacted, but the JSON structure
+    // must remain valid.
+    expect(out).toBe(`{"message":"authorization: Bearer [REDACTED]"}`);
+    expect(out).not.toContain("abc");
+    // Structural sanity: still parseable as JSON.
+    expect(() => JSON.parse(out)).not.toThrow();
+  });
+
+  it("still redacts HTTP-style Authorization headers at line start", () => {
+    // The line-anchored pattern handles `^Authorization:` and the
+    // post-`\n` form. We accept that mid-line non-JSON occurrences are
+    // not matched (trade-off for not mangling JSON).
+    expect(scrubSecrets("Authorization: Bearer abc")).toBe(
+      "Authorization: Bearer [REDACTED]",
+    );
+    const multiline = "GET /api\nAuthorization: Bearer xyz\nHost: example.com";
+    const out = scrubSecrets(multiline);
+    expect(out).toContain("Authorization: Bearer [REDACTED]");
+    expect(out).not.toContain("xyz");
+    expect(out).toContain("Host: example.com");
+  });
 });
 
 describe("AuditWriter", () => {


### PR DESCRIPTION
This PR updates the regexes used in `scrubSecrets` and `scrubSqlSecrets` to successfully redact credentials stored within JSON payloads and HTTP `Authorization` headers before they are committed to logs.

---
*PR created automatically by Jules for task [9336628919186754324](https://jules.google.com/task/9336628919186754324) started by @rfv-code*