### PR TITLE
chore(release): 2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "narai-primitives",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "narai-primitives",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.119",
         "adf-to-markdown": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "narai-primitives",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Read-only connectors + planning hub + connector framework + credential resolution, in one package. Bundles what was @narai/connector-toolkit, @narai/connector-config, @narai/connector-hub, the seven @narai/<svc>-agent-connector packages, and @narai/credential-providers.",
   "type": "module",
   "main": "./dist/hub/index.js",


### PR DESCRIPTION
Version bump to `2.3.0` (minor) for the next npm release.

Includes the six fail-closed hardening fixes merged in #86 (dispatcher unparseable-input deny + db manifest enforcement, confirm_once persistence, file-content DB-URI scanning, opt-in bare-DML preset, hardened git guard, example external-write presets). All changes are opt-in and backward-compatible.

After merge, tagging `v2.3.0` triggers the release workflow (npm publish --provenance + GitHub Release).