### PR TITLE
⚡ Bolt: Replace O(N log N) sort with O(N) Top-K extraction in session summary hook

### DIFF
--- a/plugin-hooks/session-summary.mjs
+++ b/plugin-hooks/session-summary.mjs
@@ -45,10 +45,27 @@ function aggregate(connector, sessionId, records) {
       avg_ms: s.ms_count > 0 ? Math.round(s.ms_total / s.ms_count) : 0,
     };
   }
-  const top_responses = [...records]
-    .sort((a, b) => b.response_bytes - a.response_bytes)
-    .slice(0, 3)
+
+  // ⚡ Bolt: Replace O(N log N) sort with O(N) Top-K manual tracking
+  // Avoids sorting the entire records array to find the 3 largest response_bytes.
+  let top1 = null, top2 = null, top3 = null;
+  for (const r of records) {
+    if (!top1 || r.response_bytes > top1.response_bytes) {
+      top3 = top2;
+      top2 = top1;
+      top1 = r;
+    } else if (!top2 || r.response_bytes > top2.response_bytes) {
+      top3 = top2;
+      top2 = r;
+    } else if (!top3 || r.response_bytes > top3.response_bytes) {
+      top3 = r;
+    }
+  }
+
+  const top_responses = [top1, top2, top3]
+    .filter(Boolean)
     .map((r) => ({ action: r.action, response_bytes: r.response_bytes }));
+
   return {
     session_id: sessionId,
     connector,

--- a/plugin-hooks/session-summary.mjs
+++ b/plugin-hooks/session-summary.mjs
@@ -22,12 +22,27 @@ function aggregate(connector, sessionId, records) {
   const byAction = {};
   let totalBytes = 0, totalTokens = 0, errors = 0;
   let start = records[0].ts, end = records[0].ts;
+  // ⚡ Bolt: Replace O(N log N) sort with O(N) Top-K manual tracking
+  // Avoids sorting the entire records array to find the 3 largest response_bytes.
+  // Strict `>` keeps the first record of a tie ahead of later ones, matching
+  // the stable sort this replaced.
+  let top1 = null, top2 = null, top3 = null;
   for (const r of records) {
     totalBytes += r.response_bytes;
     totalTokens += r.estimated_tokens;
     if (r.status !== "success") errors++;
     if (r.ts < start) start = r.ts;
     if (r.ts > end) end = r.ts;
+    if (!top1 || r.response_bytes > top1.response_bytes) {
+      top3 = top2;
+      top2 = top1;
+      top1 = r;
+    } else if (!top2 || r.response_bytes > top2.response_bytes) {
+      top3 = top2;
+      top2 = r;
+    } else if (!top3 || r.response_bytes > top3.response_bytes) {
+      top3 = r;
+    }
     const s = byAction[r.action] ||= {
       calls: 0, response_bytes: 0, estimated_tokens: 0, ms_total: 0, ms_count: 0,
     };
@@ -44,22 +59,6 @@ function aggregate(connector, sessionId, records) {
       estimated_tokens: s.estimated_tokens,
       avg_ms: s.ms_count > 0 ? Math.round(s.ms_total / s.ms_count) : 0,
     };
-  }
-
-  // ⚡ Bolt: Replace O(N log N) sort with O(N) Top-K manual tracking
-  // Avoids sorting the entire records array to find the 3 largest response_bytes.
-  let top1 = null, top2 = null, top3 = null;
-  for (const r of records) {
-    if (!top1 || r.response_bytes > top1.response_bytes) {
-      top3 = top2;
-      top2 = top1;
-      top1 = r;
-    } else if (!top2 || r.response_bytes > top2.response_bytes) {
-      top3 = top2;
-      top2 = r;
-    } else if (!top3 || r.response_bytes > top3.response_bytes) {
-      top3 = r;
-    }
   }
 
   const top_responses = [top1, top2, top3]

--- a/tests/toolkit/integration/usage_hooks.test.ts
+++ b/tests/toolkit/integration/usage_hooks.test.ts
@@ -114,6 +114,46 @@ describe("session-summary.mjs", () => {
     runHook("session-summary.mjs", { USAGE_CONNECTOR_NAME: "github" }, JSON.stringify({ session_id: "S" }));
     expect(JSON.parse(readFileSync(join(dir, "summary-S.json"), "utf-8")).marker).toBe("preexisting");
   });
+
+  // top_responses is produced by a Top-K scan that replaced `sort().slice(0, 3)`.
+  // These pin the three properties that make the two interchangeable: descending
+  // order, ties broken toward the earlier record, and a short tail under 3 records.
+  function summarize(records: Array<Record<string, unknown>>) {
+    const dir = join(workDir, "usage");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "S.jsonl"), records.map((r) => JSON.stringify(r)).join("\n") + "\n");
+    const res = runHook("session-summary.mjs", { USAGE_CONNECTOR_NAME: "github" }, JSON.stringify({ session_id: "S" }));
+    expect(res.status).toBe(0);
+    return JSON.parse(readFileSync(join(dir, "summary-S.json"), "utf-8"));
+  }
+  const rec = (action: string, response_bytes: number) => ({
+    ts: "2026-04-23T12:00:00.000Z", session_id: "S", connector: "github",
+    action, status: "success", response_bytes, estimated_tokens: 1,
+  });
+
+  it("reports the top 3 responses in descending byte order", () => {
+    const summary = summarize([rec("a", 10), rec("b", 500), rec("c", 50), rec("d", 100)]);
+    expect(summary.top_responses).toEqual([
+      { action: "b", response_bytes: 500 },
+      { action: "d", response_bytes: 100 },
+      { action: "c", response_bytes: 50 },
+    ]);
+  });
+
+  it("breaks response_bytes ties toward the earlier record", () => {
+    const summary = summarize([rec("first", 7), rec("second", 7), rec("third", 7), rec("fourth", 7)]);
+    expect(summary.top_responses.map((t: { action: string }) => t.action)).toEqual([
+      "first", "second", "third",
+    ]);
+  });
+
+  it("returns fewer than 3 entries when there are fewer than 3 records", () => {
+    const summary = summarize([rec("only", 3), rec("other", 9)]);
+    expect(summary.top_responses).toEqual([
+      { action: "other", response_bytes: 9 },
+      { action: "only", response_bytes: 3 },
+    ]);
+  });
 });
 
 describe("stale-summarize.mjs", () => {


### PR DESCRIPTION
💡 What: Replaced the `O(N log N)` array sort and slice with an `O(N)` linear pass manual tracking to find the top 3 usage records by response bytes.
🎯 Why: `Array.prototype.sort()` creates overhead and can block the event loop for large arrays (like long session logs in `usage.jsonl`), when `O(N)` is sufficient to track a fixed K top elements.
📊 Impact: Reduces memory allocation and speeds up session summary generation, preventing potential event loop blocking on very large usage files.
🔬 Measurement: Run the test suite `npm run test` and check execution time on large `usage.jsonl` processing.

---
*PR created automatically by Jules for task [10158439563665613295](https://jules.google.com/task/10158439563665613295) started by @rfv-code*