### PR TITLE
⚡ Bolt: Replace O(N log N) usage aggregate sort with O(N) top-K loop

### DIFF
--- a/src/toolkit/usage/aggregate.ts
+++ b/src/toolkit/usage/aggregate.ts
@@ -27,7 +27,13 @@ export function aggregateRecords(
 
   const byAction: Record<
     string,
-    { calls: number; response_bytes: number; estimated_tokens: number; ms_total: number; ms_count: number }
+    {
+      calls: number;
+      response_bytes: number;
+      estimated_tokens: number;
+      ms_total: number;
+      ms_count: number;
+    }
   > = {};
 
   let totalBytes = 0;
@@ -35,6 +41,12 @@ export function aggregateRecords(
   let errors = 0;
   let start = records[0].ts;
   let end = records[0].ts;
+
+  // ⚡ Bolt: Replace O(N log N) full sort and array copy with O(N) manual top-K extraction
+  // during the existing iteration to avoid blocking the event loop on large datasets.
+  let top1: UsageRecord | null = null;
+  let top2: UsageRecord | null = null;
+  let top3: UsageRecord | null = null;
 
   for (const rec of records) {
     totalBytes += rec.response_bytes;
@@ -59,6 +71,19 @@ export function aggregateRecords(
       slot.ms_total += rec.execution_time_ms;
       slot.ms_count += 1;
     }
+
+    // ⚡ Bolt: Update top 3 largest responses
+    const rb = rec.response_bytes;
+    if (!top1 || rb > top1.response_bytes) {
+      top3 = top2;
+      top2 = top1;
+      top1 = rec;
+    } else if (!top2 || rb > top2.response_bytes) {
+      top3 = top2;
+      top2 = rec;
+    } else if (!top3 || rb > top3.response_bytes) {
+      top3 = rec;
+    }
   }
 
   const by_action: Record<string, UsageActionBreakdown> = {};
@@ -71,10 +96,22 @@ export function aggregateRecords(
     };
   }
 
-  const top_responses: UsageTopResponse[] = [...records]
-    .sort((a, b) => b.response_bytes - a.response_bytes)
-    .slice(0, 3)
-    .map((r) => ({ action: r.action, response_bytes: r.response_bytes }));
+  const top_responses: UsageTopResponse[] = [];
+  if (top1)
+    top_responses.push({
+      action: top1.action,
+      response_bytes: top1.response_bytes,
+    });
+  if (top2)
+    top_responses.push({
+      action: top2.action,
+      response_bytes: top2.response_bytes,
+    });
+  if (top3)
+    top_responses.push({
+      action: top3.action,
+      response_bytes: top3.response_bytes,
+    });
 
   return {
     session_id: sessionId,
@@ -105,7 +142,10 @@ export function renderSummaryMarkdown(s: UsageSummary): string {
     .join("\n");
 
   const top = s.top_responses
-    .map((t, i) => `${i + 1}. ${t.action} (${t.response_bytes.toLocaleString()} bytes)`)
+    .map(
+      (t, i) =>
+        `${i + 1}. ${t.action} (${t.response_bytes.toLocaleString()} bytes)`,
+    )
     .join("\n");
 
   return [


### PR DESCRIPTION
💡 What: Replaced the `sort().slice(0, 3)` logic used to find top responses with an O(N) loop extracting the top 3 items inside the existing `records` iteration.

🎯 Why: Calling `.sort()` on `[...records]` has an O(N log N) complexity and duplicates the entire array. For large tracking payloads, this blocks the Node.js event loop and significantly impacts overall memory use.

📊 Impact: Reduces memory overhead and shifts time complexity from O(N log N) to O(N) when extracting top responses. The single pass scales properly with larger usage histories.

🔬 Measurement: Review `src/toolkit/usage/aggregate.ts` to see that `top_responses` now maintains three state variables inline without duplicating `records`. Run `npm run test` to verify equivalent functionality.

---
*PR created automatically by Jules for task [14149114544699813529](https://jules.google.com/task/14149114544699813529) started by @rfv-code*