### PR TITLE
fix(plugins): make all manifests pass `claude plugin validate`

### DIFF
--- a/plugins/aws-connector/.claude-plugin/plugin.json
+++ b/plugins/aws-connector/.claude-plugin/plugin.json
@@ -1,6 +1,9 @@
 {
   "name": "aws-connector-plugin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Read-only AWS connector for Claude Code. Built on narai-primitives (subpath ./aws). Lambda, RDS, S3, CloudWatch.",
-  "author": "narai"
+  "author": {
+    "name": "NarAI Labs",
+    "url": "https://github.com/narailabs"
+  }
 }

--- a/plugins/confluence-connector/.claude-plugin/plugin.json
+++ b/plugins/confluence-connector/.claude-plugin/plugin.json
@@ -1,6 +1,9 @@
 {
   "name": "confluence-connector-plugin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Read + write CRUD on Confluence pages, comments, and attachments. Policy-gated.",
-  "author": "narai"
+  "author": {
+    "name": "NarAI Labs",
+    "url": "https://github.com/narailabs"
+  }
 }

--- a/plugins/db-connector/.claude-plugin/plugin.json
+++ b/plugins/db-connector/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "db-connector-plugin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Safe, read-only database query agent for Claude Code. Built on narai-primitives (subpath ./db). Every statement passes the policy gate before any driver loads or any connection is opened.",
   "author": {
     "name": "Narai Labs",
@@ -9,9 +9,18 @@
   "homepage": "https://github.com/narailabs/narai-primitives/tree/main/plugins/db-connector",
   "repository": "https://github.com/narailabs/narai-primitives",
   "license": "MIT",
-  "keywords": ["database", "sql", "postgresql", "mysql", "sqlite", "policy-gate"],
+  "keywords": [
+    "database",
+    "sql",
+    "postgresql",
+    "mysql",
+    "sqlite",
+    "policy-gate"
+  ],
   "userConfig": {
     "install_guardrails": {
+      "type": "string",
+      "title": "DB-client guardrails",
       "description": "Block direct DB-client invocations (psql, mysql, sqlite3, mongosh, pg_dump, aws dynamodb, ...) from Bash so all database access is routed through the db-connector CLI. Strongly recommended. Set to 'off' to disable.",
       "sensitive": false
     }

--- a/plugins/gcp-connector/.claude-plugin/plugin.json
+++ b/plugins/gcp-connector/.claude-plugin/plugin.json
@@ -1,6 +1,9 @@
 {
   "name": "gcp-connector-plugin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Read-only GCP connector for Claude Code. Built on narai-primitives (subpath ./gcp). Cloud Run, Cloud SQL, Pub/Sub, Cloud Logging.",
-  "author": "narai"
+  "author": {
+    "name": "NarAI Labs",
+    "url": "https://github.com/narailabs"
+  }
 }

--- a/plugins/git-connector/.claude-plugin/plugin.json
+++ b/plugins/git-connector/.claude-plugin/plugin.json
@@ -1,6 +1,9 @@
 {
   "name": "git-connector-plugin",
-  "version": "1.0.0",
-  "description": "Pre-tool-use hook that gates risky git commands (push, force-push, branch deletion, reset --hard, etc.). No agents or actions — hooks only.",
-  "author": "narailabs"
+  "version": "1.0.1",
+  "description": "Pre-tool-use hook that gates risky git commands (push, force-push, branch deletion, reset --hard, etc.). No agents or actions \u2014 hooks only.",
+  "author": {
+    "name": "NarAI Labs",
+    "url": "https://github.com/narailabs"
+  }
 }

--- a/plugins/github-connector/.claude-plugin/plugin.json
+++ b/plugins/github-connector/.claude-plugin/plugin.json
@@ -1,6 +1,9 @@
 {
   "name": "github-connector-plugin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Read-only GitHub connector for Claude Code. Built on narai-primitives (subpath ./github).",
-  "author": "narai"
+  "author": {
+    "name": "NarAI Labs",
+    "url": "https://github.com/narailabs"
+  }
 }

--- a/plugins/gitlab-connector/.claude-plugin/plugin.json
+++ b/plugins/gitlab-connector/.claude-plugin/plugin.json
@@ -1,6 +1,9 @@
 {
   "name": "gitlab-connector-plugin",
-  "version": "1.0.0",
-  "description": "Read + write GitLab connector — projects, issues, merge requests, notes, releases, and CI pipelines. Policy-gated. Built on narai-primitives. Self-hosted GitLab supported via GITLAB_HOST.",
-  "author": "narailabs"
+  "version": "1.0.1",
+  "description": "Read + write GitLab connector \u2014 projects, issues, merge requests, notes, releases, and CI pipelines. Policy-gated. Built on narai-primitives. Self-hosted GitLab supported via GITLAB_HOST.",
+  "author": {
+    "name": "NarAI Labs",
+    "url": "https://github.com/narailabs"
+  }
 }

--- a/plugins/jira-connector/.claude-plugin/plugin.json
+++ b/plugins/jira-connector/.claude-plugin/plugin.json
@@ -1,6 +1,9 @@
 {
   "name": "jira-connector-plugin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Read + write CRUD on Jira issues, comments, transitions, and attachments. Policy-gated.",
-  "author": "narai"
+  "author": {
+    "name": "NarAI Labs",
+    "url": "https://github.com/narailabs"
+  }
 }

--- a/plugins/linear-connector/.claude-plugin/plugin.json
+++ b/plugins/linear-connector/.claude-plugin/plugin.json
@@ -1,6 +1,9 @@
 {
   "name": "linear-connector-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Read + write CRUD on Linear issues, projects, comments, and attachment links. Policy-gated.",
-  "author": "narai"
+  "author": {
+    "name": "NarAI Labs",
+    "url": "https://github.com/narailabs"
+  }
 }

--- a/plugins/notion-connector/.claude-plugin/plugin.json
+++ b/plugins/notion-connector/.claude-plugin/plugin.json
@@ -1,6 +1,9 @@
 {
   "name": "notion-connector-plugin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Read + write CRUD on Notion pages, blocks, and database entries. Policy-gated.",
-  "author": "narai"
+  "author": {
+    "name": "NarAI Labs",
+    "url": "https://github.com/narailabs"
+  }
 }


### PR DESCRIPTION
## What

Pre-submission fixes for the Claude Code plugin directory: the community-marketplace review pipeline runs `claude plugin validate` on every submission, and 10 of our 11 plugins were failing it.

- **Nine manifests** had `"author": "narai"` (a string); the schema requires an object. Now `{"name": "NarAI Labs", "url": "https://github.com/narailabs"}`, matching connector-creator and db-connector.
- **db-connector** `userConfig.install_guardrails` was missing the required `type` and `title`. Type is `"string"` because the consuming check (`plugin-hooks/dispatcher.mjs:269`) compares the injected `DB_AGENT_GUARDRAILS` env value against the string `"off"`.
- Each changed plugin's independent version gets a patch bump per CONTRIBUTING's versioning rule, so marketplace consumers receive the update.

## Verification

`claude plugin validate` now passes for all 11 `plugins/*` directories (was: 10 failures).

## Follow-up (separate repo)

After this merges, `narailabs/narai-claude-plugins` `marketplace.json` entry versions should be bumped to match (1.1.1 / 1.0.1).

https://claude.ai/code/session_01Q576AyR3j21jYG5YEsMUxG