### PR TITLE
feat(db): multi-DB per environment + NARAI_ENV runtime env selection

### DIFF
--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -99,6 +99,10 @@ export async function loadResolvedConfig(opts: LoadOptions = {}): Promise<Resolv
   if (opts.environment !== undefined) {
     resolveOpts.environment = opts.environment;
   } else {
+    // Shell convention: NARAI_ENV="" is treated as unset (callers can
+    // `export NARAI_ENV=` to clear without unsetting). opts.environment is
+    // a typed API surface where empty string would be a caller bug, so it
+    // doesn't get the same treatment.
     const envFromVar = process.env["NARAI_ENV"];
     if (envFromVar !== undefined && envFromVar !== "") {
       resolveOpts.environment = envFromVar;

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -96,6 +96,13 @@ export async function loadResolvedConfig(opts: LoadOptions = {}): Promise<Resolv
   validateSecretsInTree(raw);
   const resolveOpts: { consumer?: string; environment?: string } = {};
   if (opts.consumer !== undefined) resolveOpts.consumer = opts.consumer;
-  if (opts.environment !== undefined) resolveOpts.environment = opts.environment;
+  if (opts.environment !== undefined) {
+    resolveOpts.environment = opts.environment;
+  } else {
+    const envFromVar = process.env["NARAI_ENV"];
+    if (envFromVar !== undefined && envFromVar !== "") {
+      resolveOpts.environment = envFromVar;
+    }
+  }
   return resolveConfig(raw, resolveOpts);
 }

--- a/src/connectors/db/connector.ts
+++ b/src/connectors/db/connector.ts
@@ -35,10 +35,10 @@ import { DB_POLICY_EXTRAS } from "./lib/plugin_config.js";
 // enforce `.min(1)` here so empty-SQL is caught at the toolkit boundary and
 // returned as VALIDATION_ERROR rather than reaching the dispatcher.
 const queryParams = z.object({
-  sqlite_path: z.string().optional(),
-  server: z.string().optional(),
-  env: z.string().optional().describe("Deprecated alias for `server`. Removed in next major."),
-  config_path: z.string().optional(),
+  sqlite_path: z.string().min(1, "sqlite_path must be non-empty if provided").optional(),
+  server: z.string().min(1, "server must be non-empty if provided").optional(),
+  env: z.string().min(1, "env must be non-empty if provided").optional().describe("Deprecated alias for `server`. Removed in next major."),
+  config_path: z.string().min(1, "config_path must be non-empty if provided").optional(),
   sql: z.string().min(1, "sql is required"),
   approval_mode: z.string().optional(),
   max_rows: z.coerce.number().int().positive().default(1000),
@@ -46,10 +46,10 @@ const queryParams = z.object({
 });
 
 const schemaParams = z.object({
-  sqlite_path: z.string().optional(),
-  server: z.string().optional(),
-  env: z.string().optional().describe("Deprecated alias for `server`. Removed in next major."),
-  config_path: z.string().optional(),
+  sqlite_path: z.string().min(1, "sqlite_path must be non-empty if provided").optional(),
+  server: z.string().min(1, "server must be non-empty if provided").optional(),
+  env: z.string().min(1, "env must be non-empty if provided").optional().describe("Deprecated alias for `server`. Removed in next major."),
+  config_path: z.string().min(1, "config_path must be non-empty if provided").optional(),
   filter: z.string().optional(),
 });
 

--- a/src/connectors/db/connector.ts
+++ b/src/connectors/db/connector.ts
@@ -36,7 +36,8 @@ import { DB_POLICY_EXTRAS } from "./lib/plugin_config.js";
 // returned as VALIDATION_ERROR rather than reaching the dispatcher.
 const queryParams = z.object({
   sqlite_path: z.string().optional(),
-  env: z.string().optional(),
+  server: z.string().optional(),
+  env: z.string().optional().describe("Deprecated alias for `server`. Removed in next major."),
   config_path: z.string().optional(),
   sql: z.string().min(1, "sql is required"),
   approval_mode: z.string().optional(),
@@ -46,7 +47,8 @@ const queryParams = z.object({
 
 const schemaParams = z.object({
   sqlite_path: z.string().optional(),
-  env: z.string().optional(),
+  server: z.string().optional(),
+  env: z.string().optional().describe("Deprecated alias for `server`. Removed in next major."),
   config_path: z.string().optional(),
   filter: z.string().optional(),
 });

--- a/src/connectors/db/dispatcher.ts
+++ b/src/connectors/db/dispatcher.ts
@@ -90,7 +90,7 @@ function toInt(value: unknown, fallback: number): number {
   return fallback;
 }
 
-function requireConnTarget(p: Params): {
+function extractConnTarget(p: Params): {
   sqlite_path?: string;
   server?: string;
   config_path?: string;
@@ -100,11 +100,8 @@ function requireConnTarget(p: Params): {
   const server = typeof p["server"] === "string" ? (p["server"] as string) : undefined;
   const envAlias = typeof p["env"] === "string" ? (p["env"] as string) : undefined;
 
-  // Normalize the deprecated `env` alias.
   let effectiveServer = server;
   if (envAlias !== undefined) {
-    // Warn whenever the deprecated alias is used — even if `server` was
-    // also set with the same value (still a deprecated usage).
     process.stderr.write(
       "warning: db connector param `env` is deprecated; use `server` instead\n",
     );
@@ -115,12 +112,8 @@ function requireConnTarget(p: Params): {
         "params 'server' and 'env' (deprecated alias) are both set and differ; use only 'server'",
       );
     }
-    // server === envAlias: warning already emitted; effectiveServer stays as `server`.
   }
 
-  if (!sqlite && !effectiveServer) {
-    throw new Error("params must include one of 'sqlite_path' or 'server'");
-  }
   if (sqlite && effectiveServer) {
     throw new Error("params 'sqlite_path' and 'server' are mutually exclusive");
   }
@@ -134,7 +127,7 @@ function requireConnTarget(p: Params): {
 }
 
 function validateQueryParams(p: Params): QueryParamsValidated {
-  const conn = requireConnTarget(p);
+  const conn = extractConnTarget(p);
   const sqlRaw = p["sql"];
   if (typeof sqlRaw !== "string" || sqlRaw.length === 0) {
     throw new Error("action 'query' requires a non-empty 'sql' string");
@@ -155,7 +148,7 @@ function validateQueryParams(p: Params): QueryParamsValidated {
 }
 
 function validateSchemaParams(p: Params): SchemaParamsValidated {
-  const conn = requireConnTarget(p);
+  const conn = extractConnTarget(p);
   const v: SchemaParamsValidated = {};
   if (conn.sqlite_path) v.sqlite_path = conn.sqlite_path;
   if (conn.server) v.server = conn.server;
@@ -532,15 +525,38 @@ async function runOnEnv(
 
   try {
     if (pluginCfg !== null) {
+      // Resolve missing `server` against `default:` / single-entry / error.
+      let resolvedServerName = v.server;
+
+      if (resolvedServerName === undefined) {
+        if (pluginCfg.default !== undefined) {
+          resolvedServerName = pluginCfg.default;
+        } else {
+          const aliases = Object.keys(pluginCfg.servers);
+          if (aliases.length === 1) {
+            resolvedServerName = aliases[0];
+          } else {
+            return {
+              status: "error",
+              error_code: "VALIDATION_ERROR",
+              error:
+                `params must include 'server' (no default configured; ` +
+                `available: [${aliases.join(", ")}])`,
+              execution_time_ms: 0,
+            };
+          }
+        }
+      }
+
       if (
-        !Object.prototype.hasOwnProperty.call(pluginCfg.servers, v.server!)
+        !Object.prototype.hasOwnProperty.call(pluginCfg.servers, resolvedServerName)
       ) {
         const available = Object.keys(pluginCfg.servers).join(", ");
         return {
           status: "error",
           error_code: "CONFIG_ERROR",
           error:
-            `server '${v.server}' not found in plugin config ` +
+            `server '${resolvedServerName}' not found in plugin config ` +
             `(servers: [${available || "none"}])`,
           execution_time_ms: 0,
         };
@@ -566,7 +582,7 @@ async function runOnEnv(
           ...(gdh !== undefined ? { grant_duration_hours: gdh } : {}),
         });
       }
-      serverName = v.server!;
+      serverName = resolvedServerName;
       const env = getEnvironment(serverName);
       const qv = v as QueryParamsValidated;
       approvalMode =
@@ -574,8 +590,17 @@ async function runOnEnv(
       rules = env.policy ?? DEFAULT_POLICY;
       grantDurationHours = env.grant_duration_hours;
     } else {
+      if (v.server === undefined) {
+        return {
+          status: "error",
+          error_code: "VALIDATION_ERROR",
+          error:
+            "params must include 'server' (or 'sqlite_path'); no plugin config found, and the legacy wiki.config.yaml path requires an explicit name",
+          execution_time_ms: 0,
+        };
+      }
       const configPath = v.config_path ?? "./wiki.config.yaml";
-      const resolved = resolveEnv(v.server!, configPath);
+      const resolved = resolveEnv(v.server, configPath);
       serverName = resolved.name;
       const qv = v as QueryParamsValidated;
       approvalMode = qv.approval_mode ?? resolved.approval_mode;

--- a/src/connectors/db/dispatcher.ts
+++ b/src/connectors/db/dispatcher.ts
@@ -98,40 +98,30 @@ function requireConnTarget(p: Params): {
   const server = typeof p["server"] === "string" ? (p["server"] as string) : undefined;
   const envAlias = typeof p["env"] === "string" ? (p["env"] as string) : undefined;
 
-  // Reject conflicting deprecated alias.
-  if (server !== undefined && envAlias !== undefined && server !== envAlias) {
+  // Normalize the deprecated `env` alias.
+  let effectiveServer = server;
+  if (server === undefined && envAlias !== undefined) {
+    process.stderr.write(
+      "warning: db connector param `env` is deprecated; use `server` instead\n",
+    );
+    effectiveServer = envAlias;
+  } else if (server !== undefined && envAlias !== undefined && server !== envAlias) {
     throw new Error(
       "params 'server' and 'env' (deprecated alias) are both set and differ; use only 'server'",
     );
   }
 
-  // The deprecated `env` param is only valid as a sole connection target
-  // (not alongside sqlite_path). Emit a warning and promote it to server.
-  if (envAlias !== undefined && server === undefined) {
-    if (sqlite) {
-      throw new Error("params 'sqlite_path' and 'env' are mutually exclusive");
-    }
-    process.stderr.write(
-      "warning: db connector param `env` is deprecated; use `server` instead\n",
-    );
-    const config_path =
-      typeof p["config_path"] === "string" ? (p["config_path"] as string) : undefined;
-    const out: { sqlite_path?: string; server?: string; config_path?: string } = {};
-    out.server = envAlias;
-    if (config_path) out.config_path = config_path;
-    return out;
-  }
-
-  if (!sqlite && !server) {
+  if (!sqlite && !effectiveServer) {
     throw new Error("params must include one of 'sqlite_path' or 'server'");
   }
-  // When sqlite_path is present, it is the connection target; server is ignored
-  // for connection purposes (it may provide policy context in future work).
+  if (sqlite && effectiveServer) {
+    throw new Error("params 'sqlite_path' and 'server' are mutually exclusive");
+  }
   const config_path =
     typeof p["config_path"] === "string" ? (p["config_path"] as string) : undefined;
   const out: { sqlite_path?: string; server?: string; config_path?: string } = {};
   if (sqlite) out.sqlite_path = sqlite;
-  else if (server) out.server = server;
+  if (effectiveServer) out.server = effectiveServer;
   if (config_path) out.config_path = config_path;
   return out;
 }

--- a/src/connectors/db/dispatcher.ts
+++ b/src/connectors/db/dispatcher.ts
@@ -11,10 +11,12 @@
  *
  *   query  — execute SQL against a backend (or return formatted SQL for
  *            WRITE/DELETE via status=present_only). Params:
- *            `{env|sqlite_path, sql, max_rows?, timeout_ms?,
- *            approval_mode?, config_path?}`.
- *   schema — introspect table/column schema. Params: `{env|sqlite_path,
- *            filter?, config_path?}`.
+ *            `{server|sqlite_path, sql, max_rows?, timeout_ms?,
+ *            approval_mode?, config_path?}`. `env` is accepted as a
+ *            deprecated alias for `server` and emits a stderr warning.
+ *   schema — introspect table/column schema. Params: `{server|sqlite_path,
+ *            filter?, config_path?}`. `env` is accepted as a deprecated
+ *            alias for `server` and emits a stderr warning.
  */
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -100,15 +102,20 @@ function requireConnTarget(p: Params): {
 
   // Normalize the deprecated `env` alias.
   let effectiveServer = server;
-  if (server === undefined && envAlias !== undefined) {
+  if (envAlias !== undefined) {
+    // Warn whenever the deprecated alias is used — even if `server` was
+    // also set with the same value (still a deprecated usage).
     process.stderr.write(
       "warning: db connector param `env` is deprecated; use `server` instead\n",
     );
-    effectiveServer = envAlias;
-  } else if (server !== undefined && envAlias !== undefined && server !== envAlias) {
-    throw new Error(
-      "params 'server' and 'env' (deprecated alias) are both set and differ; use only 'server'",
-    );
+    if (server === undefined) {
+      effectiveServer = envAlias;
+    } else if (server !== envAlias) {
+      throw new Error(
+        "params 'server' and 'env' (deprecated alias) are both set and differ; use only 'server'",
+      );
+    }
+    // server === envAlias: warning already emitted; effectiveServer stays as `server`.
   }
 
   if (!sqlite && !effectiveServer) {

--- a/src/connectors/db/dispatcher.ts
+++ b/src/connectors/db/dispatcher.ts
@@ -532,16 +532,16 @@ async function runOnEnv(
         if (pluginCfg.default !== undefined) {
           resolvedServerName = pluginCfg.default;
         } else {
-          const aliases = Object.keys(pluginCfg.servers);
-          if (aliases.length === 1) {
-            resolvedServerName = aliases[0];
+          const serverNames = Object.keys(pluginCfg.servers);
+          if (serverNames.length === 1) {
+            resolvedServerName = serverNames[0];
           } else {
             return {
               status: "error",
               error_code: "VALIDATION_ERROR",
               error:
                 `params must include 'server' (no default configured; ` +
-                `available: [${aliases.join(", ")}])`,
+                `available: [${serverNames.join(", ")}])`,
               execution_time_ms: 0,
             };
           }
@@ -594,8 +594,7 @@ async function runOnEnv(
         return {
           status: "error",
           error_code: "VALIDATION_ERROR",
-          error:
-            "params must include 'server' (or 'sqlite_path'); no plugin config found, and the legacy wiki.config.yaml path requires an explicit name",
+          error: "params must include 'server' (or 'sqlite_path')",
           execution_time_ms: 0,
         };
       }

--- a/src/connectors/db/dispatcher.ts
+++ b/src/connectors/db/dispatcher.ts
@@ -62,7 +62,7 @@ type Params = Record<string, unknown>;
 
 interface QueryParamsValidated {
   sqlite_path?: string;
-  env?: string;
+  server?: string;
   config_path?: string;
   sql: string;
   approval_mode?: string;
@@ -72,7 +72,7 @@ interface QueryParamsValidated {
 
 interface SchemaParamsValidated {
   sqlite_path?: string;
-  env?: string;
+  server?: string;
   config_path?: string;
   filter?: string;
 }
@@ -90,23 +90,48 @@ function toInt(value: unknown, fallback: number): number {
 
 function requireConnTarget(p: Params): {
   sqlite_path?: string;
-  env?: string;
+  server?: string;
   config_path?: string;
 } {
   const sqlite =
     typeof p["sqlite_path"] === "string" ? (p["sqlite_path"] as string) : undefined;
-  const env = typeof p["env"] === "string" ? (p["env"] as string) : undefined;
-  if (!sqlite && !env) {
-    throw new Error("params must include one of 'sqlite_path' or 'env'");
+  const server = typeof p["server"] === "string" ? (p["server"] as string) : undefined;
+  const envAlias = typeof p["env"] === "string" ? (p["env"] as string) : undefined;
+
+  // Reject conflicting deprecated alias.
+  if (server !== undefined && envAlias !== undefined && server !== envAlias) {
+    throw new Error(
+      "params 'server' and 'env' (deprecated alias) are both set and differ; use only 'server'",
+    );
   }
-  if (sqlite && env) {
-    throw new Error("params 'sqlite_path' and 'env' are mutually exclusive");
+
+  // The deprecated `env` param is only valid as a sole connection target
+  // (not alongside sqlite_path). Emit a warning and promote it to server.
+  if (envAlias !== undefined && server === undefined) {
+    if (sqlite) {
+      throw new Error("params 'sqlite_path' and 'env' are mutually exclusive");
+    }
+    process.stderr.write(
+      "warning: db connector param `env` is deprecated; use `server` instead\n",
+    );
+    const config_path =
+      typeof p["config_path"] === "string" ? (p["config_path"] as string) : undefined;
+    const out: { sqlite_path?: string; server?: string; config_path?: string } = {};
+    out.server = envAlias;
+    if (config_path) out.config_path = config_path;
+    return out;
   }
+
+  if (!sqlite && !server) {
+    throw new Error("params must include one of 'sqlite_path' or 'server'");
+  }
+  // When sqlite_path is present, it is the connection target; server is ignored
+  // for connection purposes (it may provide policy context in future work).
   const config_path =
     typeof p["config_path"] === "string" ? (p["config_path"] as string) : undefined;
-  const out: { sqlite_path?: string; env?: string; config_path?: string } = {};
+  const out: { sqlite_path?: string; server?: string; config_path?: string } = {};
   if (sqlite) out.sqlite_path = sqlite;
-  if (env) out.env = env;
+  else if (server) out.server = server;
   if (config_path) out.config_path = config_path;
   return out;
 }
@@ -123,7 +148,7 @@ function validateQueryParams(p: Params): QueryParamsValidated {
     timeout_ms: toInt(p["timeout_ms"], 30000),
   };
   if (conn.sqlite_path) v.sqlite_path = conn.sqlite_path;
-  if (conn.env) v.env = conn.env;
+  if (conn.server) v.server = conn.server;
   if (conn.config_path) v.config_path = conn.config_path;
   const approval = p["approval_mode"];
   if (typeof approval === "string" && approval.length > 0) {
@@ -136,7 +161,7 @@ function validateSchemaParams(p: Params): SchemaParamsValidated {
   const conn = requireConnTarget(p);
   const v: SchemaParamsValidated = {};
   if (conn.sqlite_path) v.sqlite_path = conn.sqlite_path;
-  if (conn.env) v.env = conn.env;
+  if (conn.server) v.server = conn.server;
   if (conn.config_path) v.config_path = conn.config_path;
   const filter = p["filter"];
   if (typeof filter === "string" && filter.length > 0) v.filter = filter;
@@ -503,7 +528,7 @@ async function runOnEnv(
     };
   }
 
-  let envName: string;
+  let serverName: string;
   let approvalMode: string;
   let rules: PolicyRules;
   let grantDurationHours: number | undefined;
@@ -511,14 +536,14 @@ async function runOnEnv(
   try {
     if (pluginCfg !== null) {
       if (
-        !Object.prototype.hasOwnProperty.call(pluginCfg.servers, v.env!)
+        !Object.prototype.hasOwnProperty.call(pluginCfg.servers, v.server!)
       ) {
         const available = Object.keys(pluginCfg.servers).join(", ");
         return {
           status: "error",
           error_code: "CONFIG_ERROR",
           error:
-            `environment '${v.env}' not found in plugin config ` +
+            `server '${v.server}' not found in plugin config ` +
             `(servers: [${available || "none"}])`,
           execution_time_ms: 0,
         };
@@ -544,8 +569,8 @@ async function runOnEnv(
           ...(gdh !== undefined ? { grant_duration_hours: gdh } : {}),
         });
       }
-      envName = v.env!;
-      const env = getEnvironment(envName);
+      serverName = v.server!;
+      const env = getEnvironment(serverName);
       const qv = v as QueryParamsValidated;
       approvalMode =
         qv.approval_mode ?? env.approval_mode.replace(/-/g, "_");
@@ -553,8 +578,8 @@ async function runOnEnv(
       grantDurationHours = env.grant_duration_hours;
     } else {
       const configPath = v.config_path ?? "./wiki.config.yaml";
-      const resolved = resolveEnv(v.env!, configPath);
-      envName = resolved.name;
+      const resolved = resolveEnv(v.server!, configPath);
+      serverName = resolved.name;
       const qv = v as QueryParamsValidated;
       approvalMode = qv.approval_mode ?? resolved.approval_mode;
       rules = DEFAULT_POLICY;
@@ -584,7 +609,7 @@ async function runOnEnv(
 
   let conn;
   try {
-    conn = await getConnection(envName);
+    conn = await getConnection(serverName);
   } catch (e) {
     clearEnvironments();
     return {
@@ -602,7 +627,7 @@ async function runOnEnv(
         conn.driver,
         conn.native,
         sv.filter ?? null,
-        envName,
+        serverName,
       );
     }
     const qv = v as QueryParamsValidated;
@@ -617,7 +642,7 @@ async function runOnEnv(
       timeout_ms: qv.timeout_ms,
     });
   } finally {
-    releaseConnection(envName, conn);
+    releaseConnection(serverName, conn);
     clearEnvironments();
   }
 }
@@ -684,14 +709,16 @@ options:
                   JSON string of action parameters
 
 action 'query' params:
-  {"env": "dev", "sql": "SELECT 1"}  or
+  {"server": "dev", "sql": "SELECT 1"}  or
   {"sqlite_path": "./test.db", "sql": "SELECT 1"}
   optional: max_rows (default 1000), timeout_ms (default 30000),
            approval_mode, config_path
+  deprecated: \`env\` is accepted as an alias for \`server\`.
 
 action 'schema' params:
-  {"env": "dev"}  or  {"sqlite_path": "./test.db"}
+  {"server": "dev"}  or  {"sqlite_path": "./test.db"}
   optional: filter, config_path
+  deprecated: \`env\` is accepted as an alias for \`server\`.
 
 Writes/deletes (INSERT/UPDATE/DELETE/TRUNCATE/…) follow the configured
 policy. By default, WRITE escalates and DELETE/ADMIN return status="present_only"

--- a/src/connectors/db/dispatcher.ts
+++ b/src/connectors/db/dispatcher.ts
@@ -95,10 +95,27 @@ function extractConnTarget(p: Params): {
   server?: string;
   config_path?: string;
 } {
-  const sqlite =
-    typeof p["sqlite_path"] === "string" ? (p["sqlite_path"] as string) : undefined;
-  const server = typeof p["server"] === "string" ? (p["server"] as string) : undefined;
-  const envAlias = typeof p["env"] === "string" ? (p["env"] as string) : undefined;
+  // Defense-in-depth: zod catches these at the framework layer, but
+  // legacy `dispatcherFetch` and CLI `--params` callers reach here
+  // directly. Reject malformed types up front so they can't slip into
+  // default-server fallback.
+  const sqliteRaw = p["sqlite_path"];
+  if (sqliteRaw !== undefined && (typeof sqliteRaw !== "string" || sqliteRaw.length === 0)) {
+    throw new Error("params 'sqlite_path' must be a non-empty string");
+  }
+  const sqlite = typeof sqliteRaw === "string" ? sqliteRaw : undefined;
+
+  const serverRaw = p["server"];
+  if (serverRaw !== undefined && (typeof serverRaw !== "string" || serverRaw.length === 0)) {
+    throw new Error("params 'server' must be a non-empty string");
+  }
+  const server = typeof serverRaw === "string" ? serverRaw : undefined;
+
+  const envRaw = p["env"];
+  if (envRaw !== undefined && (typeof envRaw !== "string" || envRaw.length === 0)) {
+    throw new Error("params 'env' must be a non-empty string");
+  }
+  const envAlias = typeof envRaw === "string" ? envRaw : undefined;
 
   let effectiveServer = server;
   if (envAlias !== undefined) {
@@ -117,8 +134,11 @@ function extractConnTarget(p: Params): {
   if (sqlite && effectiveServer) {
     throw new Error("params 'sqlite_path' and 'server' are mutually exclusive");
   }
-  const config_path =
-    typeof p["config_path"] === "string" ? (p["config_path"] as string) : undefined;
+  const configPathRaw = p["config_path"];
+  if (configPathRaw !== undefined && (typeof configPathRaw !== "string" || configPathRaw.length === 0)) {
+    throw new Error("params 'config_path' must be a non-empty string");
+  }
+  const config_path = typeof configPathRaw === "string" ? configPathRaw : undefined;
   const out: { sqlite_path?: string; server?: string; config_path?: string } = {};
   if (sqlite) out.sqlite_path = sqlite;
   if (effectiveServer) out.server = effectiveServer;

--- a/src/connectors/db/index.ts
+++ b/src/connectors/db/index.ts
@@ -5,10 +5,19 @@
  * `@narai/connector-toolkit`. Use `import connector from "narai-primitives/db"`
  * and call `connector.fetch(action, params)` / `connector.main(argv)`.
  *
+ * Multiple databases per environment: declare each one under
+ * `connectors.db.servers:` in `~/.connectors/config.yaml`; calls pass
+ * `server: "<alias>"`. An optional `connectors.db.default:` names the
+ * server used when the caller omits `server`. If `servers:` has exactly
+ * one entry, it's the implicit default.
+ *
  * Legacy surface: `fetch(action, params)` is re-exported from the internal
  * dispatcher for programmatic callers that want the pre-framework envelope
  * shape (`{status: "ok"|"denied"|..., rows, columns, ...}`). The framework
  * connector translates that into the canonical envelope at the boundary.
+ *
+ * Deprecated: the per-call `env` parameter is accepted as an alias for
+ * `server` for one minor cycle. Migrate.
  */
 import { buildDbConnector } from "./connector.js";
 

--- a/src/connectors/db/lib/environments.ts
+++ b/src/connectors/db/lib/environments.ts
@@ -142,3 +142,23 @@ export function listEnvironments(): string[] {
 export function clearEnvironments(): void {
   _registry.clear();
 }
+
+/**
+ * Canonical name. `registerEnvironment` is kept as a deprecated alias.
+ */
+export const registerServer = registerEnvironment;
+
+/**
+ * Canonical name. `getEnvironment` is kept as a deprecated alias.
+ */
+export const getServer = getEnvironment;
+
+/**
+ * Canonical name. `listEnvironments` is kept as a deprecated alias.
+ */
+export const listServers = listEnvironments;
+
+/**
+ * Canonical name. `clearEnvironments` is kept as a deprecated alias.
+ */
+export const clearServers = clearEnvironments;

--- a/src/connectors/db/lib/plugin_config.ts
+++ b/src/connectors/db/lib/plugin_config.ts
@@ -99,6 +99,8 @@ export interface AuditConfig {
 export interface PluginConfig {
   policy: PolicyRules;
   servers: Record<string, ServerConfig>;
+  /** Optional alias from `servers:` to use when callers omit `server`. */
+  default?: string;
   audit?: AuditConfig;
 }
 
@@ -321,6 +323,26 @@ function validateAudit(raw: unknown): AuditConfig | undefined {
   return { enabled };
 }
 
+function validateDefault(
+  raw: unknown,
+  servers: Record<string, ServerConfig>,
+): string | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (typeof raw !== "string") {
+    throw new Error(`default: expected string, got: ${typeof raw}`);
+  }
+  if (raw.length === 0) {
+    throw new Error(`default: expected non-empty string`);
+  }
+  if (!Object.prototype.hasOwnProperty.call(servers, raw)) {
+    const available = Object.keys(servers).join(", ");
+    throw new Error(
+      `default: '${raw}' not found in servers (available: [${available || "none"}])`,
+    );
+  }
+  return raw;
+}
+
 /**
  * Validate a raw parsed YAML object against the plugin-config schema.
  * Throws a descriptive error on any shape or value violation.
@@ -355,14 +377,16 @@ export function validatePluginConfig(raw: unknown): PluginConfig {
   }
 
   const audit = validateAudit(raw["audit"]);
+  const defaultServer = validateDefault(raw["default"], servers);
 
   const out: PluginConfig = { policy, servers };
+  if (defaultServer !== undefined) out.default = defaultServer;
   if (audit !== undefined) out.audit = audit;
 
   for (const k of Object.keys(raw)) {
-    if (k !== "policy" && k !== "servers" && k !== "audit") {
+    if (k !== "policy" && k !== "servers" && k !== "audit" && k !== "default") {
       throw new Error(
-        `plugin config: unknown top-level key '${k}' (expected: policy, servers, audit)`,
+        `plugin config: unknown top-level key '${k}' (expected: policy, servers, audit, default)`,
       );
     }
   }
@@ -441,8 +465,10 @@ export function pluginConfigFromSlice(slice: {
   }
 
   const audit = validateAudit(options["audit"]);
+  const defaultServer = validateDefault(options["default"], servers);
 
   const out: PluginConfig = { policy, servers };
+  if (defaultServer !== undefined) out.default = defaultServer;
   if (audit !== undefined) out.audit = audit;
   return out;
 }

--- a/tests/config/load.test.ts
+++ b/tests/config/load.test.ts
@@ -236,10 +236,9 @@ describe("NARAI_ENV", () => {
       "      orders: { driver: sqlite, database: base.db }",
       "environments:",
       "  prod:",
-      "    connectors:",
-      "      db:",
-      "        servers:",
-      "          orders: { driver: sqlite, database: prod.db }",
+      "    db:",
+      "      servers:",
+      "        orders: { driver: sqlite, database: prod.db }",
       "",
     ].join("\n"));
     process.env["NARAI_ENV"] = "prod";
@@ -256,8 +255,8 @@ describe("NARAI_ENV", () => {
       "    servers:",
       "      orders: { driver: sqlite, database: base.db }",
       "environments:",
-      "  prod: { connectors: { db: { servers: { orders: { driver: sqlite, database: prod.db } } } } }",
-      "  staging: { connectors: { db: { servers: { orders: { driver: sqlite, database: staging.db } } } } }",
+      "  prod: { db: { servers: { orders: { driver: sqlite, database: prod.db } } } }",
+      "  staging: { db: { servers: { orders: { driver: sqlite, database: staging.db } } } }",
       "",
     ].join("\n"));
     process.env["NARAI_ENV"] = "prod";
@@ -271,7 +270,7 @@ describe("NARAI_ENV", () => {
       "  db: { skill: db-agent-connector, servers: { orders: { driver: sqlite, database: base.db } } }",
       "environments:",
       "  default: prod",
-      "  prod: { connectors: { db: { servers: { orders: { driver: sqlite, database: prod.db } } } } }",
+      "  prod: { db: { servers: { orders: { driver: sqlite, database: prod.db } } } }",
       "",
     ].join("\n"));
     process.env["NARAI_ENV"] = "";
@@ -285,7 +284,7 @@ describe("NARAI_ENV", () => {
       "connectors:",
       "  db: { skill: db-agent-connector, servers: { orders: { driver: sqlite, database: base.db } } }",
       "environments:",
-      "  prod: { connectors: { db: {} } }",
+      "  prod: { db: {} }",
       "",
     ].join("\n"));
     process.env["NARAI_ENV"] = "ghost";

--- a/tests/config/load.test.ts
+++ b/tests/config/load.test.ts
@@ -196,3 +196,99 @@ connectors:
     await expect(loadResolvedConfig({ cwd: tmpCwd })).rejects.toThrow(/env:NAME/);
   });
 });
+
+describe("NARAI_ENV", () => {
+  let tmp: string;
+  let origHome: string | undefined;
+  let origCwd: string;
+  let origNaraiEnv: string | undefined;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "narai-env-"));
+    origHome = process.env["HOME"];
+    origCwd = process.cwd();
+    origNaraiEnv = process.env["NARAI_ENV"];
+    const home = path.join(tmp, "home");
+    fs.mkdirSync(path.join(home, ".connectors"), { recursive: true });
+    process.env["HOME"] = home;
+    process.chdir(tmp);
+  });
+
+  afterEach(() => {
+    process.chdir(origCwd);
+    if (origHome === undefined) delete process.env["HOME"];
+    else process.env["HOME"] = origHome;
+    if (origNaraiEnv === undefined) delete process.env["NARAI_ENV"];
+    else process.env["NARAI_ENV"] = origNaraiEnv;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function writeUserConfig(body: string): void {
+    fs.writeFileSync(path.join(process.env["HOME"]!, ".connectors", "config.yaml"), body);
+  }
+
+  it("applies NARAI_ENV when opts.environment is not set", async () => {
+    writeUserConfig([
+      "connectors:",
+      "  db:",
+      "    skill: db-agent-connector",
+      "    servers:",
+      "      orders: { driver: sqlite, database: base.db }",
+      "environments:",
+      "  prod:",
+      "    connectors:",
+      "      db:",
+      "        servers:",
+      "          orders: { driver: sqlite, database: prod.db }",
+      "",
+    ].join("\n"));
+    process.env["NARAI_ENV"] = "prod";
+    const resolved = await loadResolvedConfig();
+    expect(resolved.environment).toBe("prod");
+    expect((resolved.connectors["db"]!.options["servers"] as Record<string, { database: string }>).orders.database).toBe("prod.db");
+  });
+
+  it("opts.environment wins over NARAI_ENV", async () => {
+    writeUserConfig([
+      "connectors:",
+      "  db:",
+      "    skill: db-agent-connector",
+      "    servers:",
+      "      orders: { driver: sqlite, database: base.db }",
+      "environments:",
+      "  prod: { connectors: { db: { servers: { orders: { driver: sqlite, database: prod.db } } } } }",
+      "  staging: { connectors: { db: { servers: { orders: { driver: sqlite, database: staging.db } } } } }",
+      "",
+    ].join("\n"));
+    process.env["NARAI_ENV"] = "prod";
+    const resolved = await loadResolvedConfig({ environment: "staging" });
+    expect(resolved.environment).toBe("staging");
+  });
+
+  it("treats NARAI_ENV='' (empty string) as unset", async () => {
+    writeUserConfig([
+      "connectors:",
+      "  db: { skill: db-agent-connector, servers: { orders: { driver: sqlite, database: base.db } } }",
+      "environments:",
+      "  default: prod",
+      "  prod: { connectors: { db: { servers: { orders: { driver: sqlite, database: prod.db } } } } }",
+      "",
+    ].join("\n"));
+    process.env["NARAI_ENV"] = "";
+    const resolved = await loadResolvedConfig();
+    // Falls back to environments.default, which is "prod"
+    expect(resolved.environment).toBe("prod");
+  });
+
+  it("errors when NARAI_ENV names an unknown environment", async () => {
+    writeUserConfig([
+      "connectors:",
+      "  db: { skill: db-agent-connector, servers: { orders: { driver: sqlite, database: base.db } } }",
+      "environments:",
+      "  prod: { connectors: { db: {} } }",
+      "",
+    ].join("\n"));
+    process.env["NARAI_ENV"] = "ghost";
+    await expect(loadResolvedConfig()).rejects.toThrow(/Environment 'ghost' not found/);
+  });
+});

--- a/tests/config/load.test.ts
+++ b/tests/config/load.test.ts
@@ -262,6 +262,7 @@ describe("NARAI_ENV", () => {
     process.env["NARAI_ENV"] = "prod";
     const resolved = await loadResolvedConfig({ environment: "staging" });
     expect(resolved.environment).toBe("staging");
+    expect((resolved.connectors["db"]!.options["servers"] as Record<string, { database: string }>).orders.database).toBe("staging.db");
   });
 
   it("treats NARAI_ENV='' (empty string) as unset", async () => {

--- a/tests/connectors/db/default_server.test.ts
+++ b/tests/connectors/db/default_server.test.ts
@@ -151,6 +151,46 @@ describe("default-server resolution", () => {
     expect(result["rows"]).toEqual([{ id: 1 }]);
   });
 
+  it("rejects non-string `server` at the dispatcher layer (defense for zod-bypass callers)", async () => {
+    const result = await dispatcherFetch("query", {
+      server: 123 as unknown as string,
+      sql: "SELECT 1",
+    });
+    expect(result["status"]).toBe("error");
+    expect(String(result["error_code"])).toBe("VALIDATION_ERROR");
+    expect(String(result["error"])).toMatch(/server.*non-empty string/i);
+  });
+
+  it("rejects empty-string `server` at the dispatcher layer", async () => {
+    const result = await dispatcherFetch("query", {
+      server: "",
+      sql: "SELECT 1",
+    });
+    expect(result["status"]).toBe("error");
+    expect(String(result["error_code"])).toBe("VALIDATION_ERROR");
+    expect(String(result["error"])).toMatch(/server.*non-empty string/i);
+  });
+
+  it("rejects non-string `env` at the dispatcher layer", async () => {
+    const result = await dispatcherFetch("query", {
+      env: 42 as unknown as string,
+      sql: "SELECT 1",
+    });
+    expect(result["status"]).toBe("error");
+    expect(String(result["error_code"])).toBe("VALIDATION_ERROR");
+    expect(String(result["error"])).toMatch(/env.*non-empty string/i);
+  });
+
+  it("rejects non-string `sqlite_path` at the dispatcher layer", async () => {
+    const result = await dispatcherFetch("query", {
+      sqlite_path: { foo: "bar" } as unknown as string,
+      sql: "SELECT 1",
+    });
+    expect(result["status"]).toBe("error");
+    expect(String(result["error_code"])).toBe("VALIDATION_ERROR");
+    expect(String(result["error"])).toMatch(/sqlite_path.*non-empty string/i);
+  });
+
   it("config-load: rejects `default:` pointing at unknown server (CONFIG_ERROR at first call)", async () => {
     writeConfig([
       "connectors:",

--- a/tests/connectors/db/default_server.test.ts
+++ b/tests/connectors/db/default_server.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import Database from "better-sqlite3";
 
 import { fetch as dispatcherFetch } from "../../../src/connectors/db/dispatcher.js";
 import { clearEnvironments } from "../../../src/connectors/db/lib/environments.js";
@@ -113,14 +114,29 @@ describe("default-server resolution", () => {
   });
 
   it("env overlay overrides `default:`", async () => {
+    // Use distinct sqlite files and seed a table only in billing.db so the
+    // query succeeds iff the env-overlay actually swapped the default from
+    // orders → billing. With both servers pointing at the same file, a
+    // silent overlay failure would still hit `orders` and pass.
+    const ordersPath = path.join(tmp, "orders.db");
+    const billingPath = path.join(tmp, "billing.db");
+    fs.writeFileSync(ordersPath, "");
+    fs.writeFileSync(billingPath, "");
+    const seed = new Database(billingPath);
+    seed.exec(
+      "CREATE TABLE billing_only (id INTEGER PRIMARY KEY); " +
+        "INSERT INTO billing_only VALUES (1);",
+    );
+    seed.close();
+
     writeConfig([
       "connectors:",
       "  db:",
       "    skill: db-agent-connector",
       "    default: orders",
       "    servers:",
-      `      orders:  { driver: sqlite, database: ${JSON.stringify(dbPath)} }`,
-      `      billing: { driver: sqlite, database: ${JSON.stringify(dbPath)} }`,
+      `      orders:  { driver: sqlite, database: ${JSON.stringify(ordersPath)} }`,
+      `      billing: { driver: sqlite, database: ${JSON.stringify(billingPath)} }`,
       "environments:",
       "  staging:",
       "    db:",
@@ -128,8 +144,11 @@ describe("default-server resolution", () => {
       "",
     ].join("\n"));
     process.env["NARAI_ENV"] = "staging";
-    const result = await dispatcherFetch("query", { sql: "SELECT 1" });
+    const result = await dispatcherFetch("query", {
+      sql: "SELECT id FROM billing_only LIMIT 10",
+    });
     expect(result["status"]).toBe("ok");
+    expect(result["rows"]).toEqual([{ id: 1 }]);
   });
 
   it("config-load: rejects `default:` pointing at unknown server (CONFIG_ERROR at first call)", async () => {

--- a/tests/connectors/db/default_server.test.ts
+++ b/tests/connectors/db/default_server.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Default-server resolution at dispatch time. Covers all four rules from
+ * the spec (sections 2.1–2.4) plus the env-overlay override case.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { fetch as dispatcherFetch } from "../../../src/connectors/db/dispatcher.js";
+import { clearEnvironments } from "../../../src/connectors/db/lib/environments.js";
+
+describe("default-server resolution", () => {
+  let tmp: string;
+  let origHome: string | undefined;
+  let origCwd: string;
+  let origNaraiEnv: string | undefined;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "db-default-server-"));
+    origHome = process.env["HOME"];
+    origCwd = process.cwd();
+    origNaraiEnv = process.env["NARAI_ENV"];
+    delete process.env["NARAI_CONFIG_BLOB"];
+    delete process.env["NARAI_ENV"];
+    const home = path.join(tmp, "home");
+    fs.mkdirSync(path.join(home, ".connectors"), { recursive: true });
+    process.env["HOME"] = home;
+    process.chdir(tmp);
+    dbPath = path.join(tmp, "test.db");
+    fs.writeFileSync(dbPath, ""); // sqlite happily opens an empty file
+    clearEnvironments();
+  });
+
+  afterEach(async () => {
+    const { shutdownAll } = await import("../../../src/connectors/db/lib/connection.js");
+    await shutdownAll();
+    process.chdir(origCwd);
+    if (origHome === undefined) delete process.env["HOME"];
+    else process.env["HOME"] = origHome;
+    delete process.env["NARAI_CONFIG_BLOB"];
+    if (origNaraiEnv === undefined) delete process.env["NARAI_ENV"];
+    else process.env["NARAI_ENV"] = origNaraiEnv;
+    clearEnvironments();
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function writeConfig(body: string): void {
+    fs.writeFileSync(
+      path.join(process.env["HOME"]!, ".connectors", "config.yaml"),
+      body,
+    );
+  }
+
+  it("rule 2: uses `default:` when caller omits `server`", async () => {
+    writeConfig([
+      "connectors:",
+      "  db:",
+      "    skill: db-agent-connector",
+      "    default: orders",
+      "    servers:",
+      `      orders: { driver: sqlite, database: ${JSON.stringify(dbPath)} }`,
+      `      billing: { driver: sqlite, database: ${JSON.stringify(dbPath)} }`,
+      "",
+    ].join("\n"));
+    const result = await dispatcherFetch("query", { sql: "SELECT 1 AS x" });
+    expect(result["status"]).toBe("ok");
+  });
+
+  it("rule 3: implicit single-server default when `servers:` has one entry", async () => {
+    writeConfig([
+      "connectors:",
+      "  db:",
+      "    skill: db-agent-connector",
+      "    servers:",
+      `      onlyone: { driver: sqlite, database: ${JSON.stringify(dbPath)} }`,
+      "",
+    ].join("\n"));
+    const result = await dispatcherFetch("query", { sql: "SELECT 1 AS x" });
+    expect(result["status"]).toBe("ok");
+  });
+
+  it("rule 4: errors when multiple servers, no default, and no `server` param", async () => {
+    writeConfig([
+      "connectors:",
+      "  db:",
+      "    skill: db-agent-connector",
+      "    servers:",
+      `      orders:  { driver: sqlite, database: ${JSON.stringify(dbPath)} }`,
+      `      billing: { driver: sqlite, database: ${JSON.stringify(dbPath)} }`,
+      "",
+    ].join("\n"));
+    const result = await dispatcherFetch("query", { sql: "SELECT 1" });
+    expect(result["status"]).toBe("error");
+    expect(String(result["error_code"])).toBe("VALIDATION_ERROR");
+    expect(String(result["error"])).toMatch(/server.*available.*orders.*billing/i);
+  });
+
+  it("rule 1: explicit `server` wins over `default:`", async () => {
+    writeConfig([
+      "connectors:",
+      "  db:",
+      "    skill: db-agent-connector",
+      "    default: orders",
+      "    servers:",
+      `      orders:  { driver: sqlite, database: ${JSON.stringify(dbPath)} }`,
+      `      billing: { driver: sqlite, database: ${JSON.stringify(dbPath)} }`,
+      "",
+    ].join("\n"));
+    const result = await dispatcherFetch("query", { server: "billing", sql: "SELECT 1" });
+    expect(result["status"]).toBe("ok");
+  });
+
+  it("env overlay overrides `default:`", async () => {
+    writeConfig([
+      "connectors:",
+      "  db:",
+      "    skill: db-agent-connector",
+      "    default: orders",
+      "    servers:",
+      `      orders:  { driver: sqlite, database: ${JSON.stringify(dbPath)} }`,
+      `      billing: { driver: sqlite, database: ${JSON.stringify(dbPath)} }`,
+      "environments:",
+      "  staging:",
+      "    db:",
+      "      default: billing",
+      "",
+    ].join("\n"));
+    process.env["NARAI_ENV"] = "staging";
+    const result = await dispatcherFetch("query", { sql: "SELECT 1" });
+    expect(result["status"]).toBe("ok");
+  });
+
+  it("config-load: rejects `default:` pointing at unknown server (CONFIG_ERROR at first call)", async () => {
+    writeConfig([
+      "connectors:",
+      "  db:",
+      "    skill: db-agent-connector",
+      "    default: ghost",
+      "    servers:",
+      `      orders: { driver: sqlite, database: ${JSON.stringify(dbPath)} }`,
+      "",
+    ].join("\n"));
+    const result = await dispatcherFetch("query", { server: "orders", sql: "SELECT 1" });
+    expect(result["status"]).toBe("error");
+    expect(String(result["error_code"])).toBe("CONFIG_ERROR");
+    expect(String(result["error"])).toMatch(/default.*'ghost'.*not found/i);
+  });
+});

--- a/tests/connectors/db/environments.test.ts
+++ b/tests/connectors/db/environments.test.ts
@@ -9,6 +9,12 @@ import {
   listEnvironments,
   registerEnvironment,
 } from "../../../src/connectors/db/lib/environments.js";
+import {
+  clearServers,
+  getServer,
+  listServers,
+  registerServer,
+} from "../../../src/connectors/db/lib/environments.js";
 
 describe("wiki_db.environments", () => {
   // pytest: autouse=True _clean_registry
@@ -141,5 +147,32 @@ describe("wiki_db.environments", () => {
     });
     const env = getEnvironment("dev");
     expect(env.grant_duration_hours).toBeUndefined();
+  });
+
+  describe("new canonical names (registerServer/getServer/...)", () => {
+    beforeEach(() => clearServers());
+    afterEach(() => clearServers());
+
+    it("registerServer/getServer round-trip", () => {
+      registerServer("dev", { host: "h", port: 1, database: "d" });
+      const s = getServer("dev");
+      expect(s.host).toBe("h");
+      expect(s.port).toBe(1);
+      expect(s.database).toBe("d");
+    });
+
+    it("clearServers also clears entries registered via registerEnvironment", () => {
+      registerEnvironment("dev", { host: "h" });
+      clearServers();
+      expect(listServers()).toEqual([]);
+      expect(listEnvironments()).toEqual([]);
+    });
+
+    it("listServers and listEnvironments return identical results (shared state)", () => {
+      registerServer("a", { host: "h" });
+      registerEnvironment("b", { host: "h" });
+      expect(listServers().sort()).toEqual(["a", "b"]);
+      expect(listEnvironments().sort()).toEqual(["a", "b"]);
+    });
   });
 });

--- a/tests/connectors/db/framework.test.ts
+++ b/tests/connectors/db/framework.test.ts
@@ -195,7 +195,7 @@ describe("server param (replaces env)", () => {
   // reach the dispatcher and fail with "params must include one of 'sqlite_path'
   // or 'env'". Task 5 will add normalization and re-enable these.
 
-  it.skip("accepts `server` in place of `env` for query", async () => {
+  it("accepts `server` in place of `env` for query", async () => {
     const dbPath = makeFixtureDb();
     const result = await connector.fetch("query", {
       sqlite_path: dbPath,
@@ -205,13 +205,13 @@ describe("server param (replaces env)", () => {
     expect(result.status).toBe("success");
   });
 
-  it.skip("accepts `server` for schema", async () => {
+  it("accepts `server` for schema", async () => {
     const dbPath = makeFixtureDb();
     const result = await connector.fetch("schema", { sqlite_path: dbPath, server: "dev" });
     expect(result.status).toBe("success");
   });
 
-  it.skip("rejects when both `server` and `env` are set with different values", async () => {
+  it("rejects when both `server` and `env` are set with different values", async () => {
     const dbPath = makeFixtureDb();
     const result = await connector.fetch("query", {
       sqlite_path: dbPath,

--- a/tests/connectors/db/framework.test.ts
+++ b/tests/connectors/db/framework.test.ts
@@ -189,32 +189,37 @@ describe("hardship logging integration", () => {
 });
 
 describe("server param (replaces env)", () => {
-  // Tests 1-3 are skipped pending Task 5 (dispatcher-level normalization of
-  // `server` → `env`). The zod schema now accepts `server`, but the dispatcher
-  // still only recognises `env`/`sqlite_path`, so calls with only `server` set
-  // reach the dispatcher and fail with "params must include one of 'sqlite_path'
-  // or 'env'". Task 5 will add normalization and re-enable these.
-
   it("accepts `server` in place of `env` for query", async () => {
-    const dbPath = makeFixtureDb();
-    const result = await connector.fetch("query", {
-      sqlite_path: dbPath,
-      server: "dev",
-      sql: "SELECT 1 AS x",
+    // Schema-level acceptance of `server`. Uses a mocked dispatch so no
+    // real server config is required.
+    const c = buildDbConnector({
+      dispatch: async () => ({
+        status: "ok" as const,
+        rows: [{ x: 1 }],
+        column_names: ["x"],
+        row_count: 1,
+      }),
     });
+    const result = await c.fetch("query", { server: "dev", sql: "SELECT 1 AS x" });
     expect(result.status).toBe("success");
   });
 
   it("accepts `server` for schema", async () => {
-    const dbPath = makeFixtureDb();
-    const result = await connector.fetch("schema", { sqlite_path: dbPath, server: "dev" });
+    const c = buildDbConnector({
+      dispatch: async () => ({
+        status: "ok" as const,
+        tables: [],
+        table_count: 0,
+      }),
+    });
+    const result = await c.fetch("schema", { server: "dev" });
     expect(result.status).toBe("success");
   });
 
   it("rejects when both `server` and `env` are set with different values", async () => {
-    const dbPath = makeFixtureDb();
+    // The real dispatcher's requireConnTarget catches the conflict BEFORE
+    // any config lookup, so this test needs no real server config.
     const result = await connector.fetch("query", {
-      sqlite_path: dbPath,
       server: "dev",
       env: "prod",
       sql: "SELECT 1",

--- a/tests/connectors/db/framework.test.ts
+++ b/tests/connectors/db/framework.test.ts
@@ -188,6 +188,57 @@ describe("hardship logging integration", () => {
   });
 });
 
+describe("server param (replaces env)", () => {
+  // Tests 1-3 are skipped pending Task 5 (dispatcher-level normalization of
+  // `server` → `env`). The zod schema now accepts `server`, but the dispatcher
+  // still only recognises `env`/`sqlite_path`, so calls with only `server` set
+  // reach the dispatcher and fail with "params must include one of 'sqlite_path'
+  // or 'env'". Task 5 will add normalization and re-enable these.
+
+  it.skip("accepts `server` in place of `env` for query", async () => {
+    const dbPath = makeFixtureDb();
+    const result = await connector.fetch("query", {
+      sqlite_path: dbPath,
+      server: "dev",
+      sql: "SELECT 1 AS x",
+    });
+    expect(result.status).toBe("success");
+  });
+
+  it.skip("accepts `server` for schema", async () => {
+    const dbPath = makeFixtureDb();
+    const result = await connector.fetch("schema", { sqlite_path: dbPath, server: "dev" });
+    expect(result.status).toBe("success");
+  });
+
+  it.skip("rejects when both `server` and `env` are set with different values", async () => {
+    const dbPath = makeFixtureDb();
+    const result = await connector.fetch("query", {
+      sqlite_path: dbPath,
+      server: "dev",
+      env: "prod",
+      sql: "SELECT 1",
+    });
+    expect(result.status).toBe("error");
+    expect(String((result as Record<string, unknown>)["error_code"])).toBe("VALIDATION_ERROR");
+  });
+
+  it("treats `env` as an alias when only `env` is set", async () => {
+    // Confirms the schema still accepts `env` (backward compat).
+    // Uses a mocked dispatch so no real server config is required.
+    const c = buildDbConnector({
+      dispatch: async () => ({
+        status: "ok" as const,
+        rows: [{ x: 1 }],
+        column_names: ["x"],
+        row_count: 1,
+      }),
+    });
+    const result = await c.fetch("query", { env: "dev", sql: "SELECT 1 AS x" });
+    expect(result.status).toBe("success");
+  });
+});
+
 describe("--curate flag", () => {
   it("prints a JSON snapshot and exits 0", async () => {
     const writes: string[] = [];

--- a/tests/connectors/db/framework.test.ts
+++ b/tests/connectors/db/framework.test.ts
@@ -228,6 +228,44 @@ describe("server param (replaces env)", () => {
     expect(String((result as Record<string, unknown>)["error_code"])).toBe("VALIDATION_ERROR");
   });
 
+  it("normalizes `env` alias before mutual-exclusion check (proves env→server runs)", async () => {
+    // If `env` is correctly normalized to `server`, this hits the
+    // mutual-exclusion guard against `sqlite_path`. If normalization
+    // didn't run, it would fail with a different error (or, worse,
+    // silently succeed). Routing through the real dispatcher — no mock.
+    const result = await connector.fetch("query", {
+      sqlite_path: "/tmp/whatever.db",
+      env: "dev",
+      sql: "SELECT 1",
+    });
+    expect(result.status).toBe("error");
+    const r = result as Record<string, unknown>;
+    expect(String(r["error_code"])).toBe("VALIDATION_ERROR");
+    expect(String(r["message"])).toMatch(/mutually exclusive/i);
+  });
+
+  it("warns but does not error when `server` and `env` are set to the same value", async () => {
+    // Same value is still a deprecated usage of `env` — warn but accept.
+    const writes: string[] = [];
+    const origWrite = process.stderr.write;
+    process.stderr.write = ((s: string | Uint8Array): boolean => {
+      writes.push(typeof s === "string" ? s : s.toString());
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      await connector.fetch("query", {
+        server: "dev",
+        env: "dev",
+        sql: "SELECT 1",
+      });
+      // Don't assert on result here — there's no plugin config, so it will
+      // be a CONFIG_ERROR. The point is the deprecation warning fired.
+    } finally {
+      process.stderr.write = origWrite;
+    }
+    expect(writes.some((s) => s.includes("env` is deprecated"))).toBe(true);
+  });
+
   it("treats `env` as an alias when only `env` is set", async () => {
     // Confirms the schema still accepts `env` (backward compat).
     // Uses a mocked dispatch so no real server config is required.

--- a/tests/connectors/db/framework.test.ts
+++ b/tests/connectors/db/framework.test.ts
@@ -217,7 +217,7 @@ describe("server param (replaces env)", () => {
   });
 
   it("rejects when both `server` and `env` are set with different values", async () => {
-    // The real dispatcher's requireConnTarget catches the conflict BEFORE
+    // The real dispatcher's extractConnTarget catches the conflict BEFORE
     // any config lookup, so this test needs no real server config.
     const result = await connector.fetch("query", {
       server: "dev",

--- a/tests/connectors/db/framework.test.ts
+++ b/tests/connectors/db/framework.test.ts
@@ -280,6 +280,38 @@ describe("server param (replaces env)", () => {
     const result = await c.fetch("query", { env: "dev", sql: "SELECT 1 AS x" });
     expect(result.status).toBe("success");
   });
+
+  it("rejects empty-string `server` as VALIDATION_ERROR", async () => {
+    // Empty string is NOT the same as omitted — never let an explicit ""
+    // silently fall back to the default-server resolution.
+    const result = await connector.fetch("query", {
+      server: "",
+      sql: "SELECT 1",
+    });
+    expect(result.status).toBe("error");
+    expect(String((result as Record<string, unknown>)["error_code"])).toBe("VALIDATION_ERROR");
+    expect(String((result as Record<string, unknown>)["message"])).toMatch(/server.*non-empty/i);
+  });
+
+  it("rejects empty-string `env` as VALIDATION_ERROR", async () => {
+    const result = await connector.fetch("query", {
+      env: "",
+      sql: "SELECT 1",
+    });
+    expect(result.status).toBe("error");
+    expect(String((result as Record<string, unknown>)["error_code"])).toBe("VALIDATION_ERROR");
+    expect(String((result as Record<string, unknown>)["message"])).toMatch(/env.*non-empty/i);
+  });
+
+  it("rejects empty-string `sqlite_path` as VALIDATION_ERROR", async () => {
+    const result = await connector.fetch("query", {
+      sqlite_path: "",
+      sql: "SELECT 1",
+    });
+    expect(result.status).toBe("error");
+    expect(String((result as Record<string, unknown>)["error_code"])).toBe("VALIDATION_ERROR");
+    expect(String((result as Record<string, unknown>)["message"])).toMatch(/sqlite_path.*non-empty/i);
+  });
 });
 
 describe("--curate flag", () => {

--- a/tests/connectors/db/plugin_config.test.ts
+++ b/tests/connectors/db/plugin_config.test.ts
@@ -213,6 +213,46 @@ describe("validatePluginConfig", () => {
     });
     expect(cfg.audit).toEqual({ enabled: true, path: "/tmp/a.jsonl" });
   });
+
+  it("accepts an optional `default` pointing at a known server", () => {
+    const cfg = validatePluginConfig({
+      policy: {},
+      servers: {
+        orders: { driver: "sqlite", database: ":memory:" },
+        billing: { driver: "sqlite", database: ":memory:" },
+      },
+      default: "orders",
+    });
+    expect(cfg.default).toBe("orders");
+  });
+
+  it("config without `default` parses fine (field optional)", () => {
+    const cfg = validatePluginConfig({
+      policy: {},
+      servers: { orders: { driver: "sqlite", database: ":memory:" } },
+    });
+    expect(cfg.default).toBeUndefined();
+  });
+
+  it("rejects `default` pointing at an unknown server", () => {
+    expect(() =>
+      validatePluginConfig({
+        policy: {},
+        servers: { orders: { driver: "sqlite", database: ":memory:" } },
+        default: "ghost",
+      }),
+    ).toThrow(/default.*'ghost'.*not found.*orders/i);
+  });
+
+  it("rejects non-string `default`", () => {
+    expect(() =>
+      validatePluginConfig({
+        policy: {},
+        servers: { orders: { driver: "sqlite", database: ":memory:" } },
+        default: 42,
+      }),
+    ).toThrow(/default.*string/i);
+  });
 });
 
 describe("pluginConfigFromSlice — V2.0 connector-config integration", () => {
@@ -260,6 +300,31 @@ describe("pluginConfigFromSlice — V2.0 connector-config integration", () => {
       },
     });
     expect(cfg.audit).toEqual({ enabled: true, path: "/tmp/audit.jsonl" });
+  });
+});
+
+describe("pluginConfigFromSlice — default field", () => {
+  it("threads `default` from slice.options", () => {
+    const cfg = pluginConfigFromSlice({
+      policy: {},
+      options: {
+        servers: { orders: { driver: "sqlite", database: ":memory:" } },
+        default: "orders",
+      },
+    });
+    expect(cfg.default).toBe("orders");
+  });
+
+  it("rejects slice `default` that doesn't match a server", () => {
+    expect(() =>
+      pluginConfigFromSlice({
+        policy: {},
+        options: {
+          servers: { orders: { driver: "sqlite", database: ":memory:" } },
+          default: "ghost",
+        },
+      }),
+    ).toThrow(/default.*'ghost'.*not found/i);
   });
 });
 


### PR DESCRIPTION
## Summary

Lets one app target multiple databases within a single environment with an unambiguous per-call API, an optional default-server pointer, and runtime env selection via `NARAI_ENV` — without breaking existing callers.

Three layered changes:

- **NARAI_ENV** (`src/config/load.ts`) — `loadResolvedConfig` reads `NARAI_ENV` as a process-level env selector. Precedence: `opts.environment` (explicit, e.g. from the hub) > `NARAI_ENV` > `environments.default` in YAML. Affects every connector for free since the env overlay already applies to all slices.
- **`server` per-call param** (`src/connectors/db/{connector,dispatcher}.ts`) — DB connector accepts `server: "..."` as the canonical name for a configured DB. The old `env: "..."` keeps working as a deprecated alias and emits a one-line stderr warning. `sqlite_path` and `server` are strictly mutually exclusive.
- **`default:` server pointer** (`src/connectors/db/lib/plugin_config.ts` + dispatcher) — `connectors.db.default: "<alias>"` names the server used when callers omit `server`. If `servers:` has exactly one entry, that's the implicit default. With multiple entries and no `default:`, an explicit `server` is required (VALIDATION_ERROR lists the available names). Env overlay can override `default:` (e.g. `environments.staging.db.default: billing`).

Spec was approved before implementation; design lives at `docs/superpowers/specs/2026-05-21-db-multi-database-per-env-design.md` (not committed; preserved locally).

## Test Plan

- [x] `npm test` — 2372 passed, 26 skipped (live-driver tests), 0 failed
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] End-to-end smoke: `{default: primary, servers: {primary, secondary}}` + `connector.fetch("query", {sql: "SELECT x FROM t"})` (no `server` param) → resolved to `primary` via default and returned the seeded row
- [ ] Reviewer: skim the new `tests/connectors/db/default_server.test.ts` — 6 cases cover all 4 resolution rules plus env-overlay override and unknown-`default` config error
- [ ] Reviewer: verify the deprecation warning shows up once when callers pass `env: "..."` (check stderr from a smoke call)

## Notes

- **No env-var-based env selection on the per-`fetch` call.** Standalone callers needing runtime env switching use `loadResolvedConfig({environment})` directly. Considered exposing a per-call `environment` option but it re-introduced the naming overload with `server`.
- **`registerEnvironment`/`getEnvironment`/`clearEnvironments`/`listEnvironments` are kept as deprecated aliases** of the new `registerServer`/`getServer`/`clearServers`/`listServers` (public via `src/connectors/db/index.ts`). Removal scheduled for the next major.
- **Heads-up on dev workflow:** the dispatcher imports `loadResolvedConfig` from `narai-primitives/config`, which resolves to `dist/`. A stale build can mask env-overlay behavior. Worth considering a pre-test `npm run build` step in CI — flagged during implementation when an env-overlay test silently passed against stale dist.