### PR TITLE
chore(release): 2.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "narai-primitives",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "narai-primitives",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.119",
         "adf-to-markdown": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "narai-primitives",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Read-only connectors + planning hub + connector framework + credential resolution, in one package. Bundles what was @narai/connector-toolkit, @narai/connector-config, @narai/connector-hub, the seven @narai/<svc>-agent-connector packages, and @narai/credential-providers.",
   "type": "module",
   "main": "./dist/hub/index.js",


### PR DESCRIPTION
Version bump to `2.5.0` (minor) for the next npm release.

Includes the 12 v2.4.0 bug fixes from #91 (dialect-aware SQL bracket guard, data-modifying CTE escalation, per-rule regex flags, container/remote-exec blocklist unwrap, case-insensitive blocklist, external_write host-anchor fix, SQL error reclassification, opt-in pg type coercion, VALUES/TABLE read classification, unrecognized-keyword reason, migration-safe connector naming), adversarially hardened. All changes opt-in / backward-compatible.

After merge, tagging `v2.5.0` triggers the release workflow (npm publish --provenance + GitHub Release).