### PR TITLE
⚡ Bolt: O(N) Top-K Extraction in Usage Aggregation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2026-05-23 - SQL Server Schema Batch Optimization
 **Learning:** When querying INFORMATION_SCHEMA.COLUMNS, chunking IN (@table...) parameters to respect SQL Server's 2100 limit is unnecessary and inefficient. It's better to avoid passing the list of tables entirely by doing a JOIN with INFORMATION_SCHEMA.TABLES and applying the same filter directly.
 **Action:** Remove the chunking loop and use a JOIN to extract metadata for all relevant tables in a single DB query, simplifying logic and reducing compilation and network overhead.
+## 2024-05-14 - O(N log N) Bottleneck in Usage Aggregation
+**Learning:** Using `[...records].sort().slice(0, K)` for Top-K extraction in usage metrics aggregation causes an O(N log N) performance bottleneck. This blocks the Node.js event loop on large datasets.
+**Action:** Replace sorting logic with an O(N) manual loop or priority queue for Top-K extraction, especially in synchronous data processing pipelines.

--- a/src/toolkit/usage/aggregate.ts
+++ b/src/toolkit/usage/aggregate.ts
@@ -71,10 +71,17 @@ export function aggregateRecords(
     };
   }
 
-  const top_responses: UsageTopResponse[] = [...records]
-    .sort((a, b) => b.response_bytes - a.response_bytes)
-    .slice(0, 3)
-    .map((r) => ({ action: r.action, response_bytes: r.response_bytes }));
+  // Top-K extraction using an O(N) approach to avoid an O(N log N) sorting bottleneck on large datasets.
+  const top_responses: UsageTopResponse[] = [];
+  for (const rec of records) {
+    if (top_responses.length < 3) {
+      top_responses.push({ action: rec.action, response_bytes: rec.response_bytes });
+      top_responses.sort((a, b) => b.response_bytes - a.response_bytes);
+    } else if (rec.response_bytes > top_responses[2].response_bytes) {
+      top_responses[2] = { action: rec.action, response_bytes: rec.response_bytes };
+      top_responses.sort((a, b) => b.response_bytes - a.response_bytes);
+    }
+  }
 
   return {
     session_id: sessionId,


### PR DESCRIPTION
💡 **What**: Replaced the `[...records].sort().slice(0, 3)` array spreading and sorting logic in `aggregateRecords` with an O(N) manual loop that maintains a sorted array of 3 top elements.

🎯 **Why**: Using full-array sorting for top-K extraction introduces an O(N log N) performance bottleneck that will block the Node.js event loop on large datasets, significantly hurting throughput.

📊 **Impact**: Reduces computation complexity from O(N log N) to O(N) and prevents large memory clones (`[...records]`), allowing synchronous usage aggregation to handle significantly larger session arrays without stalling.

🔬 **Measurement**: Verified using `npm run test -- tests/toolkit/unit/usage_aggregate.test.ts` as well as the full test suite which confirms correct top-3 extraction logic remains unchanged.

---
*PR created automatically by Jules for task [3224874206093829967](https://jules.google.com/task/3224874206093829967) started by @rfv-code*