### PR TITLE
⚡ Bolt: O(N) top responses extraction

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,7 @@
 ## 2026-05-23 - SQL Server Schema Batch Optimization
 **Learning:** When querying INFORMATION_SCHEMA.COLUMNS, chunking IN (@table...) parameters to respect SQL Server's 2100 limit is unnecessary and inefficient. It's better to avoid passing the list of tables entirely by doing a JOIN with INFORMATION_SCHEMA.TABLES and applying the same filter directly.
 **Action:** Remove the chunking loop and use a JOIN to extract metadata for all relevant tables in a single DB query, simplifying logic and reducing compilation and network overhead.
+
+## 2024-05-18 - Top-K Extraction in Node.js
+**Learning:** Using `[...array].sort().slice(0, K)` for extracting the top K items in usage metrics blocks the Node.js event loop with an O(N log N) sorting cost, which is catastrophic on large data arrays.
+**Action:** Always prefer maintaining a fixed-size Top-K list manually in O(N) when iterating over large datasets, completely eliminating the sorting phase and the array copy overhead.

--- a/src/toolkit/usage/aggregate.ts
+++ b/src/toolkit/usage/aggregate.ts
@@ -27,7 +27,13 @@ export function aggregateRecords(
 
   const byAction: Record<
     string,
-    { calls: number; response_bytes: number; estimated_tokens: number; ms_total: number; ms_count: number }
+    {
+      calls: number;
+      response_bytes: number;
+      estimated_tokens: number;
+      ms_total: number;
+      ms_count: number;
+    }
   > = {};
 
   let totalBytes = 0;
@@ -36,7 +42,23 @@ export function aggregateRecords(
   let start = records[0].ts;
   let end = records[0].ts;
 
+  // Track top 3 responses by bytes in O(N) to avoid O(N log N) sorting bottleneck
+  let top1: UsageRecord | null = null;
+  let top2: UsageRecord | null = null;
+  let top3: UsageRecord | null = null;
+
   for (const rec of records) {
+    if (!top1 || rec.response_bytes > top1.response_bytes) {
+      top3 = top2;
+      top2 = top1;
+      top1 = rec;
+    } else if (!top2 || rec.response_bytes > top2.response_bytes) {
+      top3 = top2;
+      top2 = rec;
+    } else if (!top3 || rec.response_bytes > top3.response_bytes) {
+      top3 = rec;
+    }
+
     totalBytes += rec.response_bytes;
     totalTokens += rec.estimated_tokens;
     if (rec.status !== "success") errors += 1;
@@ -71,10 +93,22 @@ export function aggregateRecords(
     };
   }
 
-  const top_responses: UsageTopResponse[] = [...records]
-    .sort((a, b) => b.response_bytes - a.response_bytes)
-    .slice(0, 3)
-    .map((r) => ({ action: r.action, response_bytes: r.response_bytes }));
+  const top_responses: UsageTopResponse[] = [];
+  if (top1)
+    top_responses.push({
+      action: top1.action,
+      response_bytes: top1.response_bytes,
+    });
+  if (top2)
+    top_responses.push({
+      action: top2.action,
+      response_bytes: top2.response_bytes,
+    });
+  if (top3)
+    top_responses.push({
+      action: top3.action,
+      response_bytes: top3.response_bytes,
+    });
 
   return {
     session_id: sessionId,
@@ -105,7 +139,10 @@ export function renderSummaryMarkdown(s: UsageSummary): string {
     .join("\n");
 
   const top = s.top_responses
-    .map((t, i) => `${i + 1}. ${t.action} (${t.response_bytes.toLocaleString()} bytes)`)
+    .map(
+      (t, i) =>
+        `${i + 1}. ${t.action} (${t.response_bytes.toLocaleString()} bytes)`,
+    )
     .join("\n");
 
   return [


### PR DESCRIPTION
💡 **What:** Replaced the O(N log N) `[...records].sort().slice(0, 3)` bottleneck in `aggregateRecords` with a manual O(N) single-pass Top-3 extraction algorithm.
🎯 **Why:** The usage metrics pipeline can process thousands of connector interaction records in a single pass. Calling `sort()` requires cloning the entire array and blocks the single Node.js event loop thread unnecessarily for a simple Top-3 lookup.
📊 **Impact:** Reduces computation complexity from O(N log N) to O(N). Avoids creating a copy of the large `records` array. Faster execution for large sessions.
🔬 **Measurement:** Execute `npm run test -- tests/toolkit/unit/usage_aggregate.test.ts` or monitor CPU/memory usage for sessions with 10k+ records. Output structure is strictly identical.

---
*PR created automatically by Jules for task [16362804627843150020](https://jules.google.com/task/16362804627843150020) started by @rfv-code*