### PR TITLE
⚡ Bolt: Replace O(N log N) sort with O(N) manual top-K tracking in session summary hook

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,6 @@
 ## 2024-06-25 - Avoid array sort for Top-K in hot paths
 **Learning:** V8 engine sorting (`[...arr].sort()`) is surprisingly slow and blocks the event loop for thousands of records when fetching Top-K elements (e.g. usage statistics). It scales at O(N log N) when O(N) is sufficient for a fixed K.
 **Action:** When gathering top elements from a large data array in this codebase, manually track the top items in a single O(N) pass rather than sorting a full copy.
+## 2023-10-27 - Top-K Extraction O(N log N) Bottleneck in Session Summary Hook
+**Learning:** V8 engine sorting (`[...arr].sort()`) is surprisingly slow and blocks the event loop for thousands of records when fetching Top-K elements (e.g. usage statistics) in Node.js hooks, causing unnecessary CPU spikes when dealing with large session logs. It scales at O(N log N) when O(N) is sufficient for a fixed K.
+**Action:** When extracting a fixed number of top elements (e.g., top 3 requests by response bytes) from a potentially unbounded array of records, use a manual tracking loop (O(N)) instead of sorting the entire array and slicing it.

--- a/plugin-hooks/session-summary.mjs
+++ b/plugin-hooks/session-summary.mjs
@@ -20,21 +20,49 @@ function aggregate(connector, sessionId, records) {
     };
   }
   const byAction = {};
-  let totalBytes = 0, totalTokens = 0, errors = 0;
-  let start = records[0].ts, end = records[0].ts;
+  let totalBytes = 0,
+    totalTokens = 0,
+    errors = 0;
+  let start = records[0].ts,
+    end = records[0].ts;
+  let top1 = null;
+  let top2 = null;
+  let top3 = null;
+
   for (const r of records) {
     totalBytes += r.response_bytes;
     totalTokens += r.estimated_tokens;
     if (r.status !== "success") errors++;
     if (r.ts < start) start = r.ts;
     if (r.ts > end) end = r.ts;
-    const s = byAction[r.action] ||= {
-      calls: 0, response_bytes: 0, estimated_tokens: 0, ms_total: 0, ms_count: 0,
-    };
+
+    // ⚡ Bolt: Replace O(N log N) sort with O(N) Top-K manual tracking
+    // Avoids sorting the entire records array to find the 3 largest response_bytes.
+    if (!top1 || r.response_bytes > top1.response_bytes) {
+      top3 = top2;
+      top2 = top1;
+      top1 = r;
+    } else if (!top2 || r.response_bytes > top2.response_bytes) {
+      top3 = top2;
+      top2 = r;
+    } else if (!top3 || r.response_bytes > top3.response_bytes) {
+      top3 = r;
+    }
+
+    const s = (byAction[r.action] ||= {
+      calls: 0,
+      response_bytes: 0,
+      estimated_tokens: 0,
+      ms_total: 0,
+      ms_count: 0,
+    });
     s.calls++;
     s.response_bytes += r.response_bytes;
     s.estimated_tokens += r.estimated_tokens;
-    if (typeof r.execution_time_ms === "number") { s.ms_total += r.execution_time_ms; s.ms_count++; }
+    if (typeof r.execution_time_ms === "number") {
+      s.ms_total += r.execution_time_ms;
+      s.ms_count++;
+    }
   }
   const by_action = {};
   for (const [k, s] of Object.entries(byAction)) {
@@ -45,14 +73,16 @@ function aggregate(connector, sessionId, records) {
       avg_ms: s.ms_count > 0 ? Math.round(s.ms_total / s.ms_count) : 0,
     };
   }
-  const top_responses = [...records]
-    .sort((a, b) => b.response_bytes - a.response_bytes)
-    .slice(0, 3)
+
+  const top_responses = [top1, top2, top3]
+    .filter(Boolean)
     .map((r) => ({ action: r.action, response_bytes: r.response_bytes }));
+
   return {
     session_id: sessionId,
     connector,
-    start, end,
+    start,
+    end,
     total_calls: records.length,
     total_response_bytes: totalBytes,
     total_estimated_tokens: totalTokens,
@@ -70,23 +100,34 @@ function renderMd(s) {
   const errors = s.total_calls - successes;
   const rows = Object.entries(s.by_action)
     .sort(([, a], [, b]) => b.response_bytes - a.response_bytes)
-    .map(([action, a]) =>
-      `| ${action} | ${a.calls} | ${a.response_bytes.toLocaleString()} | ${a.estimated_tokens.toLocaleString()} | ${a.avg_ms} |`,
-    ).join("\n");
-  const top = s.top_responses.map((t, i) =>
-    `${i + 1}. ${t.action} (${t.response_bytes.toLocaleString()} bytes)`).join("\n");
+    .map(
+      ([action, a]) =>
+        `| ${action} | ${a.calls} | ${a.response_bytes.toLocaleString()} | ${a.estimated_tokens.toLocaleString()} | ${a.avg_ms} |`,
+    )
+    .join("\n");
+  const top = s.top_responses
+    .map(
+      (t, i) =>
+        `${i + 1}. ${t.action} (${t.response_bytes.toLocaleString()} bytes)`,
+    )
+    .join("\n");
   return [
-    `# ${s.connector} usage — session ${s.session_id}`, ``,
+    `# ${s.connector} usage — session ${s.session_id}`,
+    ``,
     `- Window: ${s.start} → ${s.end}`,
     `- Calls: ${s.total_calls} (${successes} success, ${errors} error — ${(s.error_rate * 100).toFixed(1)}%)`,
     `- Response bytes: ${s.total_response_bytes.toLocaleString()} | Estimated tokens: ${s.total_estimated_tokens.toLocaleString()}`,
     ``,
-    `## By action`, ``,
+    `## By action`,
+    ``,
     `| action | calls | bytes | est. tokens | avg ms |`,
     `|---|---|---|---|---|`,
-    rows, ``,
-    `## Top responses`, ``,
-    top, ``,
+    rows,
+    ``,
+    `## Top responses`,
+    ``,
+    top,
+    ``,
   ].join("\n");
 }
 
@@ -98,10 +139,22 @@ export function summarizeSession(baseDir, connector, sessionId) {
   if (existsSync(summaryJson)) return;
 
   let raw;
-  try { raw = readFileSync(jsonl, "utf-8"); } catch { return; }
-  const records = raw.split("\n").filter(Boolean).map((l) => {
-    try { return JSON.parse(l); } catch { return null; }
-  }).filter(Boolean);
+  try {
+    raw = readFileSync(jsonl, "utf-8");
+  } catch {
+    return;
+  }
+  const records = raw
+    .split("\n")
+    .filter(Boolean)
+    .map((l) => {
+      try {
+        return JSON.parse(l);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
 
   const summary = aggregate(connector, sessionId, records);
   try {
@@ -117,7 +170,11 @@ function main() {
   if (!connector) return;
 
   let raw;
-  try { raw = readFileSync(0, "utf-8"); } catch { return; }
+  try {
+    raw = readFileSync(0, "utf-8");
+  } catch {
+    return;
+  }
   let sessionId = "unknown";
   try {
     const p = JSON.parse(raw || "{}");
@@ -133,6 +190,8 @@ function main() {
 
 // Only auto-run when executed directly (not when imported by stale-summarize.mjs).
 if (import.meta.url === `file://${process.argv[1]}`) {
-  try { main(); } catch {}
+  try {
+    main();
+  } catch {}
   process.exit(0);
 }


### PR DESCRIPTION
💡 What: Replaced the full array sort in `session-summary.mjs` with an O(N) single-pass manual tracking algorithm for calculating `top_responses`.
🎯 Why: Finding the top 3 most expensive elements by `response_bytes` previously required sorting the entire array of records (`[...records].sort().slice(0, 3)`), which scales poorly (`O(N log N)`) and spikes CPU for large sessions.
📊 Impact: Reduces time complexity from `O(N log N)` to `O(N)` for extracting the top 3 responses, minimizing event loop blocking for large node logs.
🔬 Measurement: Verify using `npx vitest run tests/toolkit/integration/usage_hooks.test.ts` to ensure Top-K elements continue extracting correctly.

---
*PR created automatically by Jules for task [10710157755211914314](https://jules.google.com/task/10710157755211914314) started by @rfv-code*