### PR TITLE
Fail-closed guardrails, durable grants, and broader hook coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ Update imports:
 
 All eleven old packages are deprecated on npm and will receive no new releases.
 
+## Configuration
+
+Connectors read `~/.connectors/config.yaml` (user defaults) with
+`<cwd>/.connectors/config.yaml` (repo overlay) merged on top. For the `db`
+connector specifically — overriding a server target and policy per-repo, and the
+admin/privilege ceiling that an overlay cannot bypass — see
+[`docs/db-layered-config.md`](docs/db-layered-config.md).
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md). Contributors touching `src/toolkit/agent_resolver.ts`, `src/hub/index.ts`, `src/credentials/`, or `src/connectors/db/` should also read [`docs/architecture-invariants.md`](docs/architecture-invariants.md).

--- a/docs/db-layered-config.md
+++ b/docs/db-layered-config.md
@@ -1,0 +1,74 @@
+# DB connector: per-repo config overlay
+
+The `db` connector reads its target servers and policy from the same two-level
+config the rest of `narai-primitives` uses. A user-level file provides defaults;
+a repo-level file overlays them. You do not need a flag to opt in — the overlay
+is always applied.
+
+## The two files
+
+- User level: `~/.connectors/config.yaml`
+- Repo level: `<cwd>/.connectors/config.yaml`
+
+Both are loaded by `loadResolvedConfig` (`src/config/load.ts`), deep-merged with
+the repo file winning on conflict. Plain objects merge recursively; arrays and
+scalars are replaced wholesale by the repo overlay.
+
+## Overriding a target and policy per-repo
+
+User level (`~/.connectors/config.yaml`) sets the defaults:
+
+```yaml
+connectors:
+  db:
+    skill: db-agent-connector
+    policy:
+      write: escalate
+    servers:
+      orders:
+        driver: postgresql
+        host: db.shared.internal
+        database: orders
+        user: ro
+        password: env:DB_PW
+```
+
+Repo level (`<cwd>/.connectors/config.yaml`) overrides only what it names:
+
+```yaml
+connectors:
+  db:
+    policy:
+      write: deny            # tighten the global write rule for this repo
+    servers:
+      orders:
+        host: db.local.test  # point the same server at a local target
+        policy:
+          read: deny         # per-server override, merged onto the global policy
+```
+
+After the merge, `connectors.db.servers.orders.host` is `db.local.test` and the
+effective `write` rule is `deny` — the repo values win. Keys the repo file does
+not mention (`driver`, `database`, `user`, `password`) are inherited from the
+user file. The per-server `policy` block is merged onto the connector-level
+policy at dispatch time (`mergePolicy` in
+`src/connectors/db/lib/plugin_config.ts`).
+
+## The admin/privilege ceiling survives the overlay
+
+The overlay cannot escalate privileges. After merging, the resolved `db` slice
+is re-validated by `pluginConfigFromSlice` -> `validateServer`. The safety floor
+forbids `admin: allow` and `privilege: allow` at every level — global or
+per-server. A repo overlay that sets, for example:
+
+```yaml
+connectors:
+  db:
+    servers:
+      orders:
+        policy:
+          admin: allow       # rejected
+```
+
+fails validation with a config error and the connector refuses to run. An
+overlay can tighten policy but can never lift the `admin`/`privilege` ceiling.

--- a/plugin-hooks/dispatcher.mjs
+++ b/plugin-hooks/dispatcher.mjs
@@ -230,14 +230,31 @@ async function onPreToolUse(cfg) {
   } catch {
     return;
   }
-  if (payload.tool_name !== "Bash") return;
-  const command = payload.tool_input?.command;
+  // Derive the tool being gated and the text to scan. Bash scans the
+  // command; Write scans the file content; Edit scans the incoming text
+  // (new_string only — old_string is the text being removed). `command`
+  // therefore holds the candidate text for whichever tool fired.
+  let scanTool;
+  let command;
+  if (payload.tool_name === "Bash") {
+    scanTool = "Bash";
+    command = payload.tool_input?.command;
+  } else if (payload.tool_name === "Write") {
+    scanTool = "Write";
+    command = payload.tool_input?.content;
+  } else if (payload.tool_name === "Edit") {
+    scanTool = "Edit";
+    command = payload.tool_input?.new_string;
+  } else {
+    return;
+  }
   if (typeof command !== "string" || command.length === 0) return;
 
   const decisions = [];
 
-  // 1. db-guard (only if kind=db, and not opted out via user_config)
-  if (cfg.kind === "db" && process.env.DB_AGENT_GUARDRAILS !== "off") {
+  // 1. db-guard (Bash only; only if kind=db, and not opted out via user_config).
+  //    The token-blocklist engine is command-shaped and meaningless for file content.
+  if (scanTool === "Bash" && cfg.kind === "db" && process.env.DB_AGENT_GUARDRAILS !== "off") {
     const guardrailsPath = path.join(
       process.env.CLAUDE_PLUGIN_ROOT,
       "hooks",
@@ -289,7 +306,7 @@ async function onPreToolUse(cfg) {
   if (fs.existsSync(pluginGatesFile)) {
     try {
       const gateCfg = JSON.parse(fs.readFileSync(pluginGatesFile, "utf-8"));
-      applyGatesManifest(gateCfg, cfg.name, command, disabled, decisions);
+      applyGatesManifest(gateCfg, cfg.name, command, disabled, decisions, scanTool);
     } catch (err) {
       process.stderr.write(
         `dispatcher: plugin-root gate scan failed (${err.message})\n`,
@@ -324,7 +341,7 @@ async function onPreToolUse(cfg) {
       if (!fs.existsSync(gatesFile)) continue;
       try {
         const gateCfg = JSON.parse(fs.readFileSync(gatesFile, "utf-8"));
-        applyGatesManifest(gateCfg, slug, command, disabled, decisions);
+        applyGatesManifest(gateCfg, slug, command, disabled, decisions, scanTool);
       } catch (err) {
         process.stderr.write(
           `dispatcher: gate scan failed for ${gatesFile} (${err.message})\n`,
@@ -508,14 +525,23 @@ export function effectiveEnforcement(manifestEnforcement) {
  * field), a rule whose pattern will not compile becomes a hard deny instead
  * of being silently skipped — we cannot prove the command is safe.
  */
-export function applyGatesManifest(manifest, source, command, disabled, decisions) {
+export function applyGatesManifest(manifest, source, text, disabled, decisions, scanTool = "Bash") {
   const enforcement = effectiveEnforcement(manifest.enforcement);
+  // Bash commands are split on chaining operators so anchored rules apply
+  // per-segment. File content (Write/Edit) is matched as a single unit so
+  // characters like `;` or `|` inside the file do not fragment it.
+  const segments = scanTool === "Bash" ? splitCompound(text) : [text];
   for (const rule of manifest.rules ?? []) {
     if (
       !["deny", "ask", "allow"].includes(rule.decision) ||
       typeof rule.pattern !== "string"
     ) continue;
     if (typeof rule.name === "string" && disabled.has(rule.name)) continue;
+    // A rule applies to a tool only if listed in `applies_to`. Default is
+    // Bash-only, so every existing rule keeps its current behavior and is
+    // skipped on Write/Edit unless it explicitly opts in.
+    const appliesTo = Array.isArray(rule.applies_to) ? rule.applies_to : ["Bash"];
+    if (!appliesTo.includes(scanTool)) continue;
     let re;
     try { re = new RegExp(rule.pattern); } catch {
       if (enforcement === "fail_closed") {
@@ -526,7 +552,7 @@ export function applyGatesManifest(manifest, source, command, disabled, decision
       }
       continue;
     }
-    for (const segment of splitCompound(command)) {
+    for (const segment of segments) {
       if (re.test(segment)) {
         decisions.push({
           decision: rule.decision,

--- a/plugin-hooks/dispatcher.mjs
+++ b/plugin-hooks/dispatcher.mjs
@@ -113,6 +113,31 @@ async function loadToolkit() {
 }
 
 /**
+ * Lazily load the db audit module from dist. Returns the module namespace
+ * ({ enableAudit, logEvent, scrubSqlSecrets, ... }) or null if unavailable.
+ * Only used when NARAI_AUDIT_PATH is set, so the common path stays cheap.
+ */
+async function loadAudit() {
+  const { existsSync } = fs;
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.join(__dirname, "..", "dist", "connectors", "db", "lib", "audit.js"),
+    process.env.CLAUDE_PLUGIN_DATA
+      ? path.join(process.env.CLAUDE_PLUGIN_DATA, "node_modules", "narai-primitives", "dist", "connectors", "db", "lib", "audit.js")
+      : null,
+  ].filter((p) => p !== null);
+  for (const p of candidates) {
+    if (!existsSync(p)) continue;
+    try {
+      return await import(pathToFileURL(p).href);
+    } catch {
+      // try next
+    }
+  }
+  return null;
+}
+
+/**
  * Walk siblings of `pluginDataDir` looking for a `node_modules/narai-primitives`
  * at `wantedVersion`. Returns the matched node_modules path, or null if no
  * usable sibling found. Used to skip redundant npm install when N builtin
@@ -325,6 +350,27 @@ async function onPreToolUse(cfg) {
       permissionDecisionReason: winner.reason,
     },
   }));
+
+  // Best-effort audit of blocked/escalated decisions. Only runs when an
+  // audit destination is configured, keeping the common allow path cheap.
+  const auditPath = process.env.NARAI_AUDIT_PATH;
+  if (auditPath && (winner.decision === "deny" || winner.decision === "ask")) {
+    try {
+      const audit = await loadAudit();
+      if (audit && typeof audit.logEvent === "function") {
+        audit.enableAudit(auditPath);
+        const scrub = typeof audit.scrubSqlSecrets === "function"
+          ? audit.scrubSqlSecrets
+          : (s) => s;
+        audit.logEvent({
+          event_type: winner.decision === "deny" ? "guardrail_deny" : "guardrail_ask",
+          details: { tool: payload.tool_name, command: scrub(command), reason: winner.reason },
+        });
+      }
+    } catch (err) {
+      process.stderr.write(`dispatcher: decision audit failed (${err.message})\n`);
+    }
+  }
 }
 
 async function readStdin() {

--- a/plugin-hooks/dispatcher.mjs
+++ b/plugin-hooks/dispatcher.mjs
@@ -260,6 +260,12 @@ async function onPreToolUse(cfg) {
       process.stderr.write(
         `dispatcher: plugin-root gate scan failed (${err.message})\n`,
       );
+      if (effectiveEnforcement(undefined) === "fail_closed") {
+        decisions.push({
+          decision: "deny",
+          reason: `fail-closed enforcement: gates manifest at ${pluginGatesFile} could not be parsed`,
+        });
+      }
     }
   }
 
@@ -289,6 +295,12 @@ async function onPreToolUse(cfg) {
         process.stderr.write(
           `dispatcher: gate scan failed for ${gatesFile} (${err.message})\n`,
         );
+        if (effectiveEnforcement(undefined) === "fail_closed") {
+          decisions.push({
+            decision: "deny",
+            reason: `fail-closed enforcement: gates manifest at ${gatesFile} could not be parsed`,
+          });
+        }
       }
     }
   }
@@ -420,11 +432,29 @@ async function ensureBootstrap(pluginRoot, pluginData) {
 }
 
 /**
+ * Resolve the effective enforcement posture from the global
+ * NARAI_GATE_ENFORCEMENT env var and an optional manifest-level field.
+ * Strictest wins: fail-closed if either requests it, else fail-open.
+ */
+export function effectiveEnforcement(manifestEnforcement) {
+  const env = process.env.NARAI_GATE_ENFORCEMENT;
+  if (env === "fail_closed" || manifestEnforcement === "fail_closed") {
+    return "fail_closed";
+  }
+  return "fail_open";
+}
+
+/**
  * Apply a parsed gates.json manifest to a command. Rules with invalid
  * shape, disabled names, or uncompilable patterns are skipped. Anchored
  * patterns match per-segment so chaining (`echo ok; psql ...`) can't bypass.
+ *
+ * Under fail-closed enforcement (env var or the manifest's `enforcement`
+ * field), a rule whose pattern will not compile becomes a hard deny instead
+ * of being silently skipped — we cannot prove the command is safe.
  */
-function applyGatesManifest(manifest, source, command, disabled, decisions) {
+export function applyGatesManifest(manifest, source, command, disabled, decisions) {
+  const enforcement = effectiveEnforcement(manifest.enforcement);
   for (const rule of manifest.rules ?? []) {
     if (
       !["deny", "ask", "allow"].includes(rule.decision) ||
@@ -432,7 +462,15 @@ function applyGatesManifest(manifest, source, command, disabled, decisions) {
     ) continue;
     if (typeof rule.name === "string" && disabled.has(rule.name)) continue;
     let re;
-    try { re = new RegExp(rule.pattern); } catch { continue; }
+    try { re = new RegExp(rule.pattern); } catch {
+      if (enforcement === "fail_closed") {
+        decisions.push({
+          decision: "deny",
+          reason: `fail-closed enforcement: ${source} gate rule '${rule.name ?? "rule"}' has an invalid pattern`,
+        });
+      }
+      continue;
+    }
     for (const segment of splitCompound(command)) {
       if (re.test(segment)) {
         decisions.push({

--- a/plugin-hooks/dispatcher.mjs
+++ b/plugin-hooks/dispatcher.mjs
@@ -221,21 +221,30 @@ async function onPreToolUse(cfg) {
     if (fs.existsSync(guardrailsPath)) {
       try {
         const toolkit = await loadToolkit();
-        if (toolkit) {
+        if (toolkit && typeof toolkit.findBlockingRule === "function") {
           const { findBlockingRule, defaultDenyMessage, loadGuardrailManifest } = toolkit;
-          if (typeof findBlockingRule === "function") {
-            const manifest = loadGuardrailManifest(guardrailsPath);
-            const match = findBlockingRule(command, [manifest]);
-            if (match) {
-              decisions.push({
-                decision: "deny",
-                reason: defaultDenyMessage(match),
-              });
-            }
+          const manifest = loadGuardrailManifest(guardrailsPath);
+          const match = findBlockingRule(command, [manifest]);
+          if (match) {
+            decisions.push({
+              decision: "deny",
+              reason: defaultDenyMessage(match),
+            });
           }
+        } else if (effectiveEnforcement(undefined) === "fail_closed") {
+          decisions.push({
+            decision: "deny",
+            reason: "fail-closed enforcement: db guardrail engine is unavailable",
+          });
         }
       } catch (err) {
         process.stderr.write(`dispatcher: db-guard failed (${err.message})\n`);
+        if (effectiveEnforcement(undefined) === "fail_closed") {
+          decisions.push({
+            decision: "deny",
+            reason: `fail-closed enforcement: db guardrail manifest could not be evaluated (${err.message})`,
+          });
+        }
       }
     }
   }

--- a/plugins/db-connector/gates.json
+++ b/plugins/db-connector/gates.json
@@ -1,0 +1,37 @@
+{
+  "version": 1,
+  "name": "db-strict",
+  "enforcement": "fail_closed",
+  "rules": [
+    {
+      "name": "python_db_driver_import",
+      "decision": "deny",
+      "reason": "Importing a database driver in-process bypasses the connector. Route DB access through the sanctioned connector instead.",
+      "pattern": "[iI][mM][pP][oO][rR][tT]\\s+(psycopg2|psycopg|pymysql|MySQLdb|sqlite3|pymongo|pyodbc|asyncpg|sqlalchemy)\\b|[fF][rR][oO][mM]\\s+(psycopg2|psycopg|pymysql|MySQLdb|sqlite3|pymongo|pyodbc|asyncpg|sqlalchemy)\\s+[iI][mM][pP][oO][rR][tT]\\b"
+    },
+    {
+      "name": "node_db_driver_require",
+      "decision": "deny",
+      "reason": "Requiring a database driver in-process bypasses the connector. Route DB access through the sanctioned connector instead.",
+      "pattern": "[rR][eE][qQ][uU][iI][rR][eE]\\s*\\(\\s*['\"\\\\]+(pg|mysql2|mysql|mongodb|mssql|tedious|better-sqlite3|sqlite3|oracledb)['\"\\\\]+\\s*\\)"
+    },
+    {
+      "name": "jdbc_url",
+      "decision": "deny",
+      "reason": "A JDBC connection URL bypasses the connector. Route DB access through the sanctioned connector instead.",
+      "pattern": "[jJ][dD][bB][cC]:(postgresql|mysql|mariadb|sqlserver|oracle|sqlite|mongodb)://"
+    },
+    {
+      "name": "node_db_client_construct",
+      "decision": "deny",
+      "reason": "Constructing a database client in-process bypasses the connector. Route DB access through the sanctioned connector instead.",
+      "pattern": "[nN][eE][wW]\\s+(Pool|Client)\\s*\\([^)]*\\b(host|port|database|connectionString|user|password)\\b"
+    },
+    {
+      "name": "raw_dml_exec",
+      "decision": "deny",
+      "reason": "Executing raw DML/DDL inline bypasses the connector. Route DB access through the sanctioned connector instead.",
+      "pattern": "(-c\\b|-e\\b|--eval\\b|--command\\b|--query\\b|python3?|node|deno|ruby|perl|php)\\b.*([iI][nN][sS][eE][rR][tT]\\s+[iI][nN][tT][oO]|[uU][pP][dD][aA][tT][eE]\\s+.+\\s+[sS][eE][tT]\\b|[dD][eE][lL][eE][tT][eE]\\s+[fF][rR][oO][mM]|[dD][rR][oO][pP]\\s+[tT][aA][bB][lL][eE]|[tT][rR][uU][nN][cC][aA][tT][eE]\\s+([tT][aA][bB][lL][eE]\\s+)?)"
+    }
+  ]
+}

--- a/plugins/db-connector/hooks/hooks.json
+++ b/plugins/db-connector/hooks/hooks.json
@@ -16,7 +16,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "Bash",
+        "matcher": "Bash|Write|Edit",
         "hooks": [
           {
             "type": "command",

--- a/src/connectors/db/connector.ts
+++ b/src/connectors/db/connector.ts
@@ -43,6 +43,10 @@ const queryParams = z.object({
   approval_mode: z.string().optional(),
   max_rows: z.coerce.number().int().positive().default(1000),
   timeout_ms: z.coerce.number().int().positive().default(30000),
+  // Explicit per-run approval for grant_required: issues a read grant for the
+  // configured window so subsequent reads are allowed without re-prompting.
+  // Absent/false leaves the gate intact (default behavior unchanged).
+  approve_grant: z.coerce.boolean().optional(),
 });
 
 const schemaParams = z.object({

--- a/src/connectors/db/dispatcher.ts
+++ b/src/connectors/db/dispatcher.ts
@@ -32,6 +32,12 @@ import {
   type OperationType,
 } from "./lib/policy.js";
 import { executeQuery, type QueryableDriver } from "./lib/query.js";
+import {
+  FileGrantStore,
+  grantStorePathFor,
+  shouldIssueReadGrant,
+  type GrantStore,
+} from "./lib/grant-store.js";
 import { SQLiteDriver } from "./lib/drivers/sqlite.js";
 import type {
   DatabaseDriver,
@@ -70,6 +76,10 @@ interface QueryParamsValidated {
   approval_mode?: string;
   max_rows: number;
   timeout_ms: number;
+  // Explicit per-run approval for grant_required: when true, authorizes a
+  // read grant for the configured window. Absent/false leaves the gate
+  // intact (default behavior unchanged).
+  approve_grant?: boolean;
 }
 
 interface SchemaParamsValidated {
@@ -164,6 +174,12 @@ function validateQueryParams(p: Params): QueryParamsValidated {
   if (typeof approval === "string" && approval.length > 0) {
     v.approval_mode = approval;
   }
+  // Truthy `approve_grant` (boolean true or the string "true") opts this run
+  // into issuing a read grant under grant_required. Anything else is ignored.
+  const approveGrant = p["approve_grant"];
+  if (approveGrant === true || approveGrant === "true") {
+    v.approve_grant = true;
+  }
   return v;
 }
 
@@ -197,6 +213,7 @@ export function _preCheckPolicy(
   sql: string,
   approvalMode: string,
   rules: PolicyRules,
+  grantStore?: GrantStore,
 ): { response: FetchResult; exitCode: number } | null {
   let ops: OperationType[];
   try {
@@ -219,7 +236,10 @@ export function _preCheckPolicy(
 
   let policy: Policy;
   try {
-    policy = new Policy(approvalMode, rules);
+    policy =
+      grantStore !== undefined
+        ? new Policy(approvalMode, rules, grantStore)
+        : new Policy(approvalMode, rules);
   } catch (e) {
     return {
       response: {
@@ -636,12 +656,38 @@ async function runOnEnv(
     };
   }
 
+  // Durable grants for grant_required: back the policy with a file store
+  // keyed by server alias so a grant issued in one (short-lived) invocation
+  // is visible to the next, and distinct DB targets never share a grant.
+  // The SAME instance is passed to the pre-check and execution policies so
+  // they agree within this run. Other modes keep the default in-process
+  // store (behavior unchanged).
+  let grantStore: GrantStore | undefined;
+  if (approvalMode === "grant_required" || grantDurationHours !== undefined) {
+    grantStore = new FileGrantStore(grantStorePathFor(serverName));
+  }
+
+  // Issuance: an explicit `approve_grant` on this run is the human approval
+  // authorizing reads against this target for the window. Record the grant
+  // BEFORE the gate so the approved read is permitted to run and subsequent
+  // reads within the window need no re-prompt. Without the flag nothing is
+  // seeded, so the gate stands by default. Only `read` is ever granted.
+  if (action === "query" && grantStore !== undefined) {
+    const q = v as QueryParamsValidated;
+    if (shouldIssueReadGrant(approvalMode, q.approve_grant === true)) {
+      const ttlSeconds =
+        grantDurationHours !== undefined ? grantDurationHours * 3600 : 300;
+      const issuer = new Policy(approvalMode, rules, grantStore);
+      issuer.addGrant("read", ttlSeconds);
+    }
+  }
+
   // Pre-connect policy gate: short-circuit deny/escalate/present_only
   // before we load any driver or open any connection. This is the
   // load-bearing invariant documented in CLAUDE.md and the plugin spec.
   if (action === "query") {
     const q = v as QueryParamsValidated;
-    const short = _preCheckPolicy(q.sql, approvalMode, rules);
+    const short = _preCheckPolicy(q.sql, approvalMode, rules, grantStore);
     if (short !== null) {
       clearEnvironments();
       return short.response;
@@ -672,11 +718,13 @@ async function runOnEnv(
       );
     }
     const qv = v as QueryParamsValidated;
-    const policy = new Policy(approvalMode, rules);
-    // Silence unused-var lint for metadata we carry for future audit
-    // enrichment — keeping the shape so callers can add grant checks later
-    // without re-plumbing.
-    void grantDurationHours;
+    // Under grant_required, share the same FileGrantStore the pre-check used
+    // so a persisted (or just-issued) read grant is honored here; other modes
+    // use the default in-process store.
+    const policy =
+      grantStore !== undefined
+        ? new Policy(approvalMode, rules, grantStore)
+        : new Policy(approvalMode, rules);
     const queryable = adaptDriver(conn.driver, conn.native);
     return await executeQuery(queryable, qv.sql, policy, {
       max_rows: qv.max_rows,

--- a/src/connectors/db/lib/audit.ts
+++ b/src/connectors/db/lib/audit.ts
@@ -14,6 +14,7 @@
  */
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
+import * as path from "node:path";
 
 // Module-level state
 const _state = {
@@ -29,6 +30,14 @@ const _state = {
 export function enableAudit(filePath: string, sessionId?: string | null): void {
   _state.enabled = true;
   _state.path = filePath;
+  // Create the parent directory up front so the first append does not
+  // silently drop the record when the directory is missing. Wrapped so
+  // enableAudit preserves its never-throw contract.
+  try {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  } catch {
+    // best-effort; a write failure later is still swallowed in _writeRecord
+  }
   _state.sessionId =
     sessionId !== undefined && sessionId !== null
       ? sessionId

--- a/src/connectors/db/lib/grant-store.ts
+++ b/src/connectors/db/lib/grant-store.ts
@@ -1,0 +1,166 @@
+/**
+ * grant-store.ts — pluggable backing store for time-limited read grants.
+ *
+ * The db connector runs as a fresh short-lived subprocess per invocation,
+ * so an in-process `Map` of grants never survives between invocations. This
+ * module abstracts grant storage behind a tiny interface so the `Policy`
+ * engine can be backed either by:
+ *
+ *  - `MemoryGrantStore` (DEFAULT) — a process-local `Map`. Preserves the
+ *    historical single-process behavior; grants vanish when the process
+ *    exits. Used everywhere except `grant_required` wiring.
+ *  - `FileGrantStore` — a JSON file on disk keyed by grant type, so a grant
+ *    issued in one invocation is visible to the next. Expiry values are
+ *    wall-clock epoch milliseconds (`Date.now()`-based) precisely because
+ *    they must be comparable across processes; a process-relative clock
+ *    (`performance.now()`) would be meaningless once serialized.
+ *
+ * Both stores expose the same `get`/`set` contract. They never throw out of
+ * `get`/`set`: all IO errors (missing dir, corrupt JSON, permission denied)
+ * are swallowed and treated as "no grant", which fails safe to denial under
+ * `grant_required`.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+/**
+ * Storage contract for grant expiries. Keys are grant types (only `"read"`
+ * is ever issued in practice); values are wall-clock epoch-ms expiry
+ * timestamps. `get` returns `undefined` when no grant is recorded.
+ */
+export interface GrantStore {
+  get(grantType: string): number | undefined;
+  set(grantType: string, expiryEpochMs: number): void;
+}
+
+/**
+ * In-process grant store backed by a `Map`. This is the DEFAULT and matches
+ * the connector's historical behavior: grants live only as long as the
+ * process and never persist across invocations.
+ */
+export class MemoryGrantStore implements GrantStore {
+  private readonly _grants: Map<string, number> = new Map();
+
+  get(grantType: string): number | undefined {
+    return this._grants.get(grantType);
+  }
+
+  set(grantType: string, expiryEpochMs: number): void {
+    this._grants.set(grantType, expiryEpochMs);
+  }
+}
+
+/**
+ * File-backed grant store. Persists a flat JSON object
+ * `{ [grantType]: expiryEpochMs }` at `filePath`, enabling cross-process
+ * grant visibility for the `grant_required` approval mode.
+ *
+ * Fail-safe semantics (never throw out of get/set):
+ *  - A missing file reads as empty (no grants).
+ *  - A corrupt/unparseable file reads as empty (no grants) — a damaged file
+ *    must never be interpreted as an active grant.
+ *  - Writes are ATOMIC: serialized to a temp sibling file then `rename`d into
+ *    place, so a reader never observes a half-written file and a crash mid-
+ *    write cannot corrupt the canonical file.
+ *  - The parent directory is created on demand (`recursive`).
+ */
+export class FileGrantStore implements GrantStore {
+  private readonly _filePath: string;
+
+  constructor(filePath: string) {
+    this._filePath = filePath;
+  }
+
+  get(grantType: string): number | undefined {
+    const data = this._readAll();
+    const value = data[grantType];
+    return typeof value === "number" ? value : undefined;
+  }
+
+  set(grantType: string, expiryEpochMs: number): void {
+    try {
+      const dir = path.dirname(this._filePath);
+      fs.mkdirSync(dir, { recursive: true });
+      const data = this._readAll();
+      data[grantType] = expiryEpochMs;
+      // Atomic write: serialize to a unique temp sibling, then rename.
+      // rename(2) is atomic within a filesystem, so a concurrent reader
+      // sees either the old file or the fully-written new one.
+      const tmpPath = `${this._filePath}.tmp-${process.pid}-${Date.now()}`;
+      fs.writeFileSync(tmpPath, JSON.stringify(data), { encoding: "utf-8" });
+      try {
+        fs.renameSync(tmpPath, this._filePath);
+      } catch (err) {
+        // Clean up the temp file if the rename failed so we don't leak it.
+        try {
+          fs.unlinkSync(tmpPath);
+        } catch {
+          /* best-effort cleanup */
+        }
+        throw err;
+      }
+    } catch {
+      // Fail safe: a store that cannot persist simply yields no grant on the
+      // next read, which denies under grant_required. Never propagate.
+    }
+  }
+
+  /**
+   * Read and parse the backing file. Returns an empty object for any failure
+   * (missing file, unreadable, malformed JSON, non-object root), so a corrupt
+   * file can never be read as an active grant.
+   */
+  private _readAll(): Record<string, number> {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(this._filePath, { encoding: "utf-8" });
+    } catch {
+      return {};
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return {};
+    }
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return parsed as Record<string, number>;
+  }
+}
+
+/**
+ * Stable on-disk location for a server's persisted grants, under the
+ * connector's config dir (`~/.config/wiki_db/grants/`). Keyed by the server
+ * alias so distinct DB targets never share a grant: approving reads on
+ * `staging` must not unlock `prod`. The alias is sanitized to a filesystem-
+ * safe token so arbitrary server names cannot escape the grants directory.
+ */
+export function grantStorePathFor(serverName: string): string {
+  const safe = serverName.replace(/[^A-Za-z0-9_.-]/g, "_") || "_";
+  return path.join(os.homedir(), ".config", "wiki_db", "grants", `${safe}.json`);
+}
+
+/**
+ * Pure issuance decision for the "approve-once-then-allow-for-window"
+ * semantics under `grant_required`.
+ *
+ * A read grant is issued ONLY when BOTH:
+ *  - the approval mode is `grant_required` (the only mode gated on grants); and
+ *  - the caller passed an explicit per-run approval signal
+ *    (`approveGrant === true`).
+ *
+ * The explicit `approve_grant` flag IS the human approval: it represents a
+ * person authorizing reads against this target for the configured window.
+ * Absent the flag, this returns false, so nothing is ever auto-seeded and the
+ * gate stands — a first read with no flag and no prior grant still denies.
+ * Only `read` grants are ever issued (admin/privilege are never grantable).
+ */
+export function shouldIssueReadGrant(
+  approvalMode: string,
+  approveGrant: boolean,
+): boolean {
+  return approvalMode === "grant_required" && approveGrant === true;
+}

--- a/src/connectors/db/lib/policy.ts
+++ b/src/connectors/db/lib/policy.ts
@@ -21,11 +21,11 @@
  * method without going through the SQL keyword path. Policy.checkQuery
  * accepts an optional driver and dispatches accordingly.
  */
-import { performance } from "node:perf_hooks";
 import type { PolicyDecision } from "narai-primitives/config";
 import type { DatabaseDriver } from "./drivers/base.js";
 import { logEvent, scrubSqlSecrets } from "./audit.js";
 import { DEFAULT_POLICY, type PolicyRules } from "./plugin_config.js";
+import { MemoryGrantStore, type GrantStore } from "./grant-store.js";
 
 /**
  * Possible outcomes of a db-internal policy check (wire format = lowercase
@@ -219,7 +219,11 @@ export class Policy {
   private readonly _approval_mode: ApprovalMode;
   private readonly _rules: PolicyRules;
   private _session_approved: boolean;
-  private readonly _grants: Map<string, number>; // grant_type -> expiry (ms, performance.now())
+  // grant_type -> expiry (wall-clock epoch ms). Backed by an injectable
+  // store so grants can persist across the connector's short-lived
+  // subprocess invocations (FileGrantStore) or stay in-process (default
+  // MemoryGrantStore).
+  private readonly _grants: GrantStore;
   // G-DB-AUDIT: grant_types that have already had a `grant_expired` event
   // emitted (de-dupes spam from repeated isGrantActive polling).
   private readonly _expired_logged: Set<string>;
@@ -227,6 +231,7 @@ export class Policy {
   constructor(
     approvalMode: string = "auto",
     rules: PolicyRules = DEFAULT_POLICY,
+    grantStore: GrantStore = new MemoryGrantStore(),
   ) {
     if (!_VALID_APPROVAL_MODES.has(approvalMode as ApprovalMode)) {
       // Match Python repr(): single-quoted string.
@@ -235,7 +240,7 @@ export class Policy {
     this._approval_mode = approvalMode as ApprovalMode;
     this._rules = rules;
     this._session_approved = false;
-    this._grants = new Map();
+    this._grants = grantStore;
     this._expired_logged = new Set();
   }
 
@@ -467,15 +472,18 @@ export class Policy {
    *
    * G-DB-AUDIT: emits a `grant_added` event with the grant type and TTL.
    *
-   * Lifetime scope: grants are in-process only. Expiry is measured with
-   * `performance.now()`, which is reset on every Node process start, so
-   * a new CLI invocation always begins with no active grants — even if
-   * a previous run added one seconds ago. Suitable for the CLI's
-   * single-invocation model; not suitable as a cross-process gate.
+   * Lifetime scope: depends on the injected `GrantStore`. With the default
+   * `MemoryGrantStore`, grants live only for the current process. With a
+   * `FileGrantStore`, they persist to disk and are visible to later CLI
+   * invocations. Expiry is recorded as a wall-clock epoch timestamp
+   * (`Date.now()`), which is required for cross-process comparison — a
+   * process-relative clock (`performance.now()`) would be meaningless once
+   * serialized and read by a different process.
    */
   addGrant(grantType: string, ttlSeconds: number = 300): void {
-    // performance.now() is process-relative; see JSDoc for lifetime scope.
-    this._grants.set(grantType, performance.now() + ttlSeconds * 1000);
+    // Date.now() is wall-clock epoch ms so the expiry survives serialization
+    // and is comparable across processes; see JSDoc for lifetime scope.
+    this._grants.set(grantType, Date.now() + ttlSeconds * 1000);
     logEvent({
       event_type: "grant_added",
       details: { grant_type: grantType, ttl_seconds: ttlSeconds },
@@ -492,7 +500,7 @@ export class Policy {
   isGrantActive(grantType: string): boolean {
     const expiry = this._grants.get(grantType);
     if (expiry === undefined) return false;
-    if (performance.now() < expiry) return true;
+    if (Date.now() < expiry) return true;
     if (!this._expired_logged.has(grantType)) {
       this._expired_logged.add(grantType);
       logEvent({
@@ -512,13 +520,11 @@ export class Policy {
  * low-level primitive (5-minute default, used for short-lived operations
  * like test scaffolding and administrative confirmations).
  *
- * Lifetime scope: grants live in memory only. Because `addGrant` uses
- * `performance.now()` — a process-relative monotonic clock — a grant
- * written in one CLI invocation does NOT carry into the next one, even
- * if `grant_duration_hours=8`. The "8 hour" default means "up to 8
- * wall-clock hours within a single long-running session," not "8
- * wall-clock hours across reboots." Persisting grants to disk is out
- * of scope for v2.
+ * Lifetime scope: depends on the `GrantStore` injected into `policy`.
+ * `addGrant` records a wall-clock epoch expiry (`Date.now()`), so with a
+ * `FileGrantStore` a grant written in one CLI invocation carries into the
+ * next for up to `grant_duration_hours`. With the default `MemoryGrantStore`
+ * the grant lives only for the current process.
  */
 export function grantFromEnv(
   policy: Policy,

--- a/src/toolkit/guardrail.ts
+++ b/src/toolkit/guardrail.ts
@@ -10,8 +10,11 @@
  *     so every consumer (the per-connector hooks AND the hub's unified hook)
  *     evaluates the same way.
  *
- * Best-effort, not a security boundary. The engine fails open on parse
- * errors; callers are expected to handle missing/invalid manifests gracefully.
+ * Best-effort by default: the engine fails open on parse errors, so the
+ * default posture is not a security boundary. An opt-in fail-closed mode
+ * (the NARAI_GATE_ENFORCEMENT env var / a manifest `enforcement` field,
+ * applied by the PreToolUse dispatcher) turns parse and compile failures
+ * into hard denies. Callers still handle missing/invalid manifests.
  */
 
 import * as fs from "node:fs";
@@ -41,6 +44,13 @@ export interface GuardrailManifest {
   /** Source connector name; surfaces in deny messages. */
   name: string;
   rules: GuardrailRule[];
+  /**
+   * Optional opt-in enforcement posture for evaluating this manifest. When
+   * "fail_closed", failures to evaluate a rule become hard denies. Defaults
+   * to fail-open (best-effort) when absent. Applied by the PreToolUse
+   * dispatcher together with the NARAI_GATE_ENFORCEMENT env var.
+   */
+  enforcement?: "fail_open" | "fail_closed";
 }
 
 export interface BlockMatch {
@@ -90,7 +100,20 @@ function validateManifest(value: unknown, filePath: string): GuardrailManifest {
     }
     return r as GuardrailRule;
   });
-  return { version: 1, name: obj["name"] as string, rules };
+  const manifest: GuardrailManifest = {
+    version: 1,
+    name: obj["name"] as string,
+    rules,
+  };
+  if (obj["enforcement"] !== undefined) {
+    if (obj["enforcement"] !== "fail_open" && obj["enforcement"] !== "fail_closed") {
+      throw new Error(
+        `Guardrail manifest at ${filePath}: 'enforcement' must be "fail_open" or "fail_closed".`,
+      );
+    }
+    manifest.enforcement = obj["enforcement"];
+  }
+  return manifest;
 }
 
 /**

--- a/tests/connectors/db/audit.test.ts
+++ b/tests/connectors/db/audit.test.ts
@@ -203,6 +203,17 @@ describe("wiki_db.audit", () => {
     }
   });
 
+  // ---------- 10. creates parent directories ----------
+  it("creates parent directories for the audit file", () => {
+    const logPath = path.join(tmpPath, "nested", "deep", "events.jsonl");
+    enableAudit(logPath, "mkdir-test");
+    logEvent({ event_type: "guardrail_deny", details: { rule: "x" } });
+    expect(fs.existsSync(logPath)).toBe(true);
+    const record = JSON.parse(fs.readFileSync(logPath, "utf-8").trim()) as
+      Record<string, unknown>;
+    expect(record["event_type"]).toBe("guardrail_deny");
+  });
+
   // ---------- scrubSqlSecrets unit tests ----------
   it("scrubSqlSecrets masks single-quoted credential literals", () => {
     expect(

--- a/tests/connectors/db/cli_env.test.ts
+++ b/tests/connectors/db/cli_env.test.ts
@@ -726,3 +726,107 @@ describe("cli env plugin config (V2.0 ~/.connectors/config.yaml)", () => {
     expect(result.error_code).toBe("CONFIG_ERROR");
   });
 });
+
+describe("cli grant_required durable grants", () => {
+  let tmp: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "db-grant-cli-"));
+    // Redirect the grant store dir (~/.config/wiki_db/grants) into tmp so the
+    // FileGrantStore writes are isolated from the real home directory.
+    origHome = process.env["HOME"];
+    process.env["HOME"] = tmp;
+    clearEnvironments();
+  });
+  afterEach(() => {
+    clearEnvironments();
+    if (origHome !== undefined) process.env["HOME"] = origHome;
+    else delete process.env["HOME"];
+    try {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  it("denies a read with no grant, then allows after an approved run persists one", async () => {
+    const dbPath = makeFixtureDb(tmp);
+    const configPath = makeConfig(tmp, {
+      prod: {
+        driver: "sqlite",
+        database: dbPath,
+        schema: "",
+        approval_mode: "grant_required",
+      },
+    });
+    const sql = "SELECT name FROM users WHERE id = 1";
+
+    // 1. No grant yet → denied (gate intact).
+    const out1 = await captureStdout(async () => {
+      const code = await main(
+        argsFor("query", { env: "prod", config_path: configPath, sql }),
+      );
+      expect(code).toBe(1);
+    });
+    expect((parseResult(out1) as { status: string }).status).toBe("denied");
+
+    // 2. Approved run (approve_grant) → executes AND persists a read grant.
+    const out2 = await captureStdout(async () => {
+      const code = await main(
+        argsFor("query", {
+          env: "prod",
+          config_path: configPath,
+          sql,
+          approve_grant: true,
+        }),
+      );
+      expect(code).toBe(0);
+    });
+    expect((parseResult(out2) as { status: string }).status).toBe("ok");
+
+    // 3. Fresh invocation, NO approve flag → still allowed (grant persisted).
+    const out3 = await captureStdout(async () => {
+      const code = await main(
+        argsFor("query", { env: "prod", config_path: configPath, sql }),
+      );
+      expect(code).toBe(0);
+    });
+    expect((parseResult(out3) as { status: string }).status).toBe("ok");
+  });
+
+  it("never lets a grant unlock a PRIVILEGE statement", async () => {
+    const dbPath = makeFixtureDb(tmp);
+    const configPath = makeConfig(tmp, {
+      prod: {
+        driver: "sqlite",
+        database: dbPath,
+        schema: "",
+        approval_mode: "grant_required",
+      },
+    });
+    // Approve to issue a read grant.
+    await captureStdout(async () => {
+      await main(
+        argsFor("query", {
+          env: "prod",
+          config_path: configPath,
+          sql: "SELECT name FROM users WHERE id = 1",
+          approve_grant: true,
+        }),
+      );
+    });
+    // A privilege statement must still be denied (privilege: deny).
+    const out = await captureStdout(async () => {
+      const code = await main(
+        argsFor("query", {
+          env: "prod",
+          config_path: configPath,
+          sql: "GRANT SELECT ON users TO someone",
+        }),
+      );
+      expect(code).toBe(1);
+    });
+    expect((parseResult(out) as { status: string }).status).toBe("denied");
+  });
+});

--- a/tests/connectors/db/grant_store.test.ts
+++ b/tests/connectors/db/grant_store.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for grant-store.ts and Policy grant persistence.
+ *
+ * Covers the cross-process persistence guarantee that the in-process Map
+ * could not provide: a grant written by one Policy instance (simulating
+ * CLI invocation A) is visible to a second Policy instance pointed at the
+ * same file (invocation B), so a read is allowed without re-prompting.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import {
+  FileGrantStore,
+  MemoryGrantStore,
+  grantStorePathFor,
+  shouldIssueReadGrant,
+} from "../../../src/connectors/db/lib/grant-store.js";
+import { Decision, Policy } from "../../../src/connectors/db/lib/policy.js";
+import { DEFAULT_POLICY } from "../../../src/connectors/db/lib/plugin_config.js";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "db-grant-store-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("FileGrantStore", () => {
+  it("persists a value across two instances at the same path", () => {
+    const p = path.join(tmpDir, "grants.json");
+    const expiry = Date.now() + 60_000;
+    const writer = new FileGrantStore(p);
+    writer.set("read", expiry);
+
+    // A second, independent instance (simulating a fresh process) reads it.
+    const reader = new FileGrantStore(p);
+    expect(reader.get("read")).toBe(expiry);
+  });
+
+  it("creates parent directories on demand", () => {
+    const p = path.join(tmpDir, "nested", "deeper", "grants.json");
+    const store = new FileGrantStore(p);
+    store.set("read", Date.now() + 1000);
+    expect(fs.existsSync(p)).toBe(true);
+  });
+
+  it("treats a missing file as empty (no grant)", () => {
+    const store = new FileGrantStore(path.join(tmpDir, "absent.json"));
+    expect(store.get("read")).toBeUndefined();
+  });
+
+  it("treats a corrupt file as empty (no grant), without throwing", () => {
+    const p = path.join(tmpDir, "corrupt.json");
+    fs.writeFileSync(p, "{not valid json", "utf-8");
+    const store = new FileGrantStore(p);
+    expect(() => store.get("read")).not.toThrow();
+    expect(store.get("read")).toBeUndefined();
+  });
+
+  it("does not leave temp files behind after an atomic write", () => {
+    const p = path.join(tmpDir, "grants.json");
+    const store = new FileGrantStore(p);
+    store.set("read", Date.now() + 1000);
+    store.set("read", Date.now() + 2000);
+    const leftovers = fs
+      .readdirSync(tmpDir)
+      .filter((f) => f.includes(".tmp-"));
+    expect(leftovers).toEqual([]);
+  });
+});
+
+describe("Policy with injected FileGrantStore", () => {
+  it("sees a grant added by a separate Policy at the same path (cross-process)", () => {
+    const p = path.join(tmpDir, "grants.json");
+
+    // Process A: grant_required, issue a read grant, then exit.
+    const policyA = new Policy(
+      "grant_required",
+      DEFAULT_POLICY,
+      new FileGrantStore(p),
+    );
+    policyA.addGrant("read", 300);
+
+    // Process B: fresh Policy, fresh FileGrantStore, same path. With the old
+    // in-process Map (or performance.now()) this would deny; persistence +
+    // wall-clock epoch make it allow.
+    const policyB = new Policy(
+      "grant_required",
+      DEFAULT_POLICY,
+      new FileGrantStore(p),
+    );
+    const result = policyB.checkQuery("SELECT 1");
+    expect(result.decision).toBe(Decision.ALLOW);
+  });
+
+  it("denies when the persisted grant is already expired", () => {
+    const p = path.join(tmpDir, "grants.json");
+    const store = new FileGrantStore(p);
+    // Write an expiry firmly in the past.
+    store.set("read", Date.now() - 60_000);
+
+    const policy = new Policy("grant_required", DEFAULT_POLICY, store);
+    const result = policy.checkQuery("SELECT 1");
+    expect(result.decision).toBe(Decision.DENY);
+  });
+
+  it("denies when the backing file is corrupt (fail-safe)", () => {
+    const p = path.join(tmpDir, "grants.json");
+    fs.writeFileSync(p, "garbage", "utf-8");
+    const policy = new Policy(
+      "grant_required",
+      DEFAULT_POLICY,
+      new FileGrantStore(p),
+    );
+    expect(policy.checkQuery("SELECT 1").decision).toBe(Decision.DENY);
+  });
+
+  it("never lets a grant allow an ADMIN statement", () => {
+    const p = path.join(tmpDir, "grants.json");
+    const policyA = new Policy(
+      "grant_required",
+      DEFAULT_POLICY,
+      new FileGrantStore(p),
+    );
+    // Even if someone tries to grant admin/privilege, the rule for admin is
+    // 'present' and never reaches the grant gate.
+    policyA.addGrant("read", 300);
+    policyA.addGrant("admin", 300);
+    policyA.addGrant("privilege", 300);
+
+    const policyB = new Policy(
+      "grant_required",
+      DEFAULT_POLICY,
+      new FileGrantStore(p),
+    );
+    expect(policyB.checkQuery("DROP TABLE users").decision).not.toBe(
+      Decision.ALLOW,
+    );
+    expect(policyB.checkQuery("GRANT SELECT ON t TO u").decision).not.toBe(
+      Decision.ALLOW,
+    );
+  });
+});
+
+describe("grantStorePathFor", () => {
+  it("keys distinct servers to distinct files (no cross-target leakage)", () => {
+    expect(grantStorePathFor("staging")).not.toBe(grantStorePathFor("prod"));
+  });
+
+  it("sanitizes unsafe server names so they cannot escape the grants dir", () => {
+    const p = grantStorePathFor("../../etc/passwd");
+    // The filename must contain no path separators or traversal segments, so
+    // it stays inside the grants directory regardless of the input.
+    const base = path.basename(p);
+    expect(base).not.toContain(path.sep);
+    expect(base).not.toContain("/");
+    expect(path.dirname(p).endsWith(path.join("wiki_db", "grants"))).toBe(true);
+  });
+});
+
+describe("shouldIssueReadGrant", () => {
+  it("issues only under grant_required with explicit approval", () => {
+    expect(shouldIssueReadGrant("grant_required", true)).toBe(true);
+  });
+
+  it("never issues without the explicit approval flag (gate preserved)", () => {
+    expect(shouldIssueReadGrant("grant_required", false)).toBe(false);
+  });
+
+  it("never issues outside grant_required", () => {
+    expect(shouldIssueReadGrant("auto", true)).toBe(false);
+    expect(shouldIssueReadGrant("confirm_once", true)).toBe(false);
+  });
+});
+
+describe("MemoryGrantStore (default) preserves single-process behavior", () => {
+  it("holds a grant within one Policy instance", () => {
+    const policy = new Policy("grant_required", DEFAULT_POLICY);
+    expect(policy.checkQuery("SELECT 1").decision).toBe(Decision.DENY);
+    policy.addGrant("read", 300);
+    expect(policy.checkQuery("SELECT 1").decision).toBe(Decision.ALLOW);
+  });
+
+  it("does not share grants across two separate Policy instances", () => {
+    const a = new Policy("grant_required", DEFAULT_POLICY, new MemoryGrantStore());
+    a.addGrant("read", 300);
+    const b = new Policy("grant_required", DEFAULT_POLICY, new MemoryGrantStore());
+    // Distinct memory stores: B has no grant.
+    expect(b.checkQuery("SELECT 1").decision).toBe(Decision.DENY);
+  });
+});

--- a/tests/connectors/db/layered_config.test.ts
+++ b/tests/connectors/db/layered_config.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Regression: locks in the existing two-level user+repo config overlay for
+ * the `db` connector. A repo-level `<cwd>/.connectors/config.yaml` overlays
+ * the user-level `~/.connectors/config.yaml` (repo wins), and the resolved
+ * slice still passes through `pluginConfigFromSlice` -> `validateServer`, so
+ * the admin/privilege safety floor cannot be lifted by an overlay.
+ *
+ * Isolation: the loader reads `os.homedir()` for the user file, which honors
+ * `process.env.HOME` on this platform, and accepts an explicit `cwd` for the
+ * repo file. We point both at fresh temp dirs so the test never touches the
+ * developer's real `~/.connectors/config.yaml` or actual cwd.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { loadResolvedConfig } from "../../../src/config/load.js";
+import {
+  mergePolicy,
+  pluginConfigFromSlice,
+} from "../../../src/connectors/db/lib/plugin_config.js";
+
+let tmpHome: string;
+let tmpCwd: string;
+const originalHome = process.env["HOME"];
+
+function writeUserConfig(body: string): void {
+  const dir = path.join(tmpHome, ".connectors");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "config.yaml"), body, "utf-8");
+}
+
+function writeRepoConfig(body: string): void {
+  const dir = path.join(tmpCwd, ".connectors");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "config.yaml"), body, "utf-8");
+}
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "db-layered-home-"));
+  tmpCwd = fs.mkdtempSync(path.join(os.tmpdir(), "db-layered-cwd-"));
+  process.env["HOME"] = tmpHome;
+});
+
+afterEach(() => {
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+  fs.rmSync(tmpCwd, { recursive: true, force: true });
+  if (originalHome === undefined) delete process.env["HOME"];
+  else process.env["HOME"] = originalHome;
+});
+
+describe("db layered config (user + repo overlay)", () => {
+  it("repo overlay wins over user for server host and global write policy", async () => {
+    writeUserConfig(
+      [
+        "connectors:",
+        "  db:",
+        "    skill: db-agent-connector",
+        "    policy:",
+        "      write: escalate",
+        "    servers:",
+        "      orders:",
+        "        driver: postgresql",
+        "        host: db.shared.internal",
+        "        database: orders",
+        "",
+      ].join("\n"),
+    );
+    writeRepoConfig(
+      [
+        "connectors:",
+        "  db:",
+        "    policy:",
+        "      write: deny",
+        "    servers:",
+        "      orders:",
+        "        host: db.local.test",
+        "",
+      ].join("\n"),
+    );
+
+    const resolved = await loadResolvedConfig({ cwd: tmpCwd });
+    const slice = resolved.connectors["db"];
+    expect(slice).toBeDefined();
+
+    const cfg = pluginConfigFromSlice(slice!);
+
+    // Repo host wins; user-only keys (driver, database) are inherited.
+    expect(cfg.servers["orders"]?.["host"]).toBe("db.local.test");
+    expect(cfg.servers["orders"]?.driver).toBe("postgresql");
+    expect(cfg.servers["orders"]?.["database"]).toBe("orders");
+
+    // Repo global write policy wins. mergePolicy(global, server) reflects it.
+    const effective = mergePolicy(cfg.policy, cfg.servers["orders"]?.policy);
+    expect(effective.write).toBe("deny");
+  });
+
+  it("per-server repo policy override is merged onto the global policy", async () => {
+    writeUserConfig(
+      [
+        "connectors:",
+        "  db:",
+        "    skill: db-agent-connector",
+        "    servers:",
+        "      orders:",
+        "        driver: sqlite",
+        "        database: base.db",
+        "",
+      ].join("\n"),
+    );
+    writeRepoConfig(
+      [
+        "connectors:",
+        "  db:",
+        "    servers:",
+        "      orders:",
+        "        policy:",
+        "          read: deny",
+        "",
+      ].join("\n"),
+    );
+
+    const resolved = await loadResolvedConfig({ cwd: tmpCwd });
+    const cfg = pluginConfigFromSlice(resolved.connectors["db"]!);
+    const effective = mergePolicy(cfg.policy, cfg.servers["orders"]?.policy);
+    expect(effective.read).toBe("deny");
+  });
+
+  it("uses user-level values when no repo file is present", async () => {
+    writeUserConfig(
+      [
+        "connectors:",
+        "  db:",
+        "    skill: db-agent-connector",
+        "    servers:",
+        "      orders:",
+        "        driver: postgresql",
+        "        host: db.shared.internal",
+        "        database: orders",
+        "",
+      ].join("\n"),
+    );
+
+    const resolved = await loadResolvedConfig({ cwd: tmpCwd });
+    const cfg = pluginConfigFromSlice(resolved.connectors["db"]!);
+    expect(cfg.servers["orders"]?.["host"]).toBe("db.shared.internal");
+  });
+
+  it("repo overlay cannot lift the admin ceiling (validation throws)", async () => {
+    writeUserConfig(
+      [
+        "connectors:",
+        "  db:",
+        "    skill: db-agent-connector",
+        "    servers:",
+        "      orders:",
+        "        driver: sqlite",
+        "        database: base.db",
+        "",
+      ].join("\n"),
+    );
+    writeRepoConfig(
+      [
+        "connectors:",
+        "  db:",
+        "    servers:",
+        "      orders:",
+        "        policy:",
+        "          admin: allow",
+        "",
+      ].join("\n"),
+    );
+
+    const resolved = await loadResolvedConfig({ cwd: tmpCwd });
+    expect(() => pluginConfigFromSlice(resolved.connectors["db"]!)).toThrow(
+      /admin: 'allow' is not permitted/,
+    );
+  });
+
+  it("repo overlay cannot lift the privilege ceiling (validation throws)", async () => {
+    writeUserConfig(
+      [
+        "connectors:",
+        "  db:",
+        "    skill: db-agent-connector",
+        "    servers:",
+        "      orders:",
+        "        driver: sqlite",
+        "        database: base.db",
+        "",
+      ].join("\n"),
+    );
+    writeRepoConfig(
+      [
+        "connectors:",
+        "  db:",
+        "    servers:",
+        "      orders:",
+        "        policy:",
+        "          privilege: allow",
+        "",
+      ].join("\n"),
+    );
+
+    const resolved = await loadResolvedConfig({ cwd: tmpCwd });
+    expect(() => pluginConfigFromSlice(resolved.connectors["db"]!)).toThrow(
+      /privilege: 'allow' is not permitted/,
+    );
+  });
+});

--- a/tests/plugin-hooks/dispatcher_audit.test.ts
+++ b/tests/plugin-hooks/dispatcher_audit.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DISPATCHER = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "plugin-hooks",
+  "dispatcher.mjs",
+);
+
+interface Result { stdout: string; stderr: string; exitCode: number }
+
+function runPreToolUse(opts: {
+  pluginRoot: string;
+  auditPath?: string;
+  stdin: string;
+}): Promise<Result> {
+  const data = fs.mkdtempSync(path.join(os.tmpdir(), "au-data-"));
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "au-home-"));
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "au-cwd-"));
+  const env: Record<string, string> = {
+    ...process.env,
+    CLAUDE_PLUGIN_ROOT: opts.pluginRoot,
+    CLAUDE_PLUGIN_DATA: data,
+    HOME: home,
+  };
+  if (opts.auditPath !== undefined) env.NARAI_AUDIT_PATH = opts.auditPath;
+  else delete env.NARAI_AUDIT_PATH;
+  return new Promise((resolve, reject) => {
+    const proc = spawn("node", [DISPATCHER, "pre-tool-use"], {
+      env,
+      cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "", stderr = "";
+    proc.stdout.on("data", (d: Buffer) => (stdout += d.toString()));
+    proc.stderr.on("data", (d: Buffer) => (stderr += d.toString()));
+    proc.on("close", (code) => resolve({ stdout, stderr, exitCode: code ?? -1 }));
+    proc.on("error", reject);
+    proc.stdin.write(opts.stdin);
+    proc.stdin.end();
+  });
+}
+
+function makeRootWithDenyGate(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "au-root-"));
+  fs.writeFileSync(
+    path.join(root, "plugin-config.json"),
+    JSON.stringify({ name: "test-plugin" }),
+  );
+  fs.writeFileSync(
+    path.join(root, "gates.json"),
+    JSON.stringify({
+      rules: [{ name: "psql", decision: "deny", reason: "blocked", pattern: "psql" }],
+    }),
+  );
+  return root;
+}
+
+const BASH = (command: string) =>
+  JSON.stringify({ tool_name: "Bash", tool_input: { command } });
+
+describe("dispatcher — audit of hook decisions", () => {
+  const roots: string[] = [];
+  afterEach(() => {
+    for (const r of roots) fs.rmSync(r, { recursive: true, force: true });
+    roots.length = 0;
+  });
+
+  it("writes a guardrail_deny record when a command is denied and NARAI_AUDIT_PATH is set", async () => {
+    const root = makeRootWithDenyGate();
+    roots.push(root);
+    const auditDir = fs.mkdtempSync(path.join(os.tmpdir(), "au-log-"));
+    roots.push(auditDir);
+    const auditPath = path.join(auditDir, "events.jsonl");
+    const res = await runPreToolUse({
+      pluginRoot: root,
+      auditPath,
+      stdin: BASH("psql mydb"),
+    });
+    const out = JSON.parse(res.stdout);
+    expect(out.hookSpecificOutput.permissionDecision).toBe("deny");
+    expect(fs.existsSync(auditPath)).toBe(true);
+    const record = JSON.parse(fs.readFileSync(auditPath, "utf-8").trim());
+    expect(record.event_type).toBe("guardrail_deny");
+    expect(record.details.reason).toBe("blocked");
+    expect(record.details.command).toBe("psql mydb");
+  });
+
+  it("does not write an audit record when NARAI_AUDIT_PATH is unset", async () => {
+    const root = makeRootWithDenyGate();
+    roots.push(root);
+    const res = await runPreToolUse({ pluginRoot: root, stdin: BASH("psql mydb") });
+    const out = JSON.parse(res.stdout);
+    expect(out.hookSpecificOutput.permissionDecision).toBe("deny");
+    // No NARAI_AUDIT_PATH -> nothing to assert beyond the decision; ensure no crash.
+    expect(res.exitCode).toBe(0);
+  });
+
+  it("does not write an audit record for an allowed command", async () => {
+    const root = makeRootWithDenyGate();
+    roots.push(root);
+    const auditDir = fs.mkdtempSync(path.join(os.tmpdir(), "au-log-"));
+    roots.push(auditDir);
+    const auditPath = path.join(auditDir, "events.jsonl");
+    const res = await runPreToolUse({
+      pluginRoot: root,
+      auditPath,
+      stdin: BASH("echo hi"),
+    });
+    expect(res.stdout.trim()).toBe("");
+    expect(fs.existsSync(auditPath)).toBe(false);
+  });
+});

--- a/tests/plugin-hooks/dispatcher_content_scan.test.ts
+++ b/tests/plugin-hooks/dispatcher_content_scan.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DISPATCHER = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "plugin-hooks",
+  "dispatcher.mjs",
+);
+
+interface Result { stdout: string; stderr: string; exitCode: number }
+
+function run(pluginRoot: string, stdin: string): Promise<Result> {
+  const data = fs.mkdtempSync(path.join(os.tmpdir(), "cs-data-"));
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "cs-home-"));
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "cs-cwd-"));
+  return new Promise((resolve, reject) => {
+    const proc = spawn("node", [DISPATCHER, "pre-tool-use"], {
+      env: { ...process.env, CLAUDE_PLUGIN_ROOT: pluginRoot, CLAUDE_PLUGIN_DATA: data, HOME: home },
+      cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "", stderr = "";
+    proc.stdout.on("data", (d: Buffer) => (stdout += d.toString()));
+    proc.stderr.on("data", (d: Buffer) => (stderr += d.toString()));
+    proc.on("close", (code) => resolve({ stdout, stderr, exitCode: code ?? -1 }));
+    proc.on("error", reject);
+    proc.stdin.write(stdin);
+    proc.stdin.end();
+  });
+}
+
+function makeRoot(rules: unknown[]): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "cs-root-"));
+  fs.writeFileSync(path.join(root, "plugin-config.json"), JSON.stringify({ name: "test-plugin" }));
+  fs.writeFileSync(path.join(root, "gates.json"), JSON.stringify({ rules }));
+  return root;
+}
+
+const JDBC_RULE = {
+  name: "conn_string",
+  decision: "deny",
+  reason: "connection string",
+  pattern: "jdbc:postgresql://",
+  applies_to: ["Bash", "Write", "Edit"],
+};
+
+describe("dispatcher — Write/Edit content scanning", () => {
+  const roots: string[] = [];
+  afterEach(() => {
+    for (const r of roots) fs.rmSync(r, { recursive: true, force: true });
+    roots.length = 0;
+  });
+
+  it("denies a Write whose content matches an applies_to rule", async () => {
+    const root = makeRoot([JDBC_RULE]);
+    roots.push(root);
+    const res = await run(root, JSON.stringify({
+      tool_name: "Write",
+      tool_input: { file_path: "app.properties", content: "db.url=jdbc:postgresql://h/db\nname=x" },
+    }));
+    const out = JSON.parse(res.stdout);
+    expect(out.hookSpecificOutput.permissionDecision).toBe("deny");
+  });
+
+  it("denies an Edit whose new_string matches; ignores old_string", async () => {
+    const root = makeRoot([JDBC_RULE]);
+    roots.push(root);
+    const deny = await run(root, JSON.stringify({
+      tool_name: "Edit",
+      tool_input: { file_path: "f", old_string: "x", new_string: "jdbc:postgresql://h/db" },
+    }));
+    expect(JSON.parse(deny.stdout).hookSpecificOutput.permissionDecision).toBe("deny");
+
+    const allow = await run(root, JSON.stringify({
+      tool_name: "Edit",
+      tool_input: { file_path: "f", old_string: "jdbc:postgresql://h/db", new_string: "removed" },
+    }));
+    expect(allow.stdout.trim()).toBe("");
+  });
+
+  it("does NOT scan Write content for a rule without applies_to (default Bash-only)", async () => {
+    const root = makeRoot([{ name: "bash_only", decision: "deny", reason: "r", pattern: "jdbc:postgresql://" }]);
+    roots.push(root);
+    const res = await run(root, JSON.stringify({
+      tool_name: "Write",
+      tool_input: { file_path: "f", content: "jdbc:postgresql://h/db" },
+    }));
+    expect(res.stdout.trim()).toBe("");
+  });
+
+  it("still scans Bash commands for the same rule", async () => {
+    const root = makeRoot([JDBC_RULE]);
+    roots.push(root);
+    const res = await run(root, JSON.stringify({
+      tool_name: "Bash",
+      tool_input: { command: "java -jar app --url jdbc:postgresql://h/db" },
+    }));
+    expect(JSON.parse(res.stdout).hookSpecificOutput.permissionDecision).toBe("deny");
+  });
+
+  it("ignores tools that are neither Bash, Write, nor Edit", async () => {
+    const root = makeRoot([JDBC_RULE]);
+    roots.push(root);
+    const res = await run(root, JSON.stringify({
+      tool_name: "Read",
+      tool_input: { file_path: "jdbc:postgresql://h/db" },
+    }));
+    expect(res.stdout.trim()).toBe("");
+  });
+});

--- a/tests/plugin-hooks/dispatcher_failclosed.test.ts
+++ b/tests/plugin-hooks/dispatcher_failclosed.test.ts
@@ -184,3 +184,41 @@ describe("dispatcher gates — fail-closed (subprocess)", () => {
     expect(res.stdout.trim()).toBe("");
   });
 });
+
+function makeDbRoot(guardrailsContent: string): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "fc-dbroot-"));
+  fs.writeFileSync(
+    path.join(root, "plugin-config.json"),
+    JSON.stringify({ name: "db", kind: "db" }),
+  );
+  fs.mkdirSync(path.join(root, "hooks"), { recursive: true });
+  fs.writeFileSync(path.join(root, "hooks", "guardrails.json"), guardrailsContent);
+  return root;
+}
+
+describe("dispatcher db-guard — fail-closed (subprocess)", () => {
+  const roots: string[] = [];
+  afterEach(() => {
+    for (const r of roots) fs.rmSync(r, { recursive: true, force: true });
+    roots.length = 0;
+  });
+
+  it("denies when guardrails.json will not load under fail_closed", async () => {
+    const root = makeDbRoot("{ not valid json");
+    roots.push(root);
+    const res = await runPreToolUse({
+      pluginRoot: root,
+      enforcement: "fail_closed",
+      stdin: BASH("psql mydb"),
+    });
+    const out = JSON.parse(res.stdout);
+    expect(out.hookSpecificOutput.permissionDecision).toBe("deny");
+  });
+
+  it("allows (no output) a broken guardrails.json under default fail_open", async () => {
+    const root = makeDbRoot("{ not valid json");
+    roots.push(root);
+    const res = await runPreToolUse({ pluginRoot: root, stdin: BASH("psql mydb") });
+    expect(res.stdout.trim()).toBe("");
+  });
+});

--- a/tests/plugin-hooks/dispatcher_failclosed.test.ts
+++ b/tests/plugin-hooks/dispatcher_failclosed.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  effectiveEnforcement,
+  applyGatesManifest,
+} from "../../plugin-hooks/dispatcher.mjs";
+
+const DISPATCHER = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "plugin-hooks",
+  "dispatcher.mjs",
+);
+
+// ── unit: effectiveEnforcement ──
+describe("effectiveEnforcement", () => {
+  const orig = process.env.NARAI_GATE_ENFORCEMENT;
+  afterEach(() => {
+    if (orig === undefined) delete process.env.NARAI_GATE_ENFORCEMENT;
+    else process.env.NARAI_GATE_ENFORCEMENT = orig;
+  });
+
+  it("defaults to fail_open with no env and no manifest field", () => {
+    delete process.env.NARAI_GATE_ENFORCEMENT;
+    expect(effectiveEnforcement(undefined)).toBe("fail_open");
+  });
+
+  it("is fail_closed when env is fail_closed", () => {
+    process.env.NARAI_GATE_ENFORCEMENT = "fail_closed";
+    expect(effectiveEnforcement(undefined)).toBe("fail_closed");
+  });
+
+  it("is fail_closed when the manifest field is fail_closed", () => {
+    delete process.env.NARAI_GATE_ENFORCEMENT;
+    expect(effectiveEnforcement("fail_closed")).toBe("fail_closed");
+  });
+
+  it("ignores an unrecognized env value (stays fail_open)", () => {
+    process.env.NARAI_GATE_ENFORCEMENT = "nope";
+    expect(effectiveEnforcement(undefined)).toBe("fail_open");
+  });
+});
+
+// ── unit: applyGatesManifest regex-compile failure ──
+describe("applyGatesManifest — uncompilable pattern", () => {
+  const orig = process.env.NARAI_GATE_ENFORCEMENT;
+  afterEach(() => {
+    if (orig === undefined) delete process.env.NARAI_GATE_ENFORCEMENT;
+    else process.env.NARAI_GATE_ENFORCEMENT = orig;
+  });
+
+  const badManifest = {
+    enforcement: "fail_closed",
+    rules: [{ name: "bad", decision: "deny", pattern: "([unclosed" }],
+  };
+
+  it("denies on an uncompilable pattern under fail_closed (via manifest field)", () => {
+    delete process.env.NARAI_GATE_ENFORCEMENT;
+    const decisions: { decision: string; reason: string }[] = [];
+    applyGatesManifest(badManifest, "test", "echo hi", new Set(), decisions);
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0].decision).toBe("deny");
+  });
+
+  it("skips (no decision) on an uncompilable pattern under fail_open", () => {
+    delete process.env.NARAI_GATE_ENFORCEMENT;
+    const decisions: { decision: string; reason: string }[] = [];
+    const openManifest = { rules: badManifest.rules };
+    applyGatesManifest(openManifest, "test", "echo hi", new Set(), decisions);
+    expect(decisions).toHaveLength(0);
+  });
+});
+
+// ── integration: subprocess ──
+interface Result { stdout: string; stderr: string; exitCode: number }
+
+function runPreToolUse(opts: {
+  pluginRoot: string;
+  enforcement?: string;
+  stdin: string;
+}): Promise<Result> {
+  const data = fs.mkdtempSync(path.join(os.tmpdir(), "fc-data-"));
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "fc-home-"));
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "fc-cwd-"));
+  const env: Record<string, string> = {
+    ...process.env,
+    CLAUDE_PLUGIN_ROOT: opts.pluginRoot,
+    CLAUDE_PLUGIN_DATA: data,
+    HOME: home,
+  };
+  if (opts.enforcement !== undefined) env.NARAI_GATE_ENFORCEMENT = opts.enforcement;
+  else delete env.NARAI_GATE_ENFORCEMENT;
+  return new Promise((resolve, reject) => {
+    const proc = spawn("node", [DISPATCHER, "pre-tool-use"], {
+      env,
+      cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "", stderr = "";
+    proc.stdout.on("data", (d: Buffer) => (stdout += d.toString()));
+    proc.stderr.on("data", (d: Buffer) => (stderr += d.toString()));
+    proc.on("close", (code) => resolve({ stdout, stderr, exitCode: code ?? -1 }));
+    proc.on("error", reject);
+    proc.stdin.write(opts.stdin);
+    proc.stdin.end();
+  });
+}
+
+function makeRoot(files: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "fc-root-"));
+  fs.writeFileSync(
+    path.join(root, "plugin-config.json"),
+    JSON.stringify({ name: "test-plugin" }),
+  );
+  for (const [rel, content] of Object.entries(files)) {
+    const full = path.join(root, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+  return root;
+}
+
+const BASH = (command: string) =>
+  JSON.stringify({ tool_name: "Bash", tool_input: { command } });
+
+describe("dispatcher gates — fail-closed (subprocess)", () => {
+  const roots: string[] = [];
+  afterEach(() => {
+    for (const r of roots) fs.rmSync(r, { recursive: true, force: true });
+    roots.length = 0;
+  });
+
+  it("denies a malformed gates.json under fail_closed", async () => {
+    const root = makeRoot({ "gates.json": "{ this is not json" });
+    roots.push(root);
+    const res = await runPreToolUse({
+      pluginRoot: root,
+      enforcement: "fail_closed",
+      stdin: BASH("echo hi"),
+    });
+    const out = JSON.parse(res.stdout);
+    expect(out.hookSpecificOutput.permissionDecision).toBe("deny");
+  });
+
+  it("allows (no output) a malformed gates.json under default fail_open", async () => {
+    const root = makeRoot({ "gates.json": "{ this is not json" });
+    roots.push(root);
+    const res = await runPreToolUse({ pluginRoot: root, stdin: BASH("echo hi") });
+    expect(res.stdout.trim()).toBe("");
+  });
+
+  it("denies an uncompilable rule when the manifest declares fail_closed", async () => {
+    const root = makeRoot({
+      "gates.json": JSON.stringify({
+        enforcement: "fail_closed",
+        rules: [{ name: "bad", decision: "deny", pattern: "([unclosed" }],
+      }),
+    });
+    roots.push(root);
+    const res = await runPreToolUse({ pluginRoot: root, stdin: BASH("echo hi") });
+    const out = JSON.parse(res.stdout);
+    expect(out.hookSpecificOutput.permissionDecision).toBe("deny");
+  });
+
+  it("does not over-deny: a valid non-matching manifest under fail_closed allows", async () => {
+    const root = makeRoot({
+      "gates.json": JSON.stringify({
+        enforcement: "fail_closed",
+        rules: [{ name: "psql", decision: "deny", pattern: "psql" }],
+      }),
+    });
+    roots.push(root);
+    const res = await runPreToolUse({
+      pluginRoot: root,
+      enforcement: "fail_closed",
+      stdin: BASH("echo hi"),
+    });
+    expect(res.stdout.trim()).toBe("");
+  });
+});

--- a/tests/plugins/db-connector/gates.test.ts
+++ b/tests/plugins/db-connector/gates.test.ts
@@ -1,0 +1,231 @@
+/**
+ * gates.test.ts — pure unit tests for plugins/db-connector/gates.json.
+ *
+ * Replicates the dispatcher's matching logic (regex per rule, per-segment
+ * compound split, strictest decision wins) so we can verify every rule
+ * without spawning a subprocess. This preset hardens the first-token
+ * blocklist in hooks/guardrails.json by catching DB-access vectors that
+ * route around the sanctioned connector (driver imports, JDBC URLs,
+ * in-process clients, and inline-exec raw DML).
+ */
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const GATES_PATH = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "plugins",
+  "db-connector",
+  "gates.json",
+);
+
+interface Rule {
+  name: string;
+  decision: "deny" | "ask" | "allow";
+  reason: string;
+  pattern: string;
+}
+
+const manifest = JSON.parse(fs.readFileSync(GATES_PATH, "utf-8")) as {
+  rules: Rule[];
+};
+
+const RANK: Record<string, number> = { deny: 2, ask: 1, allow: 0 };
+
+function splitCompound(cmd: string): string[] {
+  if (typeof cmd !== "string") return [];
+  const parts = cmd.split(/\s*(?:&&|\|\||;|\|)\s*/);
+  return parts
+    .map((p) => stripPrefix(p.trim()))
+    .filter((p) => p.length > 0);
+}
+
+function stripPrefix(s: string): string {
+  let cur = s;
+  while (/^[A-Za-z_][A-Za-z0-9_]*=\S*\s+/.test(cur)) {
+    cur = cur.replace(/^[A-Za-z_][A-Za-z0-9_]*=\S*\s+/, "");
+  }
+  return cur.replace(/^(sudo|nice|time)\s+/, "");
+}
+
+function classify(
+  command: string,
+  disabled = new Set<string>(),
+): { name: string; decision: string } | null {
+  const matches: { name: string; decision: string }[] = [];
+  for (const rule of manifest.rules) {
+    if (disabled.has(rule.name)) continue;
+    let re: RegExp;
+    try {
+      re = new RegExp(rule.pattern);
+    } catch {
+      continue;
+    }
+    for (const segment of splitCompound(command)) {
+      if (re.test(segment)) {
+        matches.push({ name: rule.name, decision: rule.decision });
+        break;
+      }
+    }
+  }
+  if (matches.length === 0) return null;
+  matches.sort((a, b) => RANK[b.decision] - RANK[a.decision]);
+  return matches[0];
+}
+
+describe("gates.json — python_db_driver_import (deny)", () => {
+  it.each([
+    'python3 -c "import psycopg2"',
+    'python -c "import psycopg"',
+    'python -c "import pymysql"',
+    'python -c "import MySQLdb"',
+    'python -c "import sqlite3"',
+    'python -c "import pymongo"',
+    'python -c "import pyodbc"',
+    'python -c "import asyncpg"',
+    'python -c "import sqlalchemy"',
+    "python -c 'from sqlalchemy import create_engine'",
+    "python -c 'from psycopg2 import connect'",
+  ])("denies %s", (cmd) => {
+    expect(classify(cmd)).toEqual({
+      name: "python_db_driver_import",
+      decision: "deny",
+    });
+  });
+
+  it("does not fire on a non-db import", () => {
+    expect(classify('python -c "import os"')).toBeNull();
+  });
+});
+
+describe("gates.json — node_db_driver_require (deny)", () => {
+  it.each([
+    'node -e "require(\'pg\')"',
+    'node -e "require(\'mysql\')"',
+    'node -e "require(\'mysql2\')"',
+    'node -e "require(\'mongodb\')"',
+    'node -e "require(\'mssql\')"',
+    'node -e "require(\'tedious\')"',
+    'node -e "require(\'better-sqlite3\')"',
+    'node -e "require(\'sqlite3\')"',
+    'node -e "require(\'oracledb\')"',
+    'node -e "require( \'pg\' )"',
+    'node -e "require(\\"pg\\")"',
+  ])("denies %s", (cmd) => {
+    expect(classify(cmd)).toEqual({
+      name: "node_db_driver_require",
+      decision: "deny",
+    });
+  });
+
+  it("does not fire on a non-db require", () => {
+    expect(classify('node -e "require(\'fs\')"')).toBeNull();
+  });
+});
+
+describe("gates.json — jdbc_url (deny)", () => {
+  it.each([
+    "java -jar app --url jdbc:postgresql://h/db",
+    "java -jar app --url jdbc:mysql://h/db",
+    "java -jar app --url jdbc:mariadb://h/db",
+    "java -jar app --url jdbc:sqlserver://h/db",
+    "java -jar app --url jdbc:oracle://h/db",
+    "java -jar app --url jdbc:sqlite://h/db",
+    "java -jar app --url jdbc:mongodb://h/db",
+  ])("denies %s", (cmd) => {
+    expect(classify(cmd)).toEqual({ name: "jdbc_url", decision: "deny" });
+  });
+});
+
+describe("gates.json — node_db_client_construct (deny, scoped)", () => {
+  it.each([
+    'node --eval "const {Pool}=require(\'pg\'); new Pool({host:\'db\',database:\'x\'})"',
+    'node -e "new Client({host:\'db\',port:5432})"',
+    'node -e "new Pool({connectionString:\'postgres://h/db\'})"',
+    'node -e "new Client({user:\'u\',password:\'p\',database:\'x\'})"',
+  ])("denies %s", (cmd) => {
+    expect(classify(cmd)?.decision).toBe("deny");
+  });
+
+  it("does not fire on a non-db new Client (AWS-style, no host/db key)", () => {
+    expect(classify("node -e \"new Client({ region: 'us' })\"")).toBeNull();
+  });
+});
+
+describe("gates.json — raw_dml_exec (deny, scoped to exec context)", () => {
+  it.each([
+    "python -c \"cur.execute('INSERT INTO t VALUES(1)')\"",
+    "python -c \"cur.execute('UPDATE t SET x=1')\"",
+    "python -c \"cur.execute('DELETE FROM t')\"",
+    "python -c \"cur.execute('DROP TABLE t')\"",
+    "python -c \"cur.execute('TRUNCATE TABLE t')\"",
+    "python -c \"cur.execute('TRUNCATE t')\"",
+  ])("denies %s", (cmd) => {
+    expect(classify(cmd)?.decision).toBe("deny");
+  });
+
+  it("denies mixed-case DML in exec context (char-class case handling)", () => {
+    expect(
+      classify("python -c \"cur.execute('InSeRt InTo t VALUES(1)')\"")
+        ?.decision,
+    ).toBe("deny");
+  });
+
+  it("denies DML via node --eval", () => {
+    expect(
+      classify('node --eval "db.query(\'DELETE FROM users\')"')?.decision,
+    ).toBe("deny");
+  });
+});
+
+describe("gates.json — safe benign commands (must allow)", () => {
+  it.each([
+    "git status",
+    "npm install",
+    "ls -la",
+    "cat schema.sql",
+    'grep "DELETE FROM" app.log',
+    'rg "insert into" src',
+    'echo "we should DROP TABLE temp later"',
+    'python -c "import os"',
+    "node -e \"require('fs')\"",
+    "node -e \"new Client({ region: 'us' })\"",
+  ])("%s does not match any rule", (cmd) => {
+    expect(classify(cmd)).toBeNull();
+  });
+});
+
+describe("gates.json — compound commands", () => {
+  it("strictest decision wins across a chain", () => {
+    const d = classify('ls -la && python3 -c "import psycopg2"');
+    expect(d?.decision).toBe("deny");
+  });
+
+  it("env prefix on a chained interpreter still classifies", () => {
+    expect(
+      classify("cd app && FOO=bar python3 -c \"import psycopg2\"")?.decision,
+    ).toBe("deny");
+  });
+});
+
+describe("gates.json — manifest sanity", () => {
+  it("every rule has required fields with valid shape", () => {
+    for (const r of manifest.rules) {
+      expect(typeof r.name).toBe("string");
+      expect(["deny", "ask", "allow"]).toContain(r.decision);
+      expect(typeof r.reason).toBe("string");
+      expect(typeof r.pattern).toBe("string");
+      expect(() => new RegExp(r.pattern)).not.toThrow();
+    }
+  });
+
+  it("rule names are unique", () => {
+    const names = manifest.rules.map((r) => r.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});

--- a/tests/toolkit/guardrail.test.ts
+++ b/tests/toolkit/guardrail.test.ts
@@ -237,3 +237,54 @@ describe("defaultDenyMessage", () => {
     expect(msg).toContain("psql");
   });
 });
+
+describe("guardrail manifest — enforcement field", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "guardrail-enf-"));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeManifest(obj: unknown): string {
+    const p = path.join(dir, "guardrails.json");
+    fs.writeFileSync(p, JSON.stringify(obj));
+    return p;
+  }
+
+  it("accepts a manifest with enforcement: fail_closed", () => {
+    const p = writeManifest({
+      version: 1,
+      name: "x",
+      enforcement: "fail_closed",
+      rules: [],
+    });
+    expect(loadGuardrailManifest(p).enforcement).toBe("fail_closed");
+  });
+
+  it("accepts a manifest with enforcement: fail_open", () => {
+    const p = writeManifest({
+      version: 1,
+      name: "x",
+      enforcement: "fail_open",
+      rules: [],
+    });
+    expect(loadGuardrailManifest(p).enforcement).toBe("fail_open");
+  });
+
+  it("omits enforcement when absent", () => {
+    const p = writeManifest({ version: 1, name: "x", rules: [] });
+    expect(loadGuardrailManifest(p).enforcement).toBeUndefined();
+  });
+
+  it("rejects an invalid enforcement value", () => {
+    const p = writeManifest({
+      version: 1,
+      name: "x",
+      enforcement: "fail_clsoed",
+      rules: [],
+    });
+    expect(() => loadGuardrailManifest(p)).toThrow(/enforcement/);
+  });
+});


### PR DESCRIPTION
## Summary

Six scoped, opt-in enhancements that let the existing `PreToolUse` guardrail/gates hook and the `db` connector be operated as a real fail-closed security boundary. Every change is opt-in and backward compatible — with no env vars and no new manifest fields, behavior is unchanged.

Each feature is its own commit. All wording is generic; no operator/site-specific names.

## What's included

**1. Fail-closed enforcement mode** (`feat(toolkit)` + 2× `feat(hooks)`)
- New optional `enforcement: "fail_open" | "fail_closed"` field on guardrail/gates manifests (validated), plus a global `NARAI_GATE_ENFORCEMENT` env var. Strictest-wins.
- Under fail-closed, four previously fail-*open* points become hard denies: an unparseable `gates.json`, a rule whose regex won't compile, a `guardrails.json` that won't load, and the toolkit engine being unavailable for a `kind:db` plugin.
- Default stays `fail_open`; the `guardrail.ts` disclaimer is updated to describe the opt-in boundary mode.

**2. Hardened DB-client gates preset** (`feat(db)`)
- New `plugins/db-connector/gates.json` (auto-loaded by exact name) catching vectors the first-token blocklist misses: inline driver imports (`import psycopg2`, `require('pg')`), `jdbc:*://` URLs, DB-shaped `new Pool/Client(...)`, and raw DML.
- DML and client-construction rules are **scoped to execution / DB-connection contexts** so `grep "DELETE FROM"`, docs, and non-DB SDK clients are not denied. Patterns are case-explicit (the engine compiles with no flags). Declares `enforcement: "fail_closed"`.

**3. Audit of blocked hook decisions + parent-dir creation** (`feat(db)`)
- `enableAudit` now creates the audit file's parent directory (records were silently dropped before).
- When `NARAI_AUDIT_PATH` is set, the dispatcher logs `guardrail_deny` / `guardrail_ask` events (command scrubbed via `scrubSqlSecrets`). Lazy-loaded, so the common allow path stays cheap. Never throws into the caller.

**4. PreToolUse coverage beyond Bash** (`feat(hooks)`)
- Gate rules may carry `applies_to: ["Bash","Write","Edit"]` (default `["Bash"]`, so every existing rule is unchanged). Write content / Edit `new_string` are matched as a whole (no command-splitting); the token-blocklist engine stays Bash-only. db-connector's PreToolUse matcher widened to `Bash|Write|Edit`.

**5. Durable, functional grants** (2× `feat(db)`)
- New pluggable `GrantStore` (`MemoryGrantStore` default, `FileGrantStore` with atomic writes, fail-safe reads); `Policy` grants switch to wall-clock epoch for cross-process serialization.
- `grant_required` is wired to actually function: an explicit per-run `approve_grant: true` is treated as the approval, issuing a `read` grant for `grant_duration_hours` so subsequent reads within the window are allowed across invocations. Only `read` is grantable; admin/privilege ceiling preserved. Other modes are unchanged (in-process store).

**6. Per-repo layered config** (`docs(db)`)
- The db connector already honors `~/.connectors/config.yaml` (user) overlaid by `<cwd>/.connectors/config.yaml` (repo) via the connector-config `deepMerge`. This adds documentation and a regression suite locking in repo-overrides-user for DB target + policy, and proving the admin/privilege ceiling cannot be bypassed by an overlay. No production code change.

## Testing

- New tests across all features (fail-closed, content-scan, audit, gates preset, grant store, CLI grant flow, layered config).
- Full suite: **2430 passing, 26 skipped (live DB)**, stable across 3 consecutive runs. Typecheck clean.

## Compatibility

All additions are optional/opt-in. Defaults preserve current behavior (`fail_open`, in-process grants, Bash-only matching, single-file db config). New optional fields/APIs only — suitable for a minor bump.
