### PR TITLE
⚡ Bolt: Optimize top responses extraction to O(N)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2026-05-23 - SQL Server Schema Batch Optimization
 **Learning:** When querying INFORMATION_SCHEMA.COLUMNS, chunking IN (@table...) parameters to respect SQL Server's 2100 limit is unnecessary and inefficient. It's better to avoid passing the list of tables entirely by doing a JOIN with INFORMATION_SCHEMA.TABLES and applying the same filter directly.
 **Action:** Remove the chunking loop and use a JOIN to extract metadata for all relevant tables in a single DB query, simplifying logic and reducing compilation and network overhead.
+## 2026-06-19 - Top-K Extraction Overhead
+**Learning:** In usage metrics aggregation pipelines (e.g., `src/toolkit/usage/aggregate.ts`), extracting the top-K items via `[...array].sort().slice(0, K)` scales at O(N log N). On large datasets, this blocks the Node.js event loop unnecessarily when a simple O(N) traversal would suffice.
+**Action:** Replace `sort().slice()` with an O(N) manual loop to track only the top K items when calculating `top_responses`, improving metrics aggregation speed.

--- a/src/toolkit/usage/aggregate.ts
+++ b/src/toolkit/usage/aggregate.ts
@@ -27,7 +27,13 @@ export function aggregateRecords(
 
   const byAction: Record<
     string,
-    { calls: number; response_bytes: number; estimated_tokens: number; ms_total: number; ms_count: number }
+    {
+      calls: number;
+      response_bytes: number;
+      estimated_tokens: number;
+      ms_total: number;
+      ms_count: number;
+    }
   > = {};
 
   let totalBytes = 0;
@@ -71,10 +77,21 @@ export function aggregateRecords(
     };
   }
 
-  const top_responses: UsageTopResponse[] = [...records]
-    .sort((a, b) => b.response_bytes - a.response_bytes)
-    .slice(0, 3)
-    .map((r) => ({ action: r.action, response_bytes: r.response_bytes }));
+  // ⚡ Bolt: Optimize top responses extraction to O(N) to avoid event loop blocking on large datasets.
+  const topK: UsageRecord[] = [];
+  for (const rec of records) {
+    if (topK.length < 3) {
+      topK.push(rec);
+      topK.sort((a, b) => b.response_bytes - a.response_bytes);
+    } else if (rec.response_bytes > topK[2].response_bytes) {
+      topK[2] = rec;
+      topK.sort((a, b) => b.response_bytes - a.response_bytes);
+    }
+  }
+  const top_responses: UsageTopResponse[] = topK.map((r) => ({
+    action: r.action,
+    response_bytes: r.response_bytes,
+  }));
 
   return {
     session_id: sessionId,
@@ -105,7 +122,10 @@ export function renderSummaryMarkdown(s: UsageSummary): string {
     .join("\n");
 
   const top = s.top_responses
-    .map((t, i) => `${i + 1}. ${t.action} (${t.response_bytes.toLocaleString()} bytes)`)
+    .map(
+      (t, i) =>
+        `${i + 1}. ${t.action} (${t.response_bytes.toLocaleString()} bytes)`,
+    )
     .join("\n");
 
   return [


### PR DESCRIPTION
💡 **What:** Optimized the extraction of `top_responses` in `src/toolkit/usage/aggregate.ts` from O(N log N) to O(N).
🎯 **Why:** The previous implementation cloned the entire `records` array and sorted it just to get the top 3 elements. For large datasets, this caused unnecessary memory allocation and blocked the Node.js event loop due to the overhead of a full sort.
📊 **Impact:** Reduces time complexity from O(N log N) to O(N) and memory complexity from O(N) to O(1) auxiliary space, making usage aggregation significantly faster and less memory-intensive for sessions with many records.
🔬 **Measurement:** The `tests/toolkit/unit/usage_aggregate.test.ts` suite passes, confirming correct top 3 extraction. No functionality or output structure changed.

---
*PR created automatically by Jules for task [11875459651188980154](https://jules.google.com/task/11875459651188980154) started by @rfv-code*