### PR TITLE
gcp: expressive Cloud Logging queries without losing the safety model (2.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+All notable changes to `narai-primitives` are documented here.
+
+## 2.6.0 — 2026-07-03
+
+### gcp connector — `query_logs` expressiveness (additive)
+
+- **New `structured_filter` param** for `query_logs`: JSON clauses
+  (`{field, op, value}` with one level of `and`/`or` nesting) compiled
+  internally to a Cloud Logging filter string with correct quoting and
+  escaping. This makes exact matches (`resource.type="k8s_container"`),
+  severity floors (`severity>="ERROR"`), multi-word text search
+  (`textPayload:"connection refused"`), trace lookups, and
+  `jsonPayload.*` matches expressible — none of which the raw `filter`
+  string allows under its quote/semicolon sanitization. Injection safety
+  comes by construction: `op` is an allowlist (`=`, `!=`, `>=`, `<=`,
+  `contains`/`:`), `field` must be a dotted identifier, and values are
+  always escaped quoted data. Exactly one of `filter` /
+  `structured_filter` must be provided; the raw `filter` param keeps its
+  existing strict sanitization.
+- **Scoped the shell-metachar blocklist** in the gcloud client: the
+  filter positional of `gcloud logging read` is now exempt (same
+  precedent as the `bq query` SQL body — the client spawns via
+  `execFileSync` argv arrays, never a shell), so raw filters like
+  `severity>=ERROR` no longer fail with `UNSAFE_ARG`. Flag positions
+  remain blocklisted; `ALLOWED_SUBCOMMANDS` is unchanged.
+- **Richer, backward-compatible log entry projection**: `message` now
+  falls back `textPayload` → `jsonPayload.message` →
+  `JSON.stringify(jsonPayload)` (truncated to ~2KB) → `null`, so
+  structured-JSON loggers no longer come back with empty messages. New
+  fields on every entry (null when absent, never omitted): `container`,
+  `namespace`, `pod` (from `resource.labels`), `trace_id`, `log_name`,
+  `insert_id`.
+- Exported `compileLogFilter`, `LogFilterError`, and the filter types
+  from `narai-primitives/gcp`.
+
+### Docs
+
+- jira/confluence connector skill docs: corrected the policy-override
+  location to the actual discovery paths (`~/.<name>-agent/config.yaml`
+  user-level, `<cwd>/.<name>-agent/config.yaml` repo overlay) and the
+  policy vocabulary (`success` / `escalate` / `denied`); previously they
+  pointed at `connectors.<name>.policy` in `~/.connectors/config.yaml`,
+  which the policy loader does not read.
+
+## 2.5.0 and earlier
+
+See the [GitHub releases](https://github.com/narailabs/narai-primitives/releases).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "narai-primitives",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "narai-primitives",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.119",
         "adf-to-markdown": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "narai-primitives",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Read-only-by-default service connectors (AWS, Confluence, databases, GCP, GitHub, GitLab, Jira, Linear, Notion) plus a planning hub, connector toolkit, and credential resolution, in one package. One gather() call plans and fans out across connectors; writes route through a policy gate. Replaces the deprecated @narai/* packages.",
   "keywords": [
     "agent",

--- a/plugins/confluence-connector/skills/confluence-connector/SKILL.md
+++ b/plugins/confluence-connector/skills/confluence-connector/SKILL.md
@@ -129,18 +129,18 @@ binary to call the Atlassian REST API directly — the binary is the only
 sanctioned channel. Never edit the operator's config to weaken a policy
 decision; report the decision instead.
 
-Default policy (operator may override under `connectors.confluence.policy`
-in `~/.connectors/config.yaml`; per-site override under
-`connectors.confluence.options.sites.<alias>.policy`):
+Default policy (operator may override via `~/.confluence-agent/config.yaml`
+(user-level) or `<cwd>/.confluence-agent/config.yaml` (repo overlay — wins on
+collisions)):
 
 ```yaml
 policy:
-  read: allow
+  read: success
   write: escalate
-  delete: escalate
-  admin: deny
-  privilege: deny
+  admin: denied
+  aspects:
+    delete: escalate
 ```
 
-The `admin` and `privilege` rules cannot be set to `allow` — the safety
-floor is enforced at config load.
+The `admin` rule cannot be set to `success` — the safety floor is
+enforced at config load.

--- a/plugins/gcp-connector/skills/gcp-connector/SKILL.md
+++ b/plugins/gcp-connector/skills/gcp-connector/SKILL.md
@@ -30,7 +30,7 @@ orchestrator.
 | `list_services` | `project_id` |
 | `describe_db` | `project_id`, `instance_id`, optional `database` |
 | `list_topics` | `project_id` |
-| `query_logs` | `project_id`, `filter`, optional `hours` (default 24, max 168), optional `max_results` (default 100, max 1000) |
+| `query_logs` | `project_id`, exactly one of `filter` (raw string; no quotes/semicolons) or `structured_filter` (JSON clauses `{field, op, value}` with one level of `and`/`or` nesting, compiled internally with correct quoting — use it for `severity>="ERROR"` floors, exact matches, and multi-word text search), optional `hours` (default 24, max 168), optional `max_results` (default 100, max 1000) |
 
 Example:
 

--- a/plugins/jira-connector/skills/jira-connector/SKILL.md
+++ b/plugins/jira-connector/skills/jira-connector/SKILL.md
@@ -129,18 +129,18 @@ call the Atlassian REST API directly — the binary is the only sanctioned
 channel. Never edit the operator's config to weaken a policy decision;
 report the decision instead.
 
-Default policy (operator may override under `connectors.jira.policy` in
-`~/.connectors/config.yaml`; per-site override under
-`connectors.jira.options.sites.<alias>.policy`):
+Default policy (operator may override via `~/.jira-agent/config.yaml`
+(user-level) or `<cwd>/.jira-agent/config.yaml` (repo overlay — wins on
+collisions)):
 
 ```yaml
 policy:
-  read: allow
+  read: success
   write: escalate
-  delete: escalate
-  admin: deny
-  privilege: deny
+  admin: denied
+  aspects:
+    delete: escalate
 ```
 
-The `admin` and `privilege` rules cannot be set to `allow` — the safety
-floor is enforced at config load.
+The `admin` rule cannot be set to `success` — the safety floor is
+enforced at config load.

--- a/src/connectors/gcp/index.ts
+++ b/src/connectors/gcp/index.ts
@@ -14,9 +14,15 @@ import { z } from "zod";
 import {
   GcpClient,
   detectGcloudAvailable,
+  type GcpLogEntry,
   type GcpResult,
 } from "./lib/gcp_client.js";
 import { GcpCliError } from "./lib/gcp_error.js";
+import {
+  compileLogFilter,
+  LogFilterError,
+  type FilterNode,
+} from "./lib/log_filter.js";
 
 // ───────────────────────────────────────────────────────────────────────────
 // Param schemas
@@ -42,24 +48,66 @@ const describeDbParams = z.object({
   database: z.string().default(""),
 });
 
-const queryLogsParams = z.object({
-  project_id: projectIdField,
-  filter: z
-    .string()
-    .min(1, "query_logs requires a non-empty 'filter'")
-    .refine((f) => !/[;'"]/.test(f), {
+// Structured filter clauses — compiled to a Cloud Logging filter string by
+// log_filter.ts, which owns the security model (op allowlist, identifier
+// fields, values escaped as data). The zod shape mirrors those constraints
+// so bad input fails fast as a VALIDATION_ERROR.
+const FILTER_FIELD_SAFE = /^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$/;
+
+const filterClauseSchema = z
+  .object({
+    field: z
+      .string()
+      .regex(
+        FILTER_FIELD_SAFE,
+        "Filter field must be a dotted identifier (e.g. resource.labels.namespace_name)",
+      ),
+    op: z.enum(["=", "!=", ">=", "<=", "contains", ":"]),
+    value: z.union([z.string(), z.number()]),
+  })
+  .strict();
+
+const filterLeafGroupSchema = z.union([
+  z.object({ and: z.array(filterClauseSchema).min(1) }).strict(),
+  z.object({ or: z.array(filterClauseSchema).min(1) }).strict(),
+]);
+
+const filterMemberSchema = z.union([filterClauseSchema, filterLeafGroupSchema]);
+
+const structuredFilterSchema = z.union([
+  filterClauseSchema,
+  z.object({ and: z.array(filterMemberSchema).min(1) }).strict(),
+  z.object({ or: z.array(filterMemberSchema).min(1) }).strict(),
+]);
+
+const queryLogsParams = z
+  .object({
+    project_id: projectIdField,
+    filter: z
+      .string()
+      .min(1, "query_logs requires a non-empty 'filter'")
+      .refine((f) => !/[;'"]/.test(f), {
+        message:
+          "Filter contains forbidden characters — no semicolons or quotes allowed",
+      })
+      .transform((f) => f.trim())
+      .optional(),
+    structured_filter: structuredFilterSchema.optional(),
+    hours: z.coerce.number().int().positive().max(MAX_LOG_HOURS).default(24),
+    max_results: z.coerce
+      .number()
+      .int()
+      .positive()
+      .max(MAX_RESULTS_CAP)
+      .default(MAX_RESULTS_DEFAULT),
+  })
+  .refine(
+    (p) => (p.filter !== undefined) !== (p.structured_filter !== undefined),
+    {
       message:
-        "Filter contains forbidden characters — no semicolons or quotes allowed",
-    })
-    .transform((f) => f.trim()),
-  hours: z.coerce.number().int().positive().max(MAX_LOG_HOURS).default(24),
-  max_results: z.coerce
-    .number()
-    .int()
-    .positive()
-    .max(MAX_RESULTS_CAP)
-    .default(MAX_RESULTS_DEFAULT),
-});
+        "query_logs requires exactly one of 'filter' (raw string) or 'structured_filter' (JSON clauses)",
+    },
+  );
 
 // ───────────────────────────────────────────────────────────────────────────
 // Error-code translation
@@ -83,6 +131,54 @@ const CODE_MAP: Record<string, ErrorCode> = {
   PERMISSION_DENIED: "AUTH_ERROR",
   RATE_LIMITED: "RATE_LIMITED",
 };
+
+const MAX_JSON_MESSAGE_BYTES = 2048;
+
+/**
+ * Project a raw Cloud Logging entry into the envelope shape. Existing
+ * fields keep their pre-2.6 semantics; new fields are null when absent —
+ * never omitted.
+ *
+ * message fallback chain: textPayload → jsonPayload.message →
+ * JSON.stringify(jsonPayload) truncated to ~2KB → null.
+ */
+function projectLogEntry(e: GcpLogEntry): {
+  timestamp: string | null;
+  severity: string;
+  message: string | null;
+  container: string | null;
+  namespace: string | null;
+  pod: string | null;
+  trace_id: string | null;
+  log_name: string | null;
+  insert_id: string | null;
+} {
+  let message: string | null = e.textPayload ?? null;
+  if (message === null && e.jsonPayload !== undefined) {
+    const jsonMessage = e.jsonPayload["message"];
+    if (typeof jsonMessage === "string" && jsonMessage.length > 0) {
+      message = jsonMessage;
+    } else {
+      const serialized = JSON.stringify(e.jsonPayload);
+      message =
+        serialized.length > MAX_JSON_MESSAGE_BYTES
+          ? serialized.slice(0, MAX_JSON_MESSAGE_BYTES)
+          : serialized;
+    }
+  }
+  const labels = e.resource?.labels ?? {};
+  return {
+    timestamp: e.timestamp ?? null,
+    severity: e.severity ?? "",
+    message,
+    container: labels["container_name"] ?? null,
+    namespace: labels["namespace_name"] ?? null,
+    pod: labels["pod_name"] ?? null,
+    trace_id: e.trace ?? null,
+    log_name: e.logName ?? null,
+    insert_id: e.insertId ?? null,
+  };
+}
 
 function throwIfError<T>(
   result: GcpResult<T>,
@@ -203,26 +299,31 @@ export function buildGcpConnector(overrides: BuildOptions = {}): Connector {
         },
       },
       query_logs: {
-        description: "Query Cloud Logging for entries matching a filter",
+        description:
+          "Query Cloud Logging for entries matching a filter. Prefer " +
+          "'structured_filter' (JSON clauses with and/or, compiled with " +
+          "correct quoting) over the raw 'filter' string, which forbids " +
+          "quotes and semicolons.",
         params: queryLogsParams,
         classify: { kind: "read" },
         handler: async (p: z.infer<typeof queryLogsParams>, ctx) => {
+          const compiled = p.structured_filter !== undefined;
+          const filter = compiled
+            ? compileLogFilter(p.structured_filter as FilterNode)
+            : (p.filter as string);
           const result = await ctx.sdk.queryLogs(
             p.project_id,
-            p.filter,
+            filter,
             p.hours,
             p.max_results,
+            { compiled },
           );
           throwIfError(result);
           return {
             project_id: p.project_id,
-            filter: p.filter,
+            filter,
             hours: p.hours,
-            entries: result.data.map((e) => ({
-              timestamp: e.timestamp ?? null,
-              severity: e.severity ?? "",
-              message: e.textPayload ?? "",
-            })),
+            entries: result.data.map(projectLogEntry),
             entry_count: result.data.length,
             truncated: result.data.length >= p.max_results,
           };
@@ -230,6 +331,13 @@ export function buildGcpConnector(overrides: BuildOptions = {}): Connector {
       },
     },
     mapError: (err) => {
+      if (err instanceof LogFilterError) {
+        return {
+          error_code: "VALIDATION_ERROR",
+          message: err.message,
+          retriable: false,
+        };
+      }
       if (err instanceof GcpCliError) {
         return {
           error_code: CODE_MAP[err.code] ?? "CONNECTION_ERROR",
@@ -254,3 +362,11 @@ export {
   type GcpResult,
 } from "./lib/gcp_client.js";
 export { GcpCliError } from "./lib/gcp_error.js";
+export {
+  compileLogFilter,
+  LogFilterError,
+  type FilterClause,
+  type FilterGroup,
+  type FilterNode,
+  type FilterOp,
+} from "./lib/log_filter.js";

--- a/src/connectors/gcp/lib/gcp_client.ts
+++ b/src/connectors/gcp/lib/gcp_client.ts
@@ -134,10 +134,19 @@ export class GcpClient {
     // that content is validated at the call site (bqQuery) and may
     // legitimately contain `;` inside string literals or as a single
     // trailing terminator, so we skip the blocklist for it specifically.
+    //
+    // `gcloud logging read` takes the filter as the first positional
+    // argument; Cloud Logging filter syntax legitimately uses `>` (severity
+    // floors) and `"` (exact/text matches). The filter is validated at the
+    // call site (queryLogs) — raw strings keep the strict character check,
+    // compiled strings are safe by construction — so the blocklist covers
+    // only the flag positions here.
     const isBqQuery = binary === "bq" && subcommand === "query";
+    const isLoggingRead = binary === "gcloud" && subcommand === "logging read";
     const lastIndex = args.length - 1;
     for (let idx = 0; idx < args.length; idx++) {
       if (isBqQuery && idx === lastIndex) continue;
+      if (isLoggingRead && idx === 0) continue;
       const arg = args[idx] ?? "";
       if (/[;|&`$<>\n]/.test(arg)) {
         return {
@@ -244,6 +253,7 @@ export class GcpClient {
     filter: string,
     hours: number,
     maxResults: number,
+    opts: { compiled?: boolean } = {},
   ): Promise<GcpResult<GcpLogEntry[]>> {
     if (!PROJECT_ID_SAFE.test(projectId)) {
       return {
@@ -253,7 +263,10 @@ export class GcpClient {
         retriable: false,
       };
     }
-    if (/[;'"\n]/.test(filter)) {
+    // Raw filter strings keep the strict character check. Filters compiled
+    // by log_filter.ts contain quotes by design and are safe by
+    // construction (values are escaped data), so they skip it.
+    if (!opts.compiled && /[;'"\n]/.test(filter)) {
       return {
         ok: false,
         code: "INVALID_FILTER",
@@ -359,6 +372,10 @@ export interface GcpLogEntry {
   severity?: string;
   textPayload?: string;
   jsonPayload?: Record<string, unknown>;
+  resource?: { type?: string; labels?: Record<string, string> };
+  trace?: string;
+  logName?: string;
+  insertId?: string;
 }
 
 export interface GcpBqResult {

--- a/src/connectors/gcp/lib/log_filter.ts
+++ b/src/connectors/gcp/lib/log_filter.ts
@@ -1,0 +1,120 @@
+/**
+ * log_filter.ts — compile structured JSON clauses into a Cloud Logging
+ * filter string.
+ *
+ * Security model: injection safety comes by construction, not by blocklist.
+ * - `op` is an allowlist (`=`, `!=`, `>=`, `<=`, `contains`/`:`).
+ * - `field` must be a dotted identifier (`[A-Za-z0-9_.]` segments), so a
+ *   field can never smuggle operators or quotes.
+ * - `value` is always treated as data: strings are double-quoted with
+ *   embedded quotes/backslashes/control characters escaped per Cloud
+ *   Logging filter syntax; numbers must be finite and are emitted bare.
+ *
+ * Nesting: a top-level clause, or one `and`/`or` group whose members are
+ * clauses or one further level of `and`/`or` groups of clauses.
+ */
+
+export type FilterOp = "=" | "!=" | ">=" | "<=" | "contains" | ":";
+
+export interface FilterClause {
+  field: string;
+  op: FilterOp;
+  value: string | number;
+}
+
+export interface FilterGroup {
+  and?: FilterNode[];
+  or?: FilterNode[];
+}
+
+export type FilterNode = FilterClause | FilterGroup;
+
+export class LogFilterError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LogFilterError";
+  }
+}
+
+const ALLOWED_OPS: ReadonlySet<string> = new Set([
+  "=",
+  "!=",
+  ">=",
+  "<=",
+  "contains",
+  ":",
+]);
+
+const FIELD_SAFE = /^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$/;
+
+function quoteValue(value: string | number): string {
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new LogFilterError("Numeric filter values must be finite");
+    }
+    return String(value);
+  }
+  const escaped = value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t");
+  return `"${escaped}"`;
+}
+
+function compileClause(clause: FilterClause): string {
+  if (typeof clause.field !== "string" || !FIELD_SAFE.test(clause.field)) {
+    throw new LogFilterError(
+      `Invalid filter field '${String(clause.field)}' — must be a dotted identifier`,
+    );
+  }
+  if (!ALLOWED_OPS.has(clause.op)) {
+    throw new LogFilterError(
+      `Invalid filter op '${String(clause.op)}' — allowed: =, !=, >=, <=, contains, :`,
+    );
+  }
+  const op = clause.op === "contains" ? ":" : clause.op;
+  return `${clause.field}${op}${quoteValue(clause.value)}`;
+}
+
+function isClause(node: FilterNode): node is FilterClause {
+  return !("and" in node) && !("or" in node);
+}
+
+function compileGroup(group: FilterGroup, depth: number): string {
+  const hasAnd = group.and !== undefined;
+  const hasOr = group.or !== undefined;
+  if (hasAnd === hasOr) {
+    throw new LogFilterError(
+      "Filter group must have exactly one of 'and' / 'or'",
+    );
+  }
+  const members = (hasAnd ? group.and : group.or) ?? [];
+  if (!Array.isArray(members) || members.length === 0) {
+    throw new LogFilterError("Filter group must contain at least one clause");
+  }
+  const joiner = hasAnd ? " AND " : " OR ";
+  const parts = members.map((member) => {
+    if (isClause(member)) return compileClause(member);
+    if (depth >= 1) {
+      throw new LogFilterError(
+        "Filter groups may only nest one level deep",
+      );
+    }
+    return `(${compileGroup(member, depth + 1)})`;
+  });
+  return parts.join(joiner);
+}
+
+/**
+ * Compile a structured filter node into a Cloud Logging filter string.
+ * Throws LogFilterError on any shape/op/field violation.
+ */
+export function compileLogFilter(node: FilterNode): string {
+  if (node === null || typeof node !== "object") {
+    throw new LogFilterError("Structured filter must be an object");
+  }
+  if (isClause(node)) return compileClause(node);
+  return compileGroup(node, 0);
+}

--- a/tests/connectors/gcp/unit/log_filter.test.ts
+++ b/tests/connectors/gcp/unit/log_filter.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Unit tests for the Cloud Logging structured-filter compiler.
+ *
+ * The compiler turns JSON clauses into a Cloud Logging filter string with
+ * correct quoting/escaping — injection safety comes by construction (op
+ * allowlist, identifier-pattern fields, values always treated as data),
+ * not by blocklisting characters.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  compileLogFilter,
+  LogFilterError,
+} from "../../../../src/connectors/gcp/lib/log_filter.js";
+
+describe("compileLogFilter — single clauses", () => {
+  it("compiles an exact-match clause with a quoted value", () => {
+    expect(
+      compileLogFilter({ field: "resource.type", op: "=", value: "k8s_container" }),
+    ).toBe('resource.type="k8s_container"');
+  });
+
+  it("compiles a severity floor (>=)", () => {
+    expect(
+      compileLogFilter({ field: "severity", op: ">=", value: "ERROR" }),
+    ).toBe('severity>="ERROR"');
+  });
+
+  it("compiles a multi-word text search with the : operator", () => {
+    expect(
+      compileLogFilter({ field: "textPayload", op: ":", value: "connection refused" }),
+    ).toBe('textPayload:"connection refused"');
+  });
+
+  it("accepts 'contains' as an alias for :", () => {
+    expect(
+      compileLogFilter({
+        field: "textPayload",
+        op: "contains",
+        value: "NullPointerException",
+      }),
+    ).toBe('textPayload:"NullPointerException"');
+  });
+
+  it("compiles a trace lookup", () => {
+    expect(
+      compileLogFilter({
+        field: "trace",
+        op: "=",
+        value:
+          "projects/acme-prod-123/traces/0123456789abcdef0123456789abcdef",
+      }),
+    ).toBe(
+      'trace="projects/acme-prod-123/traces/0123456789abcdef0123456789abcdef"',
+    );
+  });
+
+  it("compiles a jsonPayload field match", () => {
+    expect(
+      compileLogFilter({ field: "jsonPayload.level", op: "=", value: "ERROR" }),
+    ).toBe('jsonPayload.level="ERROR"');
+  });
+
+  it("compiles != and <= operators", () => {
+    expect(
+      compileLogFilter({ field: "severity", op: "!=", value: "DEBUG" }),
+    ).toBe('severity!="DEBUG"');
+    expect(
+      compileLogFilter({ field: "severity", op: "<=", value: "WARNING" }),
+    ).toBe('severity<="WARNING"');
+  });
+
+  it("emits finite numeric values unquoted", () => {
+    expect(
+      compileLogFilter({ field: "jsonPayload.attempts", op: ">=", value: 3 }),
+    ).toBe("jsonPayload.attempts>=3");
+  });
+});
+
+describe("compileLogFilter — and/or groups", () => {
+  it("compiles the canonical GKE error query (acceptance #1)", () => {
+    expect(
+      compileLogFilter({
+        and: [
+          { field: "resource.type", op: "=", value: "k8s_container" },
+          {
+            field: "resource.labels.namespace_name",
+            op: "=",
+            value: "orders-dev-app",
+          },
+          {
+            field: "resource.labels.container_name",
+            op: "=",
+            value: "data-entry",
+          },
+          { field: "severity", op: ">=", value: "ERROR" },
+        ],
+      }),
+    ).toBe(
+      'resource.type="k8s_container" AND ' +
+        'resource.labels.namespace_name="orders-dev-app" AND ' +
+        'resource.labels.container_name="data-entry" AND ' +
+        'severity>="ERROR"',
+    );
+  });
+
+  it("compiles an or group", () => {
+    expect(
+      compileLogFilter({
+        or: [
+          { field: "severity", op: "=", value: "ERROR" },
+          { field: "severity", op: "=", value: "CRITICAL" },
+        ],
+      }),
+    ).toBe('severity="ERROR" OR severity="CRITICAL"');
+  });
+
+  it("parenthesizes a nested group one level deep", () => {
+    expect(
+      compileLogFilter({
+        and: [
+          { field: "resource.type", op: "=", value: "k8s_container" },
+          {
+            or: [
+              { field: "severity", op: "=", value: "ERROR" },
+              { field: "textPayload", op: ":", value: "timeout" },
+            ],
+          },
+        ],
+      }),
+    ).toBe(
+      'resource.type="k8s_container" AND ' +
+        '(severity="ERROR" OR textPayload:"timeout")',
+    );
+  });
+});
+
+describe("compileLogFilter — injection attempts stay data (acceptance #5)", () => {
+  it("keeps a quote-breakout attempt inside an escaped quoted string", () => {
+    expect(
+      compileLogFilter({
+        field: "textPayload",
+        op: ":",
+        value: '" OR severity>="DEBUG',
+      }),
+    ).toBe('textPayload:"\\" OR severity>=\\"DEBUG"');
+  });
+
+  it("keeps command substitution as quoted data", () => {
+    expect(
+      compileLogFilter({ field: "textPayload", op: ":", value: "$(rm -rf /)" }),
+    ).toBe('textPayload:"$(rm -rf /)"');
+  });
+
+  it("keeps backticks as quoted data", () => {
+    expect(
+      compileLogFilter({ field: "textPayload", op: ":", value: "`whoami`" }),
+    ).toBe('textPayload:"`whoami`"');
+  });
+
+  it("escapes newlines so the value cannot span filter lines", () => {
+    expect(
+      compileLogFilter({ field: "textPayload", op: ":", value: "a\nb" }),
+    ).toBe('textPayload:"a\\nb"');
+  });
+
+  it("escapes backslashes before quotes so escapes cannot be neutralized", () => {
+    expect(
+      compileLogFilter({ field: "textPayload", op: ":", value: 'a\\" OR x' }),
+    ).toBe('textPayload:"a\\\\\\" OR x"');
+  });
+});
+
+describe("compileLogFilter — rejects unsafe shapes", () => {
+  it("rejects an op outside the allowlist", () => {
+    expect(() =>
+      compileLogFilter({
+        field: "severity",
+        op: "=~" as never,
+        value: "ERROR",
+      }),
+    ).toThrow(LogFilterError);
+  });
+
+  it("rejects a field that is not a dotted identifier", () => {
+    expect(() =>
+      compileLogFilter({
+        field: 'severity="ERROR" OR x',
+        op: "=",
+        value: "y",
+      }),
+    ).toThrow(LogFilterError);
+  });
+
+  it("rejects a field with a leading dot", () => {
+    expect(() =>
+      compileLogFilter({ field: ".hidden", op: "=", value: "x" }),
+    ).toThrow(LogFilterError);
+  });
+
+  it("rejects non-finite numeric values", () => {
+    expect(() =>
+      compileLogFilter({
+        field: "jsonPayload.n",
+        op: "=",
+        value: Number.POSITIVE_INFINITY,
+      }),
+    ).toThrow(LogFilterError);
+  });
+
+  it("rejects an empty group", () => {
+    expect(() => compileLogFilter({ and: [] })).toThrow(LogFilterError);
+  });
+
+  it("rejects a group with both and + or keys", () => {
+    expect(() =>
+      compileLogFilter({
+        and: [{ field: "severity", op: "=", value: "ERROR" }],
+        or: [{ field: "severity", op: "=", value: "INFO" }],
+      }),
+    ).toThrow(LogFilterError);
+  });
+
+  it("rejects nesting deeper than one level", () => {
+    expect(() =>
+      compileLogFilter({
+        and: [
+          {
+            or: [
+              {
+                and: [{ field: "severity", op: "=", value: "ERROR" }],
+              } as never,
+            ],
+          },
+        ],
+      }),
+    ).toThrow(LogFilterError);
+  });
+});

--- a/tests/connectors/gcp/unit/query_logs_structured.test.ts
+++ b/tests/connectors/gcp/unit/query_logs_structured.test.ts
@@ -1,0 +1,317 @@
+/**
+ * query_logs expressiveness fixes — structured filter input, scoped
+ * metachar blocklist for the logging-read filter positional, and the
+ * richer backward-compatible entry projection.
+ */
+import { describe, expect, it } from "vitest";
+import { buildGcpConnector } from "../../../../src/connectors/gcp/index.js";
+import {
+  GcpClient,
+  type GcpClientOptions,
+} from "../../../../src/connectors/gcp/lib/gcp_client.js";
+
+type RunnerCall = { file: string; args: string[] };
+
+function makeClient(
+  stdout: string,
+): { client: GcpClient; calls: RunnerCall[] } {
+  const calls: RunnerCall[] = [];
+  const runner = ((file: string, args: string[]) => {
+    calls.push({ file, args });
+    return stdout;
+  }) as GcpClientOptions["runner"];
+  const client = new GcpClient({
+    rateLimitPerMin: 100,
+    connectTimeoutMs: 50,
+    readTimeoutMs: 50,
+    runner,
+    sleepImpl: async () => {},
+  });
+  return { client, calls };
+}
+
+function makeConnector(client: GcpClient) {
+  return buildGcpConnector({
+    sdk: async () => client,
+    credentials: async () => ({}),
+  });
+}
+
+describe("GcpClient.queryLogs — scoped blocklist on the filter positional", () => {
+  it("passes a severity floor (>=) through as the filter positional", async () => {
+    const { client, calls } = makeClient("[]");
+    const r = await client.queryLogs(
+      "acme-prod-123",
+      "resource.type=k8s_container AND severity>=ERROR",
+      1,
+      10,
+    );
+    expect(r.ok).toBe(true);
+    expect(calls[0]?.file).toBe("gcloud");
+    expect(calls[0]?.args.slice(0, 3)).toEqual([
+      "logging",
+      "read",
+      "resource.type=k8s_container AND severity>=ERROR",
+    ]);
+  });
+
+  it("still rejects raw filters containing quotes (raw path unchanged)", async () => {
+    const { client, calls } = makeClient("[]");
+    const r = await client.queryLogs(
+      "acme-prod-123",
+      'resource.type="k8s_container"',
+      1,
+      10,
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("INVALID_FILTER");
+    expect(calls.length).toBe(0);
+  });
+
+  it("still rejects raw filters containing semicolons", async () => {
+    const { client, calls } = makeClient("[]");
+    const r = await client.queryLogs(
+      "acme-prod-123",
+      "severity=ERROR; rm -rf /",
+      1,
+      10,
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("INVALID_FILTER");
+    expect(calls.length).toBe(0);
+  });
+
+  it("accepts a precompiled filter containing double quotes", async () => {
+    const { client, calls } = makeClient("[]");
+    const r = await client.queryLogs(
+      "acme-prod-123",
+      'resource.type="k8s_container" AND severity>="ERROR"',
+      1,
+      10,
+      { compiled: true },
+    );
+    expect(r.ok).toBe(true);
+    expect(calls[0]?.args[2]).toBe(
+      'resource.type="k8s_container" AND severity>="ERROR"',
+    );
+  });
+
+  it("still blocks metachars in flag positions of logging read", () => {
+    const { client } = makeClient("[]");
+    const result = (
+      client as unknown as {
+        _run: (b: string, s: string, a: string[]) => unknown;
+      }
+    )._run("gcloud", "logging read", [
+      "severity>=ERROR",
+      "--project",
+      "acme;rm -rf /",
+    ]);
+    expect(result).toEqual(
+      expect.objectContaining({ ok: false, code: "UNSAFE_ARG" }),
+    );
+  });
+});
+
+describe("query_logs — structured filter input", () => {
+  it("compiles structured_filter and returns the compiled filter string", async () => {
+    const { client, calls } = makeClient("[]");
+    const c = makeConnector(client);
+    const r = await c.fetch("query_logs", {
+      project_id: "acme-prod-123",
+      structured_filter: {
+        and: [
+          { field: "resource.type", op: "=", value: "k8s_container" },
+          {
+            field: "resource.labels.namespace_name",
+            op: "=",
+            value: "orders-dev-app",
+          },
+          { field: "severity", op: ">=", value: "ERROR" },
+        ],
+      },
+    });
+    expect(r.status).toBe("success");
+    if (r.status === "success") {
+      expect(r.data["filter"]).toBe(
+        'resource.type="k8s_container" AND ' +
+          'resource.labels.namespace_name="orders-dev-app" AND ' +
+          'severity>="ERROR"',
+      );
+    }
+    expect(calls[0]?.args[2]).toBe(
+      'resource.type="k8s_container" AND ' +
+        'resource.labels.namespace_name="orders-dev-app" AND ' +
+        'severity>="ERROR"',
+    );
+  });
+
+  it("supports multi-word text search via structured_filter", async () => {
+    const { client, calls } = makeClient("[]");
+    const c = makeConnector(client);
+    const r = await c.fetch("query_logs", {
+      project_id: "acme-prod-123",
+      structured_filter: {
+        field: "textPayload",
+        op: "contains",
+        value: "connection refused",
+      },
+    });
+    expect(r.status).toBe("success");
+    expect(calls[0]?.args[2]).toBe('textPayload:"connection refused"');
+  });
+
+  it("keeps injection values as quoted data end-to-end", async () => {
+    const { client, calls } = makeClient("[]");
+    const c = makeConnector(client);
+    const r = await c.fetch("query_logs", {
+      project_id: "acme-prod-123",
+      structured_filter: {
+        field: "textPayload",
+        op: ":",
+        value: '" OR severity>="DEBUG',
+      },
+    });
+    expect(r.status).toBe("success");
+    expect(calls[0]?.args[2]).toBe('textPayload:"\\" OR severity>=\\"DEBUG"');
+  });
+
+  it("rejects a structured_filter with a disallowed op", async () => {
+    const { client, calls } = makeClient("[]");
+    const c = makeConnector(client);
+    const r = await c.fetch("query_logs", {
+      project_id: "acme-prod-123",
+      structured_filter: { field: "severity", op: "=~", value: "ERROR" },
+    });
+    expect(r.status).toBe("error");
+    if (r.status === "error") expect(r.error_code).toBe("VALIDATION_ERROR");
+    expect(calls.length).toBe(0);
+  });
+
+  it("rejects a structured_filter with an unsafe field name", async () => {
+    const { client, calls } = makeClient("[]");
+    const c = makeConnector(client);
+    const r = await c.fetch("query_logs", {
+      project_id: "acme-prod-123",
+      structured_filter: {
+        field: 'severity="ERROR" OR x',
+        op: "=",
+        value: "y",
+      },
+    });
+    expect(r.status).toBe("error");
+    if (r.status === "error") expect(r.error_code).toBe("VALIDATION_ERROR");
+    expect(calls.length).toBe(0);
+  });
+
+  it("requires exactly one of filter / structured_filter — neither", async () => {
+    const { client } = makeClient("[]");
+    const c = makeConnector(client);
+    const r = await c.fetch("query_logs", { project_id: "acme-prod-123" });
+    expect(r.status).toBe("error");
+    if (r.status === "error") expect(r.error_code).toBe("VALIDATION_ERROR");
+  });
+
+  it("requires exactly one of filter / structured_filter — both", async () => {
+    const { client } = makeClient("[]");
+    const c = makeConnector(client);
+    const r = await c.fetch("query_logs", {
+      project_id: "acme-prod-123",
+      filter: "severity=ERROR",
+      structured_filter: { field: "severity", op: "=", value: "ERROR" },
+    });
+    expect(r.status).toBe("error");
+    if (r.status === "error") expect(r.error_code).toBe("VALIDATION_ERROR");
+  });
+
+  it("raw string filter keeps its strict sanitization", async () => {
+    const { client } = makeClient("[]");
+    const c = makeConnector(client);
+    const r = await c.fetch("query_logs", {
+      project_id: "acme-prod-123",
+      filter: 'resource.type="k8s_container"',
+    });
+    expect(r.status).toBe("error");
+    if (r.status === "error") expect(r.error_code).toBe("VALIDATION_ERROR");
+  });
+});
+
+describe("query_logs — entry projection", () => {
+  const fullEntry = {
+    timestamp: "2026-07-01T12:00:00Z",
+    severity: "ERROR",
+    jsonPayload: { message: "boom from json", level: "ERROR" },
+    resource: {
+      type: "k8s_container",
+      labels: {
+        container_name: "data-entry",
+        namespace_name: "orders-dev-app",
+        pod_name: "data-entry-7f9c",
+      },
+    },
+    trace: "projects/acme-prod-123/traces/0123456789abcdef0123456789abcdef",
+    logName: "projects/acme-prod-123/logs/stdout",
+    insertId: "abc123",
+  };
+
+  async function fetchEntries(entries: unknown[]) {
+    const { client } = makeClient(JSON.stringify(entries));
+    const c = makeConnector(client);
+    const r = await c.fetch("query_logs", {
+      project_id: "acme-prod-123",
+      filter: "severity=ERROR",
+    });
+    expect(r.status).toBe("success");
+    if (r.status !== "success") throw new Error("unreachable");
+    return r.data["entries"] as Array<Record<string, unknown>>;
+  }
+
+  it("falls back to jsonPayload.message when textPayload is absent", async () => {
+    const [e] = await fetchEntries([fullEntry]);
+    expect(e?.["message"]).toBe("boom from json");
+  });
+
+  it("round-trips labels, trace, logName, insertId", async () => {
+    const [e] = await fetchEntries([fullEntry]);
+    expect(e?.["container"]).toBe("data-entry");
+    expect(e?.["namespace"]).toBe("orders-dev-app");
+    expect(e?.["pod"]).toBe("data-entry-7f9c");
+    expect(e?.["trace_id"]).toBe(
+      "projects/acme-prod-123/traces/0123456789abcdef0123456789abcdef",
+    );
+    expect(e?.["log_name"]).toBe("projects/acme-prod-123/logs/stdout");
+    expect(e?.["insert_id"]).toBe("abc123");
+  });
+
+  it("prefers textPayload over jsonPayload.message", async () => {
+    const [e] = await fetchEntries([
+      { ...fullEntry, textPayload: "boom from text" },
+    ]);
+    expect(e?.["message"]).toBe("boom from text");
+  });
+
+  it("stringifies jsonPayload without a message field, truncated to ~2KB", async () => {
+    const big = { data: "x".repeat(4000) };
+    const [e] = await fetchEntries([
+      { timestamp: "2026-07-01T12:00:00Z", severity: "INFO", jsonPayload: big },
+    ]);
+    const msg = e?.["message"] as string;
+    expect(msg.startsWith('{"data":"xxx')).toBe(true);
+    expect(msg.length).toBeLessThanOrEqual(2048);
+  });
+
+  it("yields nulls (never omitted keys) for an entry missing everything", async () => {
+    const [e] = await fetchEntries([{}]);
+    expect(e).toEqual({
+      timestamp: null,
+      severity: "",
+      message: null,
+      container: null,
+      namespace: null,
+      pod: null,
+      trace_id: null,
+      log_name: null,
+      insert_id: null,
+    });
+  });
+});


### PR DESCRIPTION
## What

The `query_logs` action made real Cloud Logging filters structurally impossible: the sanitization rejected the double quotes the filter language requires for exact matches and multi-word search, the shell-metachar blocklist rejected `>` so severity floors (`severity>="ERROR"`) failed with `UNSAFE_ARG`, and the entry projection only read `textPayload`, returning empty messages for services that log structured JSON.

Three additive fixes (no change to `ALLOWED_SUBCOMMANDS` or the read-only posture):

1. **Structured filter builder** — new `structured_filter` param: JSON clauses `{field, op, value}` with one level of `and`/`or` nesting, compiled internally to a Cloud Logging filter string. Injection safety by construction: op allowlist (`=`, `!=`, `>=`, `<=`, `contains`/`:`), dotted-identifier field pattern, values always escaped quoted data. Exactly one of `filter` / `structured_filter`; the raw `filter` keeps its strict sanitization.
2. **Scoped blocklist** — the client already spawns via `execFileSync` argv arrays (never a shell), so the belt-and-braces metachar check now exempts the `gcloud logging read` filter positional, same precedent as the existing `bq query` SQL-body carve-out. Flags stay blocklisted.
3. **Richer backward-compatible projection** — `message` falls back `textPayload → jsonPayload.message → JSON.stringify(jsonPayload)` (~2KB cap) → `null`; new always-present fields `container`, `namespace`, `pod`, `trace_id`, `log_name`, `insert_id` (null when absent, never omitted).

Separate commit: jira/confluence skill docs pointed policy overrides at `connectors.<name>.policy` in `~/.connectors/config.yaml`, but `loadPolicyConfig` discovers `<cwd|home>/.<name>-agent/config.yaml`; also fixed the rule vocabulary to what the loader accepts.

## Tests

41 new unit tests, including exact compiled-string assertions for the acceptance queries (GKE container+namespace+severity floor, multi-word text search, trace lookup, jsonPayload match) and injection-as-value cases (quote breakout, command substitution, backticks, newlines). Full suite: 2754 passed; coverage thresholds green; typecheck clean.

## Release

Version bumped to 2.6.0 (consumers pin exact versions) + CHANGELOG. After merge: tag `v2.6.0` → release workflow publishes to npm.

https://claude.ai/code/session_01Vs4UdYp47N6FuATxDZg9mh
