### PR TITLE
chore(release): 2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "narai-primitives",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "narai-primitives",
-      "version": "2.1.3",
+      "version": "2.2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.119",
         "adf-to-markdown": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "narai-primitives",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "description": "Read-only connectors + planning hub + connector framework + credential resolution, in one package. Bundles what was @narai/connector-toolkit, @narai/connector-config, @narai/connector-hub, the seven @narai/<svc>-agent-connector packages, and @narai/credential-providers.",
   "type": "module",
   "main": "./dist/hub/index.js",


### PR DESCRIPTION
Version bump to `2.2.0` (minor) for the next npm release.

This release adds six backward-compatible features and merged fixes since `2.1.3`:
- Fail-closed enforcement mode for the PreToolUse guardrail/gates hook
- Hardened DB-client gates preset
- Audit of blocked hook decisions + audit parent-dir creation
- PreToolUse Write/Edit content coverage (`applies_to` rules)
- Durable, functional `grant_required` grants
- Per-repo layered config docs/tests
- Merged: SQL parser bypass hardening (#69), DynamoDB parallel schema extraction (#43), O(N) Top-K aggregation (#83), audit scrubber cleanup (#64)

No breaking changes. After merge, tagging `v2.2.0` triggers the release workflow (npm publish --provenance + GitHub Release).