### PR TITLE
⚡ Bolt: Remove redundant Set and sort for SQL statement boundaries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,6 @@
 ## 2024-06-25 - Avoid array sort for Top-K in hot paths
 **Learning:** V8 engine sorting (`[...arr].sort()`) is surprisingly slow and blocks the event loop for thousands of records when fetching Top-K elements (e.g. usage statistics). It scales at O(N log N) when O(N) is sufficient for a fixed K.
 **Action:** When gathering top elements from a large data array in this codebase, manually track the top items in a single O(N) pass rather than sorting a full copy.
+## 2024-05-24 - Array Tracking for Monotonically Increasing Loop Indices
+**Learning:** Using `Set` to collect indices during sequential string/array iteration is an anti-pattern. Because the loop index strictly increases, the gathered elements are inherently unique and sorted. Converting the `Set` via `Array.from(...).sort()` adds redundant $O(N \log N)$ sorting and unnecessary memory overhead.
+**Action:** Use a standard `number[]` array and `.push()` when tracking positions in a sequential loop. Avoid `Set` when uniqueness is already guaranteed by the iteration mechanics.

--- a/src/connectors/db/lib/policy.ts
+++ b/src/connectors/db/lib/policy.ts
@@ -251,8 +251,10 @@ function _boundarySemicolons(
   sql: string,
   treatBackslashAsEscape: boolean,
   dialect: SqlDialect = "generic",
-): Set<number> {
-  const boundaries = new Set<number>();
+): number[] {
+  // Optimization: use an array instead of a Set since we iterate sequentially,
+  // naturally producing monotonically increasing indices.
+  const boundaries: number[] = [];
   let inString: string | null = null; // Either null, "'", '"', or '`'
 
   for (let i = 0; i < sql.length; i++) {
@@ -280,7 +282,7 @@ function _boundarySemicolons(
           i = dEnd - 1; // Advance loop to end of dollar quote
         }
       } else if (c === ";") {
-        boundaries.add(i);
+        boundaries.push(i);
       }
     }
   }
@@ -306,18 +308,16 @@ function _splitStatements(sql: string, dialect: SqlDialect = "generic"): string[
   const b1 = _boundarySemicolons(cleaned, false, dialect);
   const b2 = _boundarySemicolons(cleaned, true, dialect);
 
-  if (b1.size !== b2.size) {
+  if (b1.length !== b2.length) {
     throw new Error("Ambiguous SQL statement boundaries");
   }
-  const b1Array = Array.from(b1).sort((a, b) => a - b);
-  const b2Array = Array.from(b2).sort((a, b) => a - b);
-  for (let i = 0; i < b1Array.length; i++) {
-    if (b1Array[i] !== b2Array[i]) {
+  for (let i = 0; i < b1.length; i++) {
+    if (b1[i] !== b2[i]) {
       throw new Error("Ambiguous SQL statement boundaries");
     }
   }
 
-  const boundaries = b1Array;
+  const boundaries = b1;
 
   const out: string[] = [];
   let start = 0;


### PR DESCRIPTION
💡 **What:** Replaced the use of `Set<number>` with `number[]` in `_boundarySemicolons`, and removed the subsequent `Array.from(...).sort(...)` call in `_splitStatements`.

🎯 **Why:** When scanning SQL strings sequentially, the captured semicolon indices naturally occur in monotonically increasing order. Storing these indices in a `Set` only to convert them into an array and perform an $O(N \log N)$ sort is completely redundant overhead for an operation that runs on every statement policy evaluation.

📊 **Impact:** Reduces memory allocation overhead (avoiding `Set` internals) and eliminates unnecessary sorting cycles during SQL policy enforcement.

🔬 **Measurement:** Verify by running `npm run test` focusing on `tests/connectors/db/policy.test.ts`. The behavior and boundaries classification remain perfectly exact.

---
*PR created automatically by Jules for task [641920476202480293](https://jules.google.com/task/641920476202480293) started by @rfv-code*