### PR TITLE
⚡ Bolt: Optimize top-K usage aggregation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2026-05-23 - SQL Server Schema Batch Optimization
 **Learning:** When querying INFORMATION_SCHEMA.COLUMNS, chunking IN (@table...) parameters to respect SQL Server's 2100 limit is unnecessary and inefficient. It's better to avoid passing the list of tables entirely by doing a JOIN with INFORMATION_SCHEMA.TABLES and applying the same filter directly.
 **Action:** Remove the chunking loop and use a JOIN to extract metadata for all relevant tables in a single DB query, simplifying logic and reducing compilation and network overhead.
+## 2026-05-24 - O(N) Top-K Extraction
+**Learning:** In usage metrics aggregation pipelines (e.g., `src/toolkit/usage/aggregate.ts`), using `[...records].sort().slice(0, K)` for Top-K extraction causes an O(N log N) performance bottleneck and blocks the Node.js event loop on large datasets due to array spreading and sorting.
+**Action:** Use an O(N) manual loop or priority queue instead for extracting the top items to avoid blocking the event loop on large usage arrays.

--- a/src/toolkit/usage/aggregate.ts
+++ b/src/toolkit/usage/aggregate.ts
@@ -71,10 +71,19 @@ export function aggregateRecords(
     };
   }
 
-  const top_responses: UsageTopResponse[] = [...records]
-    .sort((a, b) => b.response_bytes - a.response_bytes)
-    .slice(0, 3)
-    .map((r) => ({ action: r.action, response_bytes: r.response_bytes }));
+  // ⚡ Bolt: Use an O(N) loop to find the top 3 responses instead of O(N log N) sort
+  // [...records].sort() blocks the event loop on large datasets and causes memory overhead
+  const topK: { action: string; response_bytes: number }[] = [];
+  for (const rec of records) {
+    if (topK.length < 3) {
+      topK.push({ action: rec.action, response_bytes: rec.response_bytes });
+      topK.sort((a, b) => b.response_bytes - a.response_bytes);
+    } else if (rec.response_bytes > topK[2].response_bytes) {
+      topK[2] = { action: rec.action, response_bytes: rec.response_bytes };
+      topK.sort((a, b) => b.response_bytes - a.response_bytes);
+    }
+  }
+  const top_responses: UsageTopResponse[] = topK;
 
   return {
     session_id: sessionId,


### PR DESCRIPTION
💡 **What:** Replaced the `O(N log N)` `.sort().slice(0, 3)` array spread with an `O(N)` single-pass loop that maintains an array of the top 3 usage responses by bytes.
🎯 **Why:** On large datasets containing many usage records, `[...records].sort()` acts as a performance bottleneck that can block the Node.js event loop and wastes memory on unnecessary array copies.
📊 **Impact:** Reduces Top-K extraction from `O(N log N)` time and `O(N)` space to `O(N)` time and `O(1)` space, making usage aggregations lightning fast even with high volume.
🔬 **Measurement:** Execute `npm run test -- tests/toolkit/unit/usage_aggregate.test.ts` to verify functionality behaves correctly. You can observe reduced CPU/memory overhead locally on large datasets.

---
*PR created automatically by Jules for task [17882528280640405047](https://jules.google.com/task/17882528280640405047) started by @rfv-code*