### PR TITLE
⚡ Bolt: parallelize dynamodb schema extraction

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,7 @@
 ## 2026-05-23 - SQL Server Schema Batch Optimization
 **Learning:** When querying INFORMATION_SCHEMA.COLUMNS, chunking IN (@table...) parameters to respect SQL Server's 2100 limit is unnecessary and inefficient. It's better to avoid passing the list of tables entirely by doing a JOIN with INFORMATION_SCHEMA.TABLES and applying the same filter directly.
 **Action:** Remove the chunking loop and use a JOIN to extract metadata for all relevant tables in a single DB query, simplifying logic and reducing compilation and network overhead.
+
+## 2026-05-24 - DynamoDB Schema Extraction Parallelization
+**Learning:** For DynamoDB schema extraction, describing tables sequentially using a simple `for` loop causes N network round-trips (`N * rtt`), creating a significant performance bottleneck.
+**Action:** Use chunked concurrent requests (e.g., `Promise.all` with a concurrency limit of 10) to parallelize the `DescribeTableCommand` calls, drastically reducing total latency while avoiding AWS API throttling limits.

--- a/src/connectors/db/lib/drivers/dynamodb.ts
+++ b/src/connectors/db/lib/drivers/dynamodb.ts
@@ -432,45 +432,60 @@ export class DynamoDriver extends DatabaseDriver {
             )
           : null;
 
+      const validNames = names.filter((name) => filterRe === null || filterRe.test(name));
       const out: Table[] = [];
-      for (const name of names) {
-        if (filterRe !== null && !filterRe.test(name)) continue;
-        const desc = (await client.send(
-          new module.DescribeTableCommand({ TableName: name }),
-        )) as DescribeTableOutput;
-        const table = desc.Table;
-        if (table === undefined) continue;
 
-        const attrTypes = new Map<string, string>();
-        for (const a of table.AttributeDefinitions ?? []) {
-          attrTypes.set(a.AttributeName, _awsAttrType(a.AttributeType));
-        }
-        const keys = new Set(
-          (table.KeySchema ?? []).map((k) => k.AttributeName),
+      // ⚡ Bolt Optimization: Use chunked concurrent requests (Promise.all)
+      // instead of sequential iteration to parallelize AWS network calls.
+      // A concurrency limit of 10 speeds up schema extraction significantly
+      // while avoiding AWS API throttling exceptions (ProvisionedThroughputExceeded).
+      const CONCURRENCY = 10;
+      for (let i = 0; i < validNames.length; i += CONCURRENCY) {
+        const chunk = validNames.slice(i, i + CONCURRENCY);
+        const results = await Promise.all(
+          chunk.map(async (name) => {
+            const desc = (await client.send(
+              new module.DescribeTableCommand({ TableName: name }),
+            )) as DescribeTableOutput;
+            const table = desc.Table;
+            if (table === undefined) return null;
+
+            const attrTypes = new Map<string, string>();
+            for (const a of table.AttributeDefinitions ?? []) {
+              attrTypes.set(a.AttributeName, _awsAttrType(a.AttributeType));
+            }
+            const keys = new Set(
+              (table.KeySchema ?? []).map((k) => k.AttributeName),
+            );
+            const columns: Column[] = (table.KeySchema ?? []).map(
+              (k) =>
+                new Column({
+                  name: k.AttributeName,
+                  data_type: attrTypes.get(k.AttributeName) ?? "unknown",
+                  nullable: false,
+                  is_primary_key: true,
+                  default: null,
+                }),
+            );
+            for (const [attrName, attrType] of attrTypes) {
+              if (keys.has(attrName)) continue;
+              columns.push(
+                new Column({
+                  name: attrName,
+                  data_type: attrType,
+                  nullable: true,
+                  is_primary_key: false,
+                  default: null,
+                }),
+              );
+            }
+            return new Table({ name, schema: schemaName, columns });
+          })
         );
-        const columns: Column[] = (table.KeySchema ?? []).map(
-          (k) =>
-            new Column({
-              name: k.AttributeName,
-              data_type: attrTypes.get(k.AttributeName) ?? "unknown",
-              nullable: false,
-              is_primary_key: true,
-              default: null,
-            }),
-        );
-        for (const [attrName, attrType] of attrTypes) {
-          if (keys.has(attrName)) continue;
-          columns.push(
-            new Column({
-              name: attrName,
-              data_type: attrType,
-              nullable: true,
-              is_primary_key: false,
-              default: null,
-            }),
-          );
+
+        for (const t of results) {
+          if (t !== null) out.push(t);
         }
-        out.push(new Table({ name, schema: schemaName, columns }));
       }
       return out;
     } catch {


### PR DESCRIPTION
💡 **What**: Replaces the sequential `for` loop in `dynamodb.ts` `getSchemaAsync` with a chunked `Promise.all` approach to parallelize `DescribeTableCommand` AWS network calls.
🎯 **Why**: In databases with multiple tables, sequentially waiting for AWS `DescribeTable` network round-trips creates an N+1 query performance bottleneck.
📊 **Impact**: Reduces total network latency for schema extraction from `N * rtt` to roughly `ceil(N/10) * rtt`, making it up to 10x faster while safely avoiding AWS API throttling limits.
🔬 **Measurement**: Can be verified by running the `tests/connectors/db/drivers/test_dynamodb.test.ts` or by extracting schema against an AWS DynamoDB instance with many tables and measuring wall clock time.

---
*PR created automatically by Jules for task [564305719964991795](https://jules.google.com/task/564305719964991795) started by @rfv-code*