### PR TITLE
docs(readme): say read-only-by-default in the hero line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # narai-primitives
 
-Read-only connectors, a planning hub, a connector toolkit, and credential
+Read-only-by-default connectors, a planning hub, a connector toolkit, and credential
 resolution for agent tooling — one npm dependency instead of N hand-rolled
 service integrations.
 


### PR DESCRIPTION
One-line honesty fix following a Codex finding on narailabs/narai-claude-plugins#10: five of the nine connectors (confluence, jira, notion, gitlab, linear) describe themselves as "Read + write CRUD … Policy-gated" in their own manifests, so the README's opening "Read-only connectors" overstates. The hero bullet ("Read-only by default…") and the npm description already use the accurate frame; this aligns the first line with them.

https://claude.ai/code/session_01Q576AyR3j21jYG5YEsMUxG