### PR TITLE
⚡ Bolt: Optimize Top-K extraction in session summary hook

### DIFF
--- a/plugin-hooks/session-summary.mjs
+++ b/plugin-hooks/session-summary.mjs
@@ -22,12 +22,26 @@ function aggregate(connector, sessionId, records) {
   const byAction = {};
   let totalBytes = 0, totalTokens = 0, errors = 0;
   let start = records[0].ts, end = records[0].ts;
+  let top1 = null, top2 = null, top3 = null;
   for (const r of records) {
     totalBytes += r.response_bytes;
     totalTokens += r.estimated_tokens;
     if (r.status !== "success") errors++;
     if (r.ts < start) start = r.ts;
     if (r.ts > end) end = r.ts;
+
+    // ⚡ Bolt: Replace O(N log N) sort with O(N) Top-K manual tracking
+    if (!top1 || r.response_bytes > top1.response_bytes) {
+      top3 = top2;
+      top2 = top1;
+      top1 = r;
+    } else if (!top2 || r.response_bytes > top2.response_bytes) {
+      top3 = top2;
+      top2 = r;
+    } else if (!top3 || r.response_bytes > top3.response_bytes) {
+      top3 = r;
+    }
+
     const s = byAction[r.action] ||= {
       calls: 0, response_bytes: 0, estimated_tokens: 0, ms_total: 0, ms_count: 0,
     };
@@ -45,9 +59,8 @@ function aggregate(connector, sessionId, records) {
       avg_ms: s.ms_count > 0 ? Math.round(s.ms_total / s.ms_count) : 0,
     };
   }
-  const top_responses = [...records]
-    .sort((a, b) => b.response_bytes - a.response_bytes)
-    .slice(0, 3)
+  const top_responses = [top1, top2, top3]
+    .filter((r) => r !== null)
     .map((r) => ({ action: r.action, response_bytes: r.response_bytes }));
   return {
     session_id: sessionId,


### PR DESCRIPTION
💡 **What:** Replaced the O(N log N) `[...records].sort().slice(0, 3)` with an O(N) manual tracking loop to extract the top 3 items (`top1`, `top2`, `top3`) based on `response_bytes` in `plugin-hooks/session-summary.mjs`.

🎯 **Why:** Sorting a potentially large array of usage records just to find the top 3 is inefficient and blocks the V8 event loop on large datasets. This fixes a specific codebase performance anti-pattern.

📊 **Impact:** Reduces time complexity of top response extraction from O(N log N) to O(N), eliminating unnecessary sorting overhead and intermediate array allocations. For thousands of usage records, this significantly speeds up the aggregation step.

🔬 **Measurement:** Code execution verification was performed by running the comprehensive test suite (`pnpm test`), which confirms that usage metrics parsing and summary functionality remains correct while utilizing the faster algorithm.

---
*PR created automatically by Jules for task [17230692824967740909](https://jules.google.com/task/17230692824967740909) started by @rfv-code*