### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unhandled error in DB Policy Engine

### DIFF
--- a/src/connectors/db/lib/policy.ts
+++ b/src/connectors/db/lib/policy.ts
@@ -631,7 +631,15 @@ export class Policy {
     for (let i = 0; i < statements.length; i++) {
       const stmt = statements[i]!;
       const op = classifications[i]!;
-      perStmt.push({ stmt, op, result: this._decideOne(stmt, op) });
+      let result: PolicyResult;
+      try {
+        result = this._decideOne(stmt, op);
+      } catch (exc) {
+        const reason = (exc as Error).message;
+        _emitDeny(reason, op);
+        return { decision: "deny", reason };
+      }
+      perStmt.push({ stmt, op, result });
     }
 
     // Pick the strictest decision; break ties by first occurrence so the
@@ -724,7 +732,14 @@ export class Policy {
       _emitDeny(reason, null);
       return { decision: "deny", reason };
     }
-    const result = this._decideOne(stmt, op);
+    let result: PolicyResult;
+    try {
+      result = this._decideOne(stmt, op);
+    } catch (exc) {
+      const reason = (exc as Error).message;
+      _emitDeny(reason, op);
+      return { decision: "deny", reason };
+    }
     if (result.decision === "deny") _emitDeny(result.reason, op);
     else if (result.decision === "escalate") _emitEscalate(result.reason, op);
     else if (result.decision === "present_only") _emitPresentOnly(result.reason, op, result.formatted_sql);


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unhandled exceptions in the database policy evaluation logic (`_decideOne`) could cause the entire connector process to crash when confronted with maliciously malformed SQL constructs.
🎯 **Impact:** Potential Denial of Service (DoS) and fail-open vulnerability if upstream services assume crashes mean no policy violation occurred.
🔧 **Fix:** Wrapped `_decideOne` in `try...catch` blocks within `checkQuery` and `_checkSingleStatement`. When an error is caught (e.g., from ambiguous syntax triggering a throw in AST parsing), the system now gracefully logs a `policy_deny` event and explicitly returns a deny decision.
✅ **Verification:** Verified by running the vitest test suite; confirmed zero regressions and appropriate handling of policy states.

---
*PR created automatically by Jules for task [6418250191256370890](https://jules.google.com/task/6418250191256370890) started by @rfv-code*