### PR TITLE
⚡ Bolt: Optimize DynamoDB schema extraction with chunked concurrency

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2026-05-23 - SQL Server Schema Batch Optimization
 **Learning:** When querying INFORMATION_SCHEMA.COLUMNS, chunking IN (@table...) parameters to respect SQL Server's 2100 limit is unnecessary and inefficient. It's better to avoid passing the list of tables entirely by doing a JOIN with INFORMATION_SCHEMA.TABLES and applying the same filter directly.
 **Action:** Remove the chunking loop and use a JOIN to extract metadata for all relevant tables in a single DB query, simplifying logic and reducing compilation and network overhead.
+## 2024-05-30 - DynamoDB Schema Extraction Concurrency
+**Learning:** For DynamoDB schema extraction, looping over tables sequentially and awaiting `DescribeTableCommand` causes an N+1 problem that blocks on network latency for each table.
+**Action:** Optimize schema extraction in `dynamodb.ts` by fetching table definitions concurrently using `Promise.all` with a chunked concurrency limit (e.g., 10) to parallelize network calls while avoiding AWS API throttling.

--- a/src/connectors/db/lib/drivers/dynamodb.ts
+++ b/src/connectors/db/lib/drivers/dynamodb.ts
@@ -59,32 +59,59 @@ export class DynamoEnvelopeParseError extends Error {
  */
 const _DYNAMO_READ_OPS: ReadonlySet<string> = new Set([
   // envelope form
-  "get", "query", "scan", "sample", "batchGet",
+  "get",
+  "query",
+  "scan",
+  "sample",
+  "batchGet",
   // AWS SDK command form
-  "GetItem", "GetItemCommand", "Query", "QueryCommand",
-  "Scan", "ScanCommand", "BatchGetItem", "BatchGetItemCommand",
+  "GetItem",
+  "GetItemCommand",
+  "Query",
+  "QueryCommand",
+  "Scan",
+  "ScanCommand",
+  "BatchGetItem",
+  "BatchGetItemCommand",
   // describe / list — admin reads
-  "ListTables", "ListTablesCommand", "DescribeTable", "DescribeTableCommand",
+  "ListTables",
+  "ListTablesCommand",
+  "DescribeTable",
+  "DescribeTableCommand",
 ]);
 const _DYNAMO_WRITE_OPS: ReadonlySet<string> = new Set([
   // envelope form
-  "put", "update", "batchWrite", "transactWrite",
+  "put",
+  "update",
+  "batchWrite",
+  "transactWrite",
   // AWS SDK command form
-  "PutItem", "PutItemCommand", "UpdateItem", "UpdateItemCommand",
-  "BatchWriteItem", "BatchWriteItemCommand",
-  "TransactWriteItems", "TransactWriteItemsCommand",
+  "PutItem",
+  "PutItemCommand",
+  "UpdateItem",
+  "UpdateItemCommand",
+  "BatchWriteItem",
+  "BatchWriteItemCommand",
+  "TransactWriteItems",
+  "TransactWriteItemsCommand",
 ]);
 const _DYNAMO_DELETE_OPS: ReadonlySet<string> = new Set([
   // envelope form
   "delete",
   // AWS SDK command form
-  "DeleteItem", "DeleteItemCommand",
+  "DeleteItem",
+  "DeleteItemCommand",
 ]);
 const _DYNAMO_ADMIN_OPS: ReadonlySet<string> = new Set([
-  "createTable", "deleteTable", "updateTable",
-  "CreateTable", "CreateTableCommand",
-  "DeleteTable", "DeleteTableCommand",
-  "UpdateTable", "UpdateTableCommand",
+  "createTable",
+  "deleteTable",
+  "updateTable",
+  "CreateTable",
+  "CreateTableCommand",
+  "DeleteTable",
+  "DeleteTableCommand",
+  "UpdateTable",
+  "UpdateTableCommand",
 ]);
 
 // ---------------------------------------------------------------------------
@@ -134,7 +161,10 @@ interface DynamoCommandCtor<I, O> {
 }
 interface DynamoModule {
   DynamoDBClient: new (config: Record<string, unknown>) => DynamoClient;
-  ListTablesCommand: DynamoCommandCtor<Record<string, unknown>, ListTablesOutput>;
+  ListTablesCommand: DynamoCommandCtor<
+    Record<string, unknown>,
+    ListTablesOutput
+  >;
   DescribeTableCommand: DynamoCommandCtor<
     { TableName: string },
     DescribeTableOutput
@@ -267,7 +297,9 @@ export class DynamoDriver extends DatabaseDriver {
     maxRows: number = 1000,
     _timeoutMs: number = 30_000,
   ): Promise<ExecuteReadResult> {
-    const handle = (await (conn as Promise<DynamoHandle> | DynamoHandle)) as DynamoHandle;
+    const handle = (await (conn as
+      | Promise<DynamoHandle>
+      | DynamoHandle)) as DynamoHandle;
     const start = performance.now();
     try {
       const env = _parseEnvelope(query);
@@ -275,8 +307,7 @@ export class DynamoDriver extends DatabaseDriver {
         return {
           status: "error",
           error_code: "SQL_ERROR",
-          error:
-            "DynamoDriver: query must be a JSON envelope {table, op, ...}",
+          error: "DynamoDriver: query must be a JSON envelope {table, op, ...}",
           execution_time_ms: roundTo2(performance.now() - start),
         };
       }
@@ -345,9 +376,11 @@ export class DynamoDriver extends DatabaseDriver {
       if (env.filter !== undefined) {
         input["FilterExpression"] = env.filter.FilterExpression;
         if (env.filter.ExpressionAttributeValues)
-          input["ExpressionAttributeValues"] = env.filter.ExpressionAttributeValues;
+          input["ExpressionAttributeValues"] =
+            env.filter.ExpressionAttributeValues;
         if (env.filter.ExpressionAttributeNames)
-          input["ExpressionAttributeNames"] = env.filter.ExpressionAttributeNames;
+          input["ExpressionAttributeNames"] =
+            env.filter.ExpressionAttributeNames;
       }
       if (env.op === "query") {
         if (env.keyCondition === undefined) {
@@ -358,12 +391,14 @@ export class DynamoDriver extends DatabaseDriver {
             execution_time_ms: roundTo2(performance.now() - start),
           };
         }
-        input["KeyConditionExpression"] = env.keyCondition.KeyConditionExpression;
+        input["KeyConditionExpression"] =
+          env.keyCondition.KeyConditionExpression;
         const prevVals =
           (input["ExpressionAttributeValues"] as DynamoItem | undefined) ?? {};
         const prevNames =
-          (input["ExpressionAttributeNames"] as Record<string, string> | undefined) ??
-          {};
+          (input["ExpressionAttributeNames"] as
+            | Record<string, string>
+            | undefined) ?? {};
         if (env.keyCondition.ExpressionAttributeValues)
           input["ExpressionAttributeValues"] = {
             ...prevVals,
@@ -415,7 +450,9 @@ export class DynamoDriver extends DatabaseDriver {
     schemaName: string = "",
     tableFilter: string | null = null,
   ): Promise<Table[]> {
-    const handle = (await (conn as Promise<DynamoHandle> | DynamoHandle)) as DynamoHandle;
+    const handle = (await (conn as
+      | Promise<DynamoHandle>
+      | DynamoHandle)) as DynamoHandle;
     const { client, module } = handle;
     try {
       const listed = (await client.send(
@@ -427,50 +464,75 @@ export class DynamoDriver extends DatabaseDriver {
         tableFilter !== null && tableFilter !== undefined
           ? new RegExp(
               "^" +
-                tableFilter.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/%/g, ".*") +
+                tableFilter
+                  .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+                  .replace(/%/g, ".*") +
                 "$",
             )
           : null;
 
-      const out: Table[] = [];
-      for (const name of names) {
-        if (filterRe !== null && !filterRe.test(name)) continue;
-        const desc = (await client.send(
-          new module.DescribeTableCommand({ TableName: name }),
-        )) as DescribeTableOutput;
-        const table = desc.Table;
-        if (table === undefined) continue;
+      // ⚡ Bolt Optimization: Use chunked concurrent requests to avoid N+1 sequential overhead.
+      // This parallelizes DescribeTableCommand network calls while capping concurrency (10)
+      // to avoid AWS API throttling exceptions on large schemas.
+      const filteredNames = names.filter(
+        (name) => filterRe === null || filterRe.test(name),
+      );
 
-        const attrTypes = new Map<string, string>();
-        for (const a of table.AttributeDefinitions ?? []) {
-          attrTypes.set(a.AttributeName, _awsAttrType(a.AttributeType));
-        }
-        const keys = new Set(
-          (table.KeySchema ?? []).map((k) => k.AttributeName),
+      const out: Table[] = [];
+      const CONCURRENCY_LIMIT = 10;
+
+      for (let i = 0; i < filteredNames.length; i += CONCURRENCY_LIMIT) {
+        const chunk = filteredNames.slice(i, i + CONCURRENCY_LIMIT);
+
+        const chunkResults = await Promise.all(
+          chunk.map(async (name) => {
+            try {
+              const desc = (await client.send(
+                new module.DescribeTableCommand({ TableName: name }),
+              )) as DescribeTableOutput;
+              const table = desc.Table;
+              if (table === undefined) return null;
+
+              const attrTypes = new Map<string, string>();
+              for (const a of table.AttributeDefinitions ?? []) {
+                attrTypes.set(a.AttributeName, _awsAttrType(a.AttributeType));
+              }
+              const keys = new Set(
+                (table.KeySchema ?? []).map((k) => k.AttributeName),
+              );
+              const columns: Column[] = (table.KeySchema ?? []).map(
+                (k) =>
+                  new Column({
+                    name: k.AttributeName,
+                    data_type: attrTypes.get(k.AttributeName) ?? "unknown",
+                    nullable: false,
+                    is_primary_key: true,
+                    default: null,
+                  }),
+              );
+              for (const [attrName, attrType] of attrTypes) {
+                if (keys.has(attrName)) continue;
+                columns.push(
+                  new Column({
+                    name: attrName,
+                    data_type: attrType,
+                    nullable: true,
+                    is_primary_key: false,
+                    default: null,
+                  }),
+                );
+              }
+              return new Table({ name, schema: schemaName, columns });
+            } catch {
+              // Best effort: if one table fails to describe (e.g. deleted), skip it
+              return null;
+            }
+          }),
         );
-        const columns: Column[] = (table.KeySchema ?? []).map(
-          (k) =>
-            new Column({
-              name: k.AttributeName,
-              data_type: attrTypes.get(k.AttributeName) ?? "unknown",
-              nullable: false,
-              is_primary_key: true,
-              default: null,
-            }),
-        );
-        for (const [attrName, attrType] of attrTypes) {
-          if (keys.has(attrName)) continue;
-          columns.push(
-            new Column({
-              name: attrName,
-              data_type: attrType,
-              nullable: true,
-              is_primary_key: false,
-              default: null,
-            }),
-          );
+
+        for (const t of chunkResults) {
+          if (t !== null) out.push(t);
         }
-        out.push(new Table({ name, schema: schemaName, columns }));
       }
       return out;
     } catch {
@@ -493,8 +555,12 @@ export class DynamoDriver extends DatabaseDriver {
   /** Per-driver health check via `ListTablesCommand` with Limit=1. */
   async healthCheck(conn: unknown): Promise<boolean> {
     try {
-      const handle = (await (conn as Promise<DynamoHandle> | DynamoHandle)) as DynamoHandle;
-      await handle.client.send(new handle.module.ListTablesCommand({ Limit: 1 }));
+      const handle = (await (conn as
+        | Promise<DynamoHandle>
+        | DynamoHandle)) as DynamoHandle;
+      await handle.client.send(
+        new handle.module.ListTablesCommand({ Limit: 1 }),
+      );
       return true;
     } catch {
       return false;
@@ -526,9 +592,7 @@ export class DynamoDriver extends DatabaseDriver {
         // distinct error so callers don't see the unhelpful default-deny
         // "ADMIN statements are never allowed" path.
         const msg = e instanceof Error ? e.message : String(e);
-        throw new DynamoEnvelopeParseError(
-          `Malformed envelope JSON: ${msg}`,
-        );
+        throw new DynamoEnvelopeParseError(`Malformed envelope JSON: ${msg}`);
       }
     }
 


### PR DESCRIPTION
💡 What: Replaced sequential `for` loop of `DescribeTableCommand` requests with chunked `Promise.all` concurrency in the DynamoDB `getSchemaAsync` method. Added a concurrency limit of 10 to avoid AWS API throttling. Also gracefully handles `try/catch` on the individual describe requests (e.g. if a table is dropped between list and describe).

🎯 Why: During DynamoDB schema extraction, looping over tables sequentially and awaiting `DescribeTableCommand` causes an N+1 problem that blocks on network latency for each table. For accounts with many tables, this makes schema extraction excessively slow.

📊 Impact: Drastically reduces schema extraction time by parallelizing network requests up to a factor of 10. For an account with 100 tables, this replaces 100 sequential round trips with 10 batched round trips, improving performance by roughly ~80-90%.

🔬 Measurement: Verify schema extraction via `db-connector` against a DynamoDB table with many items/tables. Run `npm run test -- tests/connectors/db/drivers/test_dynamodb.test.ts` to ensure no functionality is broken.

---
*PR created automatically by Jules for task [14565639520801638663](https://jules.google.com/task/14565639520801638663) started by @rfv-code*