### PR TITLE
⚡ Bolt: Optimize Top-K extraction in session-summary hook

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,6 @@
 ## 2024-06-25 - Avoid array sort for Top-K in hot paths
 **Learning:** V8 engine sorting (`[...arr].sort()`) is surprisingly slow and blocks the event loop for thousands of records when fetching Top-K elements (e.g. usage statistics). It scales at O(N log N) when O(N) is sufficient for a fixed K.
 **Action:** When gathering top elements from a large data array in this codebase, manually track the top items in a single O(N) pass rather than sorting a full copy.
+## 2024-05-24 - O(N log N) sorting for Top-K extraction
+**Learning:** Found a performance bottleneck in `plugin-hooks/session-summary.mjs` where `[...records].sort().slice(0, 3)` was used to find the top 3 records by size. This causes an O(N log N) sort operation and unnecessary array allocations, which is inefficient and can block the event loop for large log files.
+**Action:** Replace `[...records].sort().slice(0, K)` patterns with an O(N) manual Top-K tracking loop to avoid array allocations and sort overhead, especially in metrics and logging pipelines where N can be very large.

--- a/plugin-hooks/session-summary.mjs
+++ b/plugin-hooks/session-summary.mjs
@@ -22,12 +22,27 @@ function aggregate(connector, sessionId, records) {
   const byAction = {};
   let totalBytes = 0, totalTokens = 0, errors = 0;
   let start = records[0].ts, end = records[0].ts;
+  let top1 = null, top2 = null, top3 = null;
+
   for (const r of records) {
     totalBytes += r.response_bytes;
     totalTokens += r.estimated_tokens;
     if (r.status !== "success") errors++;
     if (r.ts < start) start = r.ts;
     if (r.ts > end) end = r.ts;
+
+    // ⚡ Bolt: Replace O(N log N) sort with O(N) Top-K manual tracking
+    if (!top1 || r.response_bytes > top1.response_bytes) {
+      top3 = top2;
+      top2 = top1;
+      top1 = r;
+    } else if (!top2 || r.response_bytes > top2.response_bytes) {
+      top3 = top2;
+      top2 = r;
+    } else if (!top3 || r.response_bytes > top3.response_bytes) {
+      top3 = r;
+    }
+
     const s = byAction[r.action] ||= {
       calls: 0, response_bytes: 0, estimated_tokens: 0, ms_total: 0, ms_count: 0,
     };
@@ -45,9 +60,9 @@ function aggregate(connector, sessionId, records) {
       avg_ms: s.ms_count > 0 ? Math.round(s.ms_total / s.ms_count) : 0,
     };
   }
-  const top_responses = [...records]
-    .sort((a, b) => b.response_bytes - a.response_bytes)
-    .slice(0, 3)
+
+  const top_responses = [top1, top2, top3]
+    .filter(Boolean)
     .map((r) => ({ action: r.action, response_bytes: r.response_bytes }));
   return {
     session_id: sessionId,


### PR DESCRIPTION
💡 What: Replaced an $O(N \log N)$ `[...records].sort().slice(0, 3)` array copy/sort operation with a manual $O(N)$ Top-3 tracking mechanism inside the existing `for` loop in `plugin-hooks/session-summary.mjs`.

🎯 Why: Sorting the entire array of session records just to find the top 3 largest responses creates unnecessary CPU overhead and memory allocations. For sessions with thousands of records, this blocks the event loop and slows down the summary hook execution.

📊 Impact: Reduces algorithmic complexity from $O(N \log N)$ to $O(N)$ and eliminates the intermediate array allocation, leading to faster and more memory-efficient log processing.

🔬 Measurement: Verify by running `pnpm test tests/toolkit/integration/usage_hooks.test.ts` to ensure the logic and output format remain perfectly identical.

---
*PR created automatically by Jules for task [5879016379282567390](https://jules.google.com/task/5879016379282567390) started by @rfv-code*