### PR TITLE
⚡ Bolt: Optimize DynamoDB schema extraction

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2026-05-23 - SQL Server Schema Batch Optimization
 **Learning:** When querying INFORMATION_SCHEMA.COLUMNS, chunking IN (@table...) parameters to respect SQL Server's 2100 limit is unnecessary and inefficient. It's better to avoid passing the list of tables entirely by doing a JOIN with INFORMATION_SCHEMA.TABLES and applying the same filter directly.
 **Action:** Remove the chunking loop and use a JOIN to extract metadata for all relevant tables in a single DB query, simplifying logic and reducing compilation and network overhead.
+## 2026-05-28 - DynamoDB Schema Extraction Chunking
+**Learning:** For DynamoDB schema extraction, describing tables sequentially using an `await` inside a loop leads to a slow N+1 problem on the network.
+**Action:** Use chunked concurrent requests (e.g. `Promise.all` over small batches) to parallelize the network requests while respecting AWS rate limits (ThrottlingException).

--- a/src/connectors/db/lib/drivers/dynamodb.ts
+++ b/src/connectors/db/lib/drivers/dynamodb.ts
@@ -59,32 +59,59 @@ export class DynamoEnvelopeParseError extends Error {
  */
 const _DYNAMO_READ_OPS: ReadonlySet<string> = new Set([
   // envelope form
-  "get", "query", "scan", "sample", "batchGet",
+  "get",
+  "query",
+  "scan",
+  "sample",
+  "batchGet",
   // AWS SDK command form
-  "GetItem", "GetItemCommand", "Query", "QueryCommand",
-  "Scan", "ScanCommand", "BatchGetItem", "BatchGetItemCommand",
+  "GetItem",
+  "GetItemCommand",
+  "Query",
+  "QueryCommand",
+  "Scan",
+  "ScanCommand",
+  "BatchGetItem",
+  "BatchGetItemCommand",
   // describe / list — admin reads
-  "ListTables", "ListTablesCommand", "DescribeTable", "DescribeTableCommand",
+  "ListTables",
+  "ListTablesCommand",
+  "DescribeTable",
+  "DescribeTableCommand",
 ]);
 const _DYNAMO_WRITE_OPS: ReadonlySet<string> = new Set([
   // envelope form
-  "put", "update", "batchWrite", "transactWrite",
+  "put",
+  "update",
+  "batchWrite",
+  "transactWrite",
   // AWS SDK command form
-  "PutItem", "PutItemCommand", "UpdateItem", "UpdateItemCommand",
-  "BatchWriteItem", "BatchWriteItemCommand",
-  "TransactWriteItems", "TransactWriteItemsCommand",
+  "PutItem",
+  "PutItemCommand",
+  "UpdateItem",
+  "UpdateItemCommand",
+  "BatchWriteItem",
+  "BatchWriteItemCommand",
+  "TransactWriteItems",
+  "TransactWriteItemsCommand",
 ]);
 const _DYNAMO_DELETE_OPS: ReadonlySet<string> = new Set([
   // envelope form
   "delete",
   // AWS SDK command form
-  "DeleteItem", "DeleteItemCommand",
+  "DeleteItem",
+  "DeleteItemCommand",
 ]);
 const _DYNAMO_ADMIN_OPS: ReadonlySet<string> = new Set([
-  "createTable", "deleteTable", "updateTable",
-  "CreateTable", "CreateTableCommand",
-  "DeleteTable", "DeleteTableCommand",
-  "UpdateTable", "UpdateTableCommand",
+  "createTable",
+  "deleteTable",
+  "updateTable",
+  "CreateTable",
+  "CreateTableCommand",
+  "DeleteTable",
+  "DeleteTableCommand",
+  "UpdateTable",
+  "UpdateTableCommand",
 ]);
 
 // ---------------------------------------------------------------------------
@@ -134,7 +161,10 @@ interface DynamoCommandCtor<I, O> {
 }
 interface DynamoModule {
   DynamoDBClient: new (config: Record<string, unknown>) => DynamoClient;
-  ListTablesCommand: DynamoCommandCtor<Record<string, unknown>, ListTablesOutput>;
+  ListTablesCommand: DynamoCommandCtor<
+    Record<string, unknown>,
+    ListTablesOutput
+  >;
   DescribeTableCommand: DynamoCommandCtor<
     { TableName: string },
     DescribeTableOutput
@@ -267,7 +297,9 @@ export class DynamoDriver extends DatabaseDriver {
     maxRows: number = 1000,
     _timeoutMs: number = 30_000,
   ): Promise<ExecuteReadResult> {
-    const handle = (await (conn as Promise<DynamoHandle> | DynamoHandle)) as DynamoHandle;
+    const handle = (await (conn as
+      | Promise<DynamoHandle>
+      | DynamoHandle)) as DynamoHandle;
     const start = performance.now();
     try {
       const env = _parseEnvelope(query);
@@ -275,8 +307,7 @@ export class DynamoDriver extends DatabaseDriver {
         return {
           status: "error",
           error_code: "SQL_ERROR",
-          error:
-            "DynamoDriver: query must be a JSON envelope {table, op, ...}",
+          error: "DynamoDriver: query must be a JSON envelope {table, op, ...}",
           execution_time_ms: roundTo2(performance.now() - start),
         };
       }
@@ -345,9 +376,11 @@ export class DynamoDriver extends DatabaseDriver {
       if (env.filter !== undefined) {
         input["FilterExpression"] = env.filter.FilterExpression;
         if (env.filter.ExpressionAttributeValues)
-          input["ExpressionAttributeValues"] = env.filter.ExpressionAttributeValues;
+          input["ExpressionAttributeValues"] =
+            env.filter.ExpressionAttributeValues;
         if (env.filter.ExpressionAttributeNames)
-          input["ExpressionAttributeNames"] = env.filter.ExpressionAttributeNames;
+          input["ExpressionAttributeNames"] =
+            env.filter.ExpressionAttributeNames;
       }
       if (env.op === "query") {
         if (env.keyCondition === undefined) {
@@ -358,12 +391,14 @@ export class DynamoDriver extends DatabaseDriver {
             execution_time_ms: roundTo2(performance.now() - start),
           };
         }
-        input["KeyConditionExpression"] = env.keyCondition.KeyConditionExpression;
+        input["KeyConditionExpression"] =
+          env.keyCondition.KeyConditionExpression;
         const prevVals =
           (input["ExpressionAttributeValues"] as DynamoItem | undefined) ?? {};
         const prevNames =
-          (input["ExpressionAttributeNames"] as Record<string, string> | undefined) ??
-          {};
+          (input["ExpressionAttributeNames"] as
+            | Record<string, string>
+            | undefined) ?? {};
         if (env.keyCondition.ExpressionAttributeValues)
           input["ExpressionAttributeValues"] = {
             ...prevVals,
@@ -415,7 +450,9 @@ export class DynamoDriver extends DatabaseDriver {
     schemaName: string = "",
     tableFilter: string | null = null,
   ): Promise<Table[]> {
-    const handle = (await (conn as Promise<DynamoHandle> | DynamoHandle)) as DynamoHandle;
+    const handle = (await (conn as
+      | Promise<DynamoHandle>
+      | DynamoHandle)) as DynamoHandle;
     const { client, module } = handle;
     try {
       const listed = (await client.send(
@@ -427,51 +464,72 @@ export class DynamoDriver extends DatabaseDriver {
         tableFilter !== null && tableFilter !== undefined
           ? new RegExp(
               "^" +
-                tableFilter.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/%/g, ".*") +
+                tableFilter
+                  .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+                  .replace(/%/g, ".*") +
                 "$",
             )
           : null;
 
-      const out: Table[] = [];
-      for (const name of names) {
-        if (filterRe !== null && !filterRe.test(name)) continue;
-        const desc = (await client.send(
-          new module.DescribeTableCommand({ TableName: name }),
-        )) as DescribeTableOutput;
-        const table = desc.Table;
-        if (table === undefined) continue;
+      const filteredNames =
+        filterRe !== null ? names.filter((n) => filterRe.test(n)) : names;
 
-        const attrTypes = new Map<string, string>();
-        for (const a of table.AttributeDefinitions ?? []) {
-          attrTypes.set(a.AttributeName, _awsAttrType(a.AttributeType));
-        }
-        const keys = new Set(
-          (table.KeySchema ?? []).map((k) => k.AttributeName),
+      const out: Table[] = [];
+
+      // ⚡ Bolt Optimization: Chunked concurrent requests
+      // Describing tables sequentially creates an N+1 network bottleneck.
+      // Using Promise.all with a small chunk size (e.g., 5) parallelizes
+      // the network calls while avoiding AWS API ThrottlingExceptions.
+      const CHUNK_SIZE = 5;
+      for (let i = 0; i < filteredNames.length; i += CHUNK_SIZE) {
+        const chunk = filteredNames.slice(i, i + CHUNK_SIZE);
+        const descriptions = await Promise.all(
+          chunk.map((name) =>
+            client.send(new module.DescribeTableCommand({ TableName: name })),
+          ),
         );
-        const columns: Column[] = (table.KeySchema ?? []).map(
-          (k) =>
-            new Column({
-              name: k.AttributeName,
-              data_type: attrTypes.get(k.AttributeName) ?? "unknown",
-              nullable: false,
-              is_primary_key: true,
-              default: null,
-            }),
-        );
-        for (const [attrName, attrType] of attrTypes) {
-          if (keys.has(attrName)) continue;
-          columns.push(
-            new Column({
-              name: attrName,
-              data_type: attrType,
-              nullable: true,
-              is_primary_key: false,
-              default: null,
-            }),
+
+        for (let j = 0; j < descriptions.length; j++) {
+          const desc = descriptions[j] as DescribeTableOutput;
+          const name = chunk[j];
+          const table = desc.Table;
+          if (table === undefined) continue;
+
+          const attrTypes = new Map<string, string>();
+          for (const a of table.AttributeDefinitions ?? []) {
+            attrTypes.set(a.AttributeName, _awsAttrType(a.AttributeType));
+          }
+          const keys = new Set(
+            (table.KeySchema ?? []).map((k) => k.AttributeName),
+          );
+          const columns: Column[] = (table.KeySchema ?? []).map(
+            (k) =>
+              new Column({
+                name: k.AttributeName,
+                data_type: attrTypes.get(k.AttributeName) ?? "unknown",
+                nullable: false,
+                is_primary_key: true,
+                default: null,
+              }),
+          );
+          for (const [attrName, attrType] of attrTypes) {
+            if (keys.has(attrName)) continue;
+            columns.push(
+              new Column({
+                name: attrName,
+                data_type: attrType,
+                nullable: true,
+                is_primary_key: false,
+                default: null,
+              }),
+            );
+          }
+          out.push(
+            new Table({ name: name as string, schema: schemaName, columns }),
           );
         }
-        out.push(new Table({ name, schema: schemaName, columns }));
       }
+
       return out;
     } catch {
       return [];
@@ -493,8 +551,12 @@ export class DynamoDriver extends DatabaseDriver {
   /** Per-driver health check via `ListTablesCommand` with Limit=1. */
   async healthCheck(conn: unknown): Promise<boolean> {
     try {
-      const handle = (await (conn as Promise<DynamoHandle> | DynamoHandle)) as DynamoHandle;
-      await handle.client.send(new handle.module.ListTablesCommand({ Limit: 1 }));
+      const handle = (await (conn as
+        | Promise<DynamoHandle>
+        | DynamoHandle)) as DynamoHandle;
+      await handle.client.send(
+        new handle.module.ListTablesCommand({ Limit: 1 }),
+      );
       return true;
     } catch {
       return false;
@@ -526,9 +588,7 @@ export class DynamoDriver extends DatabaseDriver {
         // distinct error so callers don't see the unhelpful default-deny
         // "ADMIN statements are never allowed" path.
         const msg = e instanceof Error ? e.message : String(e);
-        throw new DynamoEnvelopeParseError(
-          `Malformed envelope JSON: ${msg}`,
-        );
+        throw new DynamoEnvelopeParseError(`Malformed envelope JSON: ${msg}`);
       }
     }
 


### PR DESCRIPTION
💡 **What:** Replaced the sequential `for` loop over `DescribeTableCommand` with chunked concurrent requests using `Promise.all` with a chunk size of 5.
🎯 **Why:** Describing tables one-by-one in a loop created an N+1 network bottleneck, slowing down schema extraction unnecessarily for AWS DynamoDB instances with multiple tables.
📊 **Impact:** Significantly reduces the time required to extract table schemas for DynamoDB while ensuring we don't hit AWS rate limit (`ThrottlingException`) by keeping chunks small.
🔬 **Measurement:** Extracting schemas on DynamoDB instances with multiple tables will complete much faster, especially over higher-latency network links. Verified by running the test suite (`npm run test`) and `npm run typecheck`.

---
*PR created automatically by Jules for task [8950337815483465795](https://jules.google.com/task/8950337815483465795) started by @rfv-code*