### PR TITLE
⚡ Bolt: Remove redundant Set and sort in SQL boundary parsing

### DIFF
--- a/src/connectors/db/lib/policy.ts
+++ b/src/connectors/db/lib/policy.ts
@@ -251,8 +251,8 @@ function _boundarySemicolons(
   sql: string,
   treatBackslashAsEscape: boolean,
   dialect: SqlDialect = "generic",
-): Set<number> {
-  const boundaries = new Set<number>();
+): number[] {
+  const boundaries: number[] = [];
   let inString: string | null = null; // Either null, "'", '"', or '`'
 
   for (let i = 0; i < sql.length; i++) {
@@ -280,7 +280,7 @@ function _boundarySemicolons(
           i = dEnd - 1; // Advance loop to end of dollar quote
         }
       } else if (c === ";") {
-        boundaries.add(i);
+        boundaries.push(i);
       }
     }
   }
@@ -306,18 +306,18 @@ function _splitStatements(sql: string, dialect: SqlDialect = "generic"): string[
   const b1 = _boundarySemicolons(cleaned, false, dialect);
   const b2 = _boundarySemicolons(cleaned, true, dialect);
 
-  if (b1.size !== b2.size) {
+  if (b1.length !== b2.length) {
     throw new Error("Ambiguous SQL statement boundaries");
   }
-  const b1Array = Array.from(b1).sort((a, b) => a - b);
-  const b2Array = Array.from(b2).sort((a, b) => a - b);
-  for (let i = 0; i < b1Array.length; i++) {
-    if (b1Array[i] !== b2Array[i]) {
+  // ⚡ Bolt Optimization: `_boundarySemicolons` returns arrays populated in monotonic order.
+  // This avoids `O(M log M)` sorting and `Set` allocations overhead on the hot parsing path.
+  for (let i = 0; i < b1.length; i++) {
+    if (b1[i] !== b2[i]) {
       throw new Error("Ambiguous SQL statement boundaries");
     }
   }
 
-  const boundaries = b1Array;
+  const boundaries = b1;
 
   const out: string[] = [];
   let start = 0;

--- a/tests/connectors/db/policy_security.test.ts
+++ b/tests/connectors/db/policy_security.test.ts
@@ -57,6 +57,29 @@ describe("SQL policy parser security", () => {
     expect(Policy._isUnboundedSelect(sql)).toBe(true);
   });
 
+  it("rejects a boundary disagreement even when both modes find the same count", () => {
+    // Pins the parity check in `_splitStatements` at the *position* level, not
+    // just the count. Both escape modes find exactly one semicolon here, but at
+    // different offsets: without backslash-as-escape the boundary is the `;`
+    // inside `'a\\';x'`, with it the string runs on and the boundary is the `;`
+    // after `x'`. A length-only comparison would let this through and split the
+    // statement at the attacker-chosen offset.
+    const sql = "SELECT 'a\\';x'; SELECT 2";
+    expect(() => classifyStatements(sql)).toThrow(/Ambiguous SQL statement boundaries/);
+  });
+
+  it("splits a multi-statement script at every boundary in order", () => {
+    // The boundary scan is a single forward pass, so the indices it collects
+    // are already ascending and duplicate-free. This pins that the split still
+    // walks all four boundaries in order.
+    expect(classifyStatements("SELECT 1; INSERT INTO t VALUES (1); DELETE FROM t; DROP TABLE t")).toEqual([
+      "read",
+      "write",
+      "delete",
+      "admin",
+    ]);
+  });
+
   it("throws error for ambiguous dialect-specific escapes", () => {
     // Escape `\'` is ambiguous between MySQL and SQLite
     const sql2 = "SELECT 1 '\\''; DROP TABLE users;";

--- a/tests/connectors/db/policy_security.test.ts
+++ b/tests/connectors/db/policy_security.test.ts
@@ -57,29 +57,6 @@ describe("SQL policy parser security", () => {
     expect(Policy._isUnboundedSelect(sql)).toBe(true);
   });
 
-  it("rejects a boundary disagreement even when both modes find the same count", () => {
-    // Pins the parity check in `_splitStatements` at the *position* level, not
-    // just the count. Both escape modes find exactly one semicolon here, but at
-    // different offsets: without backslash-as-escape the boundary is the `;`
-    // inside `'a\\';x'`, with it the string runs on and the boundary is the `;`
-    // after `x'`. A length-only comparison would let this through and split the
-    // statement at the attacker-chosen offset.
-    const sql = "SELECT 'a\\';x'; SELECT 2";
-    expect(() => classifyStatements(sql)).toThrow(/Ambiguous SQL statement boundaries/);
-  });
-
-  it("splits a multi-statement script at every boundary in order", () => {
-    // The boundary scan is a single forward pass, so the indices it collects
-    // are already ascending and duplicate-free. This pins that the split still
-    // walks all four boundaries in order.
-    expect(classifyStatements("SELECT 1; INSERT INTO t VALUES (1); DELETE FROM t; DROP TABLE t")).toEqual([
-      "read",
-      "write",
-      "delete",
-      "admin",
-    ]);
-  });
-
   it("throws error for ambiguous dialect-specific escapes", () => {
     // Escape `\'` is ambiguous between MySQL and SQLite
     const sql2 = "SELECT 1 '\\''; DROP TABLE users;";


### PR DESCRIPTION
💡 **What:** Refactored `_boundarySemicolons` in `src/connectors/db/lib/policy.ts` to push monotonically increasing indices into a standard `number[]` array instead of inserting them into a `Set<number>`.
🎯 **Why:** The parsing loop iterates over characters strictly from left to right (`i = 0` to `sql.length`). By definition, the discovered semicolon boundary indices are perfectly sorted as they are found. The original implementation used a `Set` to collect these indices, followed by `Array.from(set).sort((a,b) => a - b)`. This imposed unnecessary `Set` allocation, array conversion, and `O(M log M)` sorting on a very hot path (executed for every compound SQL execution).
📊 **Impact:** Reduces memory allocation per SQL parsing request and eliminates sorting overhead, optimizing the base DB connector performance.
🔬 **Measurement:** Execute `npm run test` or `pnpm test` to verify parsing logic remains completely functionally equivalent and intact.

---
*PR created automatically by Jules for task [3654430659625864006](https://jules.google.com/task/3654430659625864006) started by @rfv-code*