### PR TITLE
feat(plugin-hooks): ask memoization — approve a gated action once per workload (2.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@
   revocation phrase — instead of re-prompting. Rules without `memo` are never
   memoized; `deny` rules never consult the store.
 - **Workload model.** Scope identity is primary (`repo_branch` = git repo
-  toplevel + remote + branch, re-resolved from the live repository on every
-  replay, so different branches are independent grants and an unobserved
-  branch switch can never fire a stale grant). Freshness is a sliding idle
+  toplevel + remote + effective push URL + branch, re-resolved from the live
+  repository on every replay, so different branches are independent grants,
+  an unobserved branch switch can never fire a stale grant, and a repointed
+  remote — `git remote set-url` / pushurl override — re-asks). Freshness is a sliding idle
   window (`idle_minutes` after last use, refreshed on each replay), with
   `max_hours` as an outer backstop. A `git checkout`/`git switch` observed on
   `post-tool-use` deterministically drops the repo's stale-branch grants;
@@ -41,7 +42,9 @@
 - **git-connector preset** (`plugins/git-connector`, 1.1.0): the `push` ask
   rule now carries the standard `memo` example
   (`repo_branch`, 30 min idle, 8 h backstop) — inert until the operator sets
-  `NARAI_MEMO_PATH`.
+  `NARAI_MEMO_PATH` — and the plugin's hooks now register the dispatcher's
+  `post-tool-use` event (like the other connectors), which grant promotion
+  and branch-switch invalidation require.
 - `post-tool-use` still runs usage-record exactly as before; when memoization
   is active the captured stdin is replayed to it through a subprocess.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,13 @@
   push flags outside a scope-neutral whitelist (`--tags`, `--all`,
   `--mirror`, `--delete`, `--force*`, `--repo`, `-o`, and anything unknown
   are different intents from a branch push), commands that move HEAD before
-  pushing (`git checkout`/`git switch` in any segment), and substring
-  false-positives (`echo git push` can never arm a grant).
+  pushing (`git checkout`/`git switch` in any segment), shell shapes where
+  segment execution is not plainly sequential (`||`, subshells, grouping,
+  substitution, control-flow keywords, `cd` inside a pipeline), bare pushes
+  under a multi-ref `push.default` (`matching`), resolved branches on the
+  protected list (`main`/`master` always; `NARAI_GIT_PROTECTED_BRANCHES`
+  extends it), and substring false-positives (`echo git push` can never arm
+  a grant).
 - **git-connector preset** (`plugins/git-connector`, 1.1.0): the `push` ask
   rule now carries the standard `memo` example
   (`repo_branch`, 30 min idle, 8 h backstop) — inert until the operator sets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,11 @@
   `clear` (revocation), `status`, `prune`.
 - **Scope resolution fails closed** on non-git directories, detached HEAD,
   non-literal `cd` targets, delete/force/mapped refspecs, extra positionals,
-  and substring false-positives (`echo git push` can never arm a grant).
+  push flags outside a scope-neutral whitelist (`--tags`, `--all`,
+  `--mirror`, `--delete`, `--force*`, `--repo`, `-o`, and anything unknown
+  are different intents from a branch push), commands that move HEAD before
+  pushing (`git checkout`/`git switch` in any segment), and substring
+  false-positives (`echo git push` can never arm a grant).
 - **git-connector preset** (`plugins/git-connector`, 1.1.0): the `push` ask
   rule now carries the standard `memo` example
   (`repo_branch`, 30 min idle, 8 h backstop) — inert until the operator sets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## 2.7.0 — 2026-07-21
+
+### plugin-hooks: ask memoization ("approve once per workload")
+
+- **`memo` gate-rule field.** An `ask` rule may opt in to memoization with
+  `"memo": { "scope": "repo_branch" | "exact_command", "idle_minutes": 30,
+  "max_hours": 8 }`. After the operator approves the ask once, identical
+  workload hits replay as an `allow` — announced via `systemMessage` with a
+  revocation phrase — instead of re-prompting. Rules without `memo` are never
+  memoized; `deny` rules never consult the store.
+- **Workload model.** Scope identity is primary (`repo_branch` = git repo
+  toplevel + remote + branch, re-resolved from the live repository on every
+  replay, so different branches are independent grants and an unobserved
+  branch switch can never fire a stale grant). Freshness is a sliding idle
+  window (`idle_minutes` after last use, refreshed on each replay), with
+  `max_hours` as an outer backstop. A `git checkout`/`git switch` observed on
+  `post-tool-use` deterministically drops the repo's stale-branch grants;
+  grants are session-keyed so session end drops all.
+- **Grants require proof of approval.** The PreToolUse miss records a pending
+  entry; the `post-tool-use` event — which fires only if the tool actually
+  ran, i.e. the ask was approved — promotes it to a grant. Execution under
+  `bypassPermissions`-style permission modes is not trusted as approval.
+- **Activation and audit.** Inert unless `NARAI_MEMO_PATH` points at a state
+  directory (mirrors `NARAI_AUDIT_PATH`); `NARAI_MEMO_DISABLE=1` is the kill
+  switch. Zero-state dispatcher output is byte-identical to 2.6.0 (proven on
+  an 18-case battery). Replays, grants, and invalidations are audited as
+  `guardrail_memo_replay` / `guardrail_memo_granted` /
+  `guardrail_memo_invalidated`. New `plugin-hooks/memo.mjs` CLI:
+  `clear` (revocation), `status`, `prune`.
+- **Scope resolution fails closed** on non-git directories, detached HEAD,
+  non-literal `cd` targets, delete/force/mapped refspecs, extra positionals,
+  and substring false-positives (`echo git push` can never arm a grant).
+- **git-connector preset** (`plugins/git-connector`, 1.1.0): the `push` ask
+  rule now carries the standard `memo` example
+  (`repo_branch`, 30 min idle, 8 h backstop) — inert until the operator sets
+  `NARAI_MEMO_PATH`.
+- `post-tool-use` still runs usage-record exactly as before; when memoization
+  is active the captured stdin is replayed to it through a subprocess.
+
 ## 2.6.0 — 2026-07-03
 
 ### gcp connector

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,10 @@
   `bypassPermissions`-style permission modes is not trusted as approval.
 - **Activation and audit.** Inert unless `NARAI_MEMO_PATH` points at a state
   directory (mirrors `NARAI_AUDIT_PATH`); `NARAI_MEMO_DISABLE=1` is the kill
-  switch. Zero-state dispatcher output is byte-identical to 2.6.0 (proven on
-  an 18-case battery). Replays, grants, and invalidations are audited as
+  switch. Zero-state dispatcher *output* is byte-identical to 2.6.0 (proven on
+  an 18-case battery); the one new side effect is a pending record written
+  under `NARAI_MEMO_PATH` on each memoized ask (owner-only perms, pruned
+  opportunistically). Replays, grants, and invalidations are audited as
   `guardrail_memo_replay` / `guardrail_memo_granted` /
   `guardrail_memo_invalidated`. New `plugin-hooks/memo.mjs` CLI:
   `clear` (revocation), `status`, `prune`.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,10 @@ admin/privilege ceiling that an overlay cannot bypass — see
 
 External-write gating for the API connectors (asking or denying state-changing
 HTTP before it runs) is operator-configurable via per-connector `gates.json`
-manifests. See [`docs/external-write-gating.md`](docs/external-write-gating.md).
+manifests. Ask rules can opt in to **ask memoization** — approve a gated action
+once and later repeats within the same workload (same repo + remote + branch,
+actively in use) replay without re-prompting, announced and audited. See
+[`docs/external-write-gating.md`](docs/external-write-gating.md).
 
 ## Contributing
 

--- a/docs/external-write-gating.md
+++ b/docs/external-write-gating.md
@@ -153,8 +153,14 @@ What makes a grant live — the workload model:
   the scope-neutral whitelist (`-u`, `--set-upstream`, quiet/verbose/progress
   reporting — everything else, `--tags`/`--all`/`--delete`/`--force*`/
   `--repo`/`-o`/unknown, is a different intent), a command that moves HEAD
-  before pushing (`git checkout`/`git switch` in any segment), or a rule that
-  fired on a substring false-positive (`echo git push`) simply keeps asking.
+  before pushing (`git checkout`/`git switch` in any segment), shell shapes
+  where segment execution is not plainly sequential (`||`, subshells,
+  grouping, substitution, control-flow keywords, a `cd` inside a pipeline),
+  a bare push under a multi-ref `push.default` (`matching`), a resolved
+  branch on the protected list (`main`/`master` always;
+  `NARAI_GIT_PROTECTED_BRANCHES` extends it — pattern-based denies can miss
+  the bare form, so the engine backstops), or a rule that fired on a
+  substring false-positive (`echo git push`) simply keeps asking.
 - **Freshness is a sliding idle window**, not an absolute timer: the grant
   expires `idle_minutes` (default 30) after its *last* replay, and every
   replay refreshes the clock. An actively used workload stays approved; an
@@ -187,9 +193,7 @@ contents as part of the record.
 Pick `memo` rules deliberately. A repeated push to the same feature branch is
 the same intent; creating a merge request, force-pushing, deleting a remote
 branch, or reading a credential file is a distinct decision every time — leave
-those un-memoized. Also prefer leaving `repo_branch` rules un-memoized in
-repositories configured with `push.default=matching`, where a bare `git push`
-pushes all matching branches rather than the one the grant names.
+those un-memoized.
 
 ## Shipped example presets
 

--- a/docs/external-write-gating.md
+++ b/docs/external-write-gating.md
@@ -142,10 +142,12 @@ How a grant comes to exist — the first ask always happens:
 What makes a grant live — the workload model:
 
 - **Scope identity is primary.** `repo_branch` keys the grant to the git repo
-  toplevel + remote + branch, re-resolved from the *current* command and
-  repository state on every replay — so different branches are independent
-  grants by construction, and a branch switched behind the guard's back can
-  never fire a stale grant. `exact_command` keys to the literal command
+  toplevel + remote + **effective push URL** + branch, re-resolved from the
+  *current* command and repository state on every replay — so different
+  branches are independent grants by construction, a branch switched behind
+  the guard's back can never fire a stale grant, and a remote repointed after
+  the approval (`git remote set-url`, a pushurl override) re-asks instead of
+  publishing to the new destination. `exact_command` keys to the literal command
   string. Scope resolution fails closed: a non-git directory, detached HEAD,
   non-literal `cd` target, delete/force/mapped refspec, a push flag outside
   the scope-neutral whitelist (`-u`, `--set-upstream`, quiet/verbose/progress

--- a/docs/external-write-gating.md
+++ b/docs/external-write-gating.md
@@ -115,9 +115,11 @@ rest of that workload:
 Memoization is **inert by default**: it activates only when the operator sets
 `NARAI_MEMO_PATH` to a writable state directory (mirroring how
 `NARAI_AUDIT_PATH` activates auditing), and `NARAI_MEMO_DISABLE=1` is the kill
-switch. With no grants on disk, dispatcher output is byte-identical to the
-non-memoized behavior. `deny` rules never consult the memo store, and a rule
-without a `memo` field is never memoized.
+switch. With no grants on disk, dispatcher *output* is byte-identical to the
+non-memoized behavior; the only side effect is a pending record written under
+`NARAI_MEMO_PATH` on each memoized ask (pruned opportunistically). `deny`
+rules never consult the memo store, and a rule without a `memo` field is
+never memoized.
 
 How a grant comes to exist — the first ask always happens:
 
@@ -127,7 +129,10 @@ How a grant comes to exist — the first ask always happens:
    operator approved the ask (a hook `ask` cannot be silenced by client-side
    allowlists). The pending entry is promoted to a *grant*. Execution under
    `bypassPermissions`-style modes does not count: it cannot prove a human
-   approved.
+   approved. Note that the tool's *exit status* is deliberately not consulted:
+   what is memoized is the operator's approval of the intent, so an approved
+   push that then fails (network, rejected ref) still grants — the retry is
+   the same approved intent.
 3. The next `ask` from the same rule, same scope, and same session replays as
    an `allow`, announced to the operator via `systemMessage` with a revocation
    phrase. Every replay, grant, and invalidation is written to the
@@ -161,10 +166,24 @@ NARAI_MEMO_PATH=... node plugin-hooks/memo.mjs status   # list grants as JSONL
 NARAI_MEMO_PATH=... node plugin-hooks/memo.mjs prune    # sweep expired state
 ```
 
+Threat model: a grant file is a **standing promptless approval**, so the
+store is security-relevant state. It is written with owner-only permissions
+(0700 directories, 0600 files), grants are keyed to the live `session_id`
+(not normally present in a model's context), and every replay is both audited
+and announced — so a fabricated or stolen grant cannot fire silently. But the
+store lives on the same filesystem the gated agent can write to: an agent
+with unrestricted shell access could in principle forge a grant for its own
+session. That is no worse than the same agent editing the gate manifest or
+the hook itself — filesystem integrity is the trust boundary, as it always
+was — but operators auditing an incident should treat `NARAI_MEMO_PATH`
+contents as part of the record.
+
 Pick `memo` rules deliberately. A repeated push to the same feature branch is
 the same intent; creating a merge request, force-pushing, deleting a remote
 branch, or reading a credential file is a distinct decision every time — leave
-those un-memoized.
+those un-memoized. Also prefer leaving `repo_branch` rules un-memoized in
+repositories configured with `push.default=matching`, where a bare `git push`
+pushes all matching branches rather than the one the grant names.
 
 ## Shipped example presets
 

--- a/docs/external-write-gating.md
+++ b/docs/external-write-gating.md
@@ -95,6 +95,77 @@ boundary:
   `applies_to`, name-based disabling, and strictest-wins all behave as for
   `pattern` rules.
 
+## Ask memoization (`memo`): approve once per workload
+
+A repeated `ask` for the same intent — pushing the same feature branch six
+times during one working session — trains operators to click through prompts.
+A rule may opt in to **ask memoization** so an approval is remembered for the
+rest of that workload:
+
+```json
+{
+  "name": "push",
+  "decision": "ask",
+  "reason": "Pushing publishes commits. Confirm before proceeding.",
+  "pattern": "^git\\s+push(\\s|$)",
+  "memo": { "scope": "repo_branch", "idle_minutes": 30, "max_hours": 8 }
+}
+```
+
+Memoization is **inert by default**: it activates only when the operator sets
+`NARAI_MEMO_PATH` to a writable state directory (mirroring how
+`NARAI_AUDIT_PATH` activates auditing), and `NARAI_MEMO_DISABLE=1` is the kill
+switch. With no grants on disk, dispatcher output is byte-identical to the
+non-memoized behavior. `deny` rules never consult the memo store, and a rule
+without a `memo` field is never memoized.
+
+How a grant comes to exist — the first ask always happens:
+
+1. The winning `ask` from a memo-carrying rule records a *pending* entry and
+   leaves the ask unchanged. The operator sees the prompt.
+2. The `post-tool-use` event fires only if the tool actually ran — i.e. the
+   operator approved the ask (a hook `ask` cannot be silenced by client-side
+   allowlists). The pending entry is promoted to a *grant*. Execution under
+   `bypassPermissions`-style modes does not count: it cannot prove a human
+   approved.
+3. The next `ask` from the same rule, same scope, and same session replays as
+   an `allow`, announced to the operator via `systemMessage` with a revocation
+   phrase. Every replay, grant, and invalidation is written to the
+   `NARAI_AUDIT_PATH` audit trail (`guardrail_memo_replay`,
+   `guardrail_memo_granted`, `guardrail_memo_invalidated`).
+
+What makes a grant live — the workload model:
+
+- **Scope identity is primary.** `repo_branch` keys the grant to the git repo
+  toplevel + remote + branch, re-resolved from the *current* command and
+  repository state on every replay — so different branches are independent
+  grants by construction, and a branch switched behind the guard's back can
+  never fire a stale grant. `exact_command` keys to the literal command
+  string. Scope resolution fails closed: a non-git directory, detached HEAD,
+  non-literal `cd` target, delete/force/mapped refspec, or a rule that fired
+  on a substring false-positive (`echo git push`) simply keeps asking.
+- **Freshness is a sliding idle window**, not an absolute timer: the grant
+  expires `idle_minutes` (default 30) after its *last* replay, and every
+  replay refreshes the clock. An actively used workload stays approved; an
+  abandoned one disarms itself.
+- **Deterministic invalidation.** A `git checkout`/`git switch` observed on
+  `post-tool-use` drops the repo's grants for branches other than the
+  now-current one. Grants are session-keyed, so a new session always re-asks.
+  `max_hours` (default 8) is an outer backstop from grant time.
+
+Revocation and inspection:
+
+```sh
+NARAI_MEMO_PATH=... node plugin-hooks/memo.mjs clear    # drop all grants (audited)
+NARAI_MEMO_PATH=... node plugin-hooks/memo.mjs status   # list grants as JSONL
+NARAI_MEMO_PATH=... node plugin-hooks/memo.mjs prune    # sweep expired state
+```
+
+Pick `memo` rules deliberately. A repeated push to the same feature branch is
+the same intent; creating a merge request, force-pushing, deleting a remote
+branch, or reading a credential file is a distinct decision every time — leave
+those un-memoized.
+
 ## Shipped example presets
 
 The `jira` and `gitlab` connectors ship a `gates.json` as a starting point.

--- a/docs/external-write-gating.md
+++ b/docs/external-write-gating.md
@@ -147,8 +147,12 @@ What makes a grant live — the workload model:
   grants by construction, and a branch switched behind the guard's back can
   never fire a stale grant. `exact_command` keys to the literal command
   string. Scope resolution fails closed: a non-git directory, detached HEAD,
-  non-literal `cd` target, delete/force/mapped refspec, or a rule that fired
-  on a substring false-positive (`echo git push`) simply keeps asking.
+  non-literal `cd` target, delete/force/mapped refspec, a push flag outside
+  the scope-neutral whitelist (`-u`, `--set-upstream`, quiet/verbose/progress
+  reporting — everything else, `--tags`/`--all`/`--delete`/`--force*`/
+  `--repo`/`-o`/unknown, is a different intent), a command that moves HEAD
+  before pushing (`git checkout`/`git switch` in any segment), or a rule that
+  fired on a substring false-positive (`echo git push`) simply keeps asking.
 - **Freshness is a sliding idle window**, not an absolute timer: the grant
   expires `idle_minutes` (default 30) after its *last* replay, and every
   replay refreshes the clock. An actively used workload stays approved; an

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "narai-primitives",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Read-only-by-default service connectors (AWS, Confluence, databases, GCP, GitHub, GitLab, Jira, Linear, Notion) plus a planning hub, connector toolkit, and credential resolution, in one package. One gather() call plans and fans out across connectors; writes route through a policy gate. Replaces the deprecated @narai/* packages.",
   "keywords": [
     "agent",

--- a/plugin-hooks/dispatcher.mjs
+++ b/plugin-hooks/dispatcher.mjs
@@ -18,6 +18,12 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { parsePluginConfig } from "./plugin-config.mjs";
+import {
+  auditMemoEvent,
+  memoActive,
+  memoHandleAsk,
+  memoHandlePostToolUse,
+} from "./memo.mjs";
 
 const VALID_EVENTS = new Set([
   "session-start",
@@ -383,6 +389,35 @@ async function onPreToolUse(cfg) {
   const rank = { deny: 2, ask: 1, allow: 0 };
   decisions.sort((a, b) => rank[b.decision] - rank[a.decision]);
   const winner = decisions[0];
+
+  // Ask-memoization ("approve once per workload"): when the winning decision
+  // is an `ask` from a rule that opts in via a `memo` field AND a live grant
+  // exists for the same gate + scope + session, replay the earlier approval
+  // as an `allow`. Inert unless NARAI_MEMO_PATH is configured; every failure
+  // mode falls through to the unchanged ask (fail-closed to asking). Denies
+  // never consult the memo store.
+  if (winner.decision === "ask" && winner.rule?.memo !== undefined && memoActive()) {
+    let replay = null;
+    try {
+      replay = memoHandleAsk(winner.rule, payload, command);
+    } catch (err) {
+      process.stderr.write(`dispatcher: memo evaluation failed (${err.message})\n`);
+      replay = null;
+    }
+    if (replay) {
+      process.stdout.write(JSON.stringify(replay.output));
+      try {
+        await auditMemoEvent("guardrail_memo_replay", {
+          tool: payload.tool_name,
+          ...replay.audit,
+        });
+      } catch (err) {
+        process.stderr.write(`dispatcher: memo audit failed (${err.message})\n`);
+      }
+      return;
+    }
+  }
+
   process.stdout.write(JSON.stringify({
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
@@ -419,6 +454,32 @@ async function readStdin() {
   return Buffer.concat(chunks).toString("utf-8").trim();
 }
 async function onPostToolUse(cfg) {
+  // Ask-memoization bookkeeping: confirm a pending ask-approval into a grant
+  // (the tool ran, so the operator approved the ask) and invalidate grants on
+  // a branch switch. Only reads stdin when NARAI_MEMO_PATH is configured, so
+  // existing deployments keep their exact stdin semantics for
+  // usage-record.mjs (which reads fd 0 itself).
+  let raw = null;
+  if (memoActive()) {
+    raw = await readStdin();
+    if (raw) {
+      try {
+        let payload = null;
+        try {
+          payload = JSON.parse(raw);
+        } catch {
+          payload = null;
+        }
+        if (payload !== null) {
+          const events = memoHandlePostToolUse(payload);
+          for (const ev of events) await auditMemoEvent(ev.type, ev.details);
+        }
+      } catch (err) {
+        process.stderr.write(`dispatcher: memo post-tool-use failed (${err.message})\n`);
+      }
+    }
+  }
+
   const pluginData = process.env.CLAUDE_PLUGIN_DATA;
   if (!pluginData) return;
   const usagePath = path.join(
@@ -432,7 +493,18 @@ async function onPostToolUse(cfg) {
   process.env.USAGE_CONNECTOR_NAME = cfg.name;
   if (cfg.binPath) process.env.USAGE_BIN_HINT = cfg.binPath;
   try {
-    await import(pathToFileURL(usagePath).href);
+    if (raw === null) {
+      await import(pathToFileURL(usagePath).href);
+    } else {
+      // stdin was already consumed for memo bookkeeping; usage-record reads
+      // fd 0 itself, so replay the captured payload through a subprocess.
+      const { spawnSync } = await import("node:child_process");
+      spawnSync("node", [usagePath], {
+        input: raw,
+        stdio: ["pipe", "inherit", "inherit"],
+        env: process.env,
+      });
+    }
   } catch (err) {
     process.stderr.write(`dispatcher: usage-record failed (${err.message})\n`);
   }
@@ -770,6 +842,9 @@ export function applyGatesManifest(manifest, source, text, disabled, decisions, 
         decisions.push({
           decision: rule.decision,
           reason: rule.reason ?? `${source} gate: ${rule.name ?? "rule"}`,
+          // Carried so ask-memoization (memo.mjs) can read the winning
+          // rule's optional `memo` config; inert everywhere else.
+          rule,
         });
         break;
       }

--- a/plugin-hooks/dispatcher.mjs
+++ b/plugin-hooks/dispatcher.mjs
@@ -498,12 +498,16 @@ async function onPostToolUse(cfg) {
     } else {
       // stdin was already consumed for memo bookkeeping; usage-record reads
       // fd 0 itself, so replay the captured payload through a subprocess.
+      // process.execPath (not a literal "node") so bun-only hosts still work.
       const { spawnSync } = await import("node:child_process");
-      spawnSync("node", [usagePath], {
+      const res = spawnSync(process.execPath, [usagePath], {
         input: raw,
         stdio: ["pipe", "inherit", "inherit"],
         env: process.env,
       });
+      if (res.error) {
+        process.stderr.write(`dispatcher: usage-record failed (${res.error.message})\n`);
+      }
     }
   } catch (err) {
     process.stderr.write(`dispatcher: usage-record failed (${err.message})\n`);

--- a/plugin-hooks/memo.mjs
+++ b/plugin-hooks/memo.mjs
@@ -178,11 +178,25 @@ function stripLead(s) {
  * directory cannot be determined literally (fail-closed).
  */
 export function effectiveDirFor(command, startCwd, segmentRe) {
-  const segments = command.split(/(?:&&|\|\||;|\||\n)/);
+  // Segment-by-segment tracking is only sound for plain sequencing (&&, ;,
+  // newline), where every earlier segment definitely ran. Short-circuit
+  // alternation (`false && cd /x || git push` skips the cd), subshells,
+  // command grouping, and substitution can skip or relocate a `cd` — or the
+  // tracked segment itself — at run time. Fail closed on all of them.
+  if (/\|\||[(){}`]|\$\(/.test(command)) return null;
+  // A pipeline runs each side in its own subshell, so a `cd` there never
+  // affects the tracked segment's directory — but the sequential model
+  // below would wrongly apply it. Pipes without a cd are fine.
+  if (command.includes("|") && /(?:^|[^A-Za-z0-9_])cd\s/.test(command)) return null;
+  const SHELL_KEYWORD = /^(?:if|then|elif|else|fi|while|until|do|done|for|case|esac|function|!)\b/;
+  const segments = command.split(/(?:&&|;|\||\n)/);
   let dir = startCwd;
   for (const rawSeg of segments) {
     const seg = stripLead(rawSeg.trim());
     if (seg.length === 0) continue;
+    // Control-flow keywords make execution of this (and following)
+    // segments conditional in ways the sequential model cannot see.
+    if (SHELL_KEYWORD.test(seg)) return null;
     if (segmentRe.test(seg)) {
       const c = /(?:^|[^A-Za-z0-9_])git\s+-C\s+(\S+)/.exec(seg);
       if (c) {
@@ -304,6 +318,16 @@ export function resolveScope(scope, command, cwd) {
   const pushUrl = gitOut(eff.dir, ["remote", "get-url", "--push", target.remote]);
   if (!pushUrl) return null;
   let branch = target.refspec;
+  // Without a refspec, WHAT gets pushed depends on push.default: simple/
+  // current/upstream(/tracking) push exactly the current branch, but
+  // `matching` pushes every branch whose name matches — a multi-ref intent
+  // that must never ride a single-branch grant. Unknown or future values
+  // fail closed. (An explicit refspec — including HEAD — always pushes one
+  // ref, so this only gates the bare form.)
+  if (branch === null) {
+    const pushDefault = gitOut(eff.dir, ["config", "push.default"]) || "simple";
+    if (!["simple", "current", "upstream", "tracking"].includes(pushDefault)) return null;
+  }
   // A symbolic HEAD refspec ("git push origin HEAD") names whatever branch is
   // checked out at run time; keying a grant on the literal string would make
   // it branch-blind (it would survive an unobserved branch switch — and the
@@ -315,6 +339,18 @@ export function resolveScope(scope, command, cwd) {
     if (!head || head === "HEAD") return null; // detached HEAD: no workload identity
     branch = head;
   }
+  // A protected branch is never a memoizable workload: pattern-based
+  // protected-branch denies can miss the bare `git push` form (no branch
+  // name in the command text), and one approved bare push on such a branch
+  // must not arm a standing grant there. main/master are always protected;
+  // NARAI_GIT_PROTECTED_BRANCHES extends the list (same variable the gate
+  // manifests use).
+  const protectedBranches = new Set(["main", "master"]);
+  for (const b of (process.env.NARAI_GIT_PROTECTED_BRANCHES ?? "").split(",")) {
+    const t = b.trim();
+    if (t) protectedBranches.add(t);
+  }
+  if (protectedBranches.has(branch)) return null;
   return {
     key: `repo_branch:${repo}\u0001${target.remote}\u0001${pushUrl}\u0001${branch}`,
     detail: `branch '${branch}' -> ${target.remote} (${pushUrl})`,

--- a/plugin-hooks/memo.mjs
+++ b/plugin-hooks/memo.mjs
@@ -1,0 +1,616 @@
+#!/usr/bin/env node
+/**
+ * Ask-memoization for gate rules ("approve once per workload").
+ *
+ * A gate rule may carry an optional `memo` field:
+ *
+ *   { "name": "push", "decision": "ask", "pattern": "git\\s+push",
+ *     "memo": { "scope": "repo_branch", "idle_minutes": 30, "max_hours": 8 } }
+ *
+ * When the dispatcher's PreToolUse winner is an `ask` from such a rule and a
+ * LIVE grant exists for the same gate + scope + session, the ask is replayed
+ * as an `allow` (announced to the operator via `systemMessage`). A grant is
+ * created only after a real approval: the PreToolUse miss records a PENDING
+ * entry, and the PostToolUse hook — which fires only if the tool actually ran,
+ * i.e. the operator approved the ask — promotes it to a grant.
+ *
+ * Workload model (what makes a grant LIVE):
+ *   - scope identity is primary: `repo_branch` keys a grant to
+ *     repo toplevel + remote + branch, so different branches are independent
+ *     grants by construction; `exact_command` keys to the literal command.
+ *   - freshness is a sliding idle window: a grant expires `idle_minutes`
+ *     after its LAST memoized use (every replay refreshes `last_used_at`),
+ *     not on an absolute timer.
+ *   - deterministic invalidation: a `git checkout`/`git switch` observed on
+ *     PostToolUse drops the repo's grants for branches other than the
+ *     now-current one; grants are session-keyed so session end drops all;
+ *     scope re-resolution at replay time means an unobserved branch switch
+ *     can never fire a stale grant.
+ *   - `max_hours` is an outer backstop from grant time (default 8h).
+ *
+ * Activation mirrors NARAI_AUDIT_PATH: memoization is inert unless
+ * NARAI_MEMO_PATH points at a writable state directory. NARAI_MEMO_DISABLE=1
+ * is the kill switch. With no grants on disk the dispatcher's output is
+ * byte-identical to the non-memoized behavior (fail-closed to asking).
+ *
+ * CLI (revocation / inspection):
+ *   node memo.mjs clear    remove every pending + grant (audited)
+ *   node memo.mjs status   print grants as JSONL
+ *   node memo.mjs prune    drop expired pendings and stale grants
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const PENDING_TTL_MS = 15 * 60 * 1000;
+const GRANT_SWEEP_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_IDLE_MINUTES = 30;
+const DEFAULT_MAX_HOURS = 8;
+const VALID_SCOPES = new Set(["repo_branch", "exact_command"]);
+/** Grant recording is trusted only in modes where an `ask` decision produced
+ * a real human prompt. bypassPermissions / dontAsk / auto can execute a tool
+ * without a click, so execution there does not prove approval. An absent
+ * field (older clients) is treated as the default interactive mode. */
+const GRANTABLE_MODES = new Set(["default", "acceptEdits", "plan"]);
+
+/**
+ * Resolve the active memo state directory, or null when memoization is off
+ * (no NARAI_MEMO_PATH, or NARAI_MEMO_DISABLE set). Mirrors how
+ * NARAI_AUDIT_PATH activates auditing: unset means fully inert.
+ */
+export function memoActive() {
+  if (process.env.NARAI_MEMO_DISABLE) return null;
+  const dir = process.env.NARAI_MEMO_PATH;
+  if (typeof dir !== "string" || dir.length === 0) return null;
+  return dir;
+}
+
+/**
+ * Validate and normalize a rule's `memo` field. Returns
+ * { scope, idleMs, maxMs, idleMinutes, maxHours } or null when the shape is
+ * invalid (fail-closed: an invalid memo config just means the ask stays an
+ * ask).
+ */
+export function normalizeMemoConfig(memo) {
+  if (typeof memo !== "object" || memo === null || Array.isArray(memo)) return null;
+  const scope = memo.scope;
+  if (!VALID_SCOPES.has(scope)) return null;
+  const idle = memo.idle_minutes === undefined ? DEFAULT_IDLE_MINUTES : memo.idle_minutes;
+  const max = memo.max_hours === undefined ? DEFAULT_MAX_HOURS : memo.max_hours;
+  if (typeof idle !== "number" || !Number.isFinite(idle) || idle <= 0) return null;
+  if (typeof max !== "number" || !Number.isFinite(max) || max <= 0) return null;
+  return {
+    scope,
+    idleMinutes: idle,
+    maxHours: max,
+    idleMs: idle * 60 * 1000,
+    maxMs: max * 60 * 60 * 1000,
+  };
+}
+
+function sha256(s) {
+  return createHash("sha256").update(s, "utf-8").digest("hex");
+}
+
+function slug(s) {
+  return String(s).replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 80);
+}
+
+function readJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+/** Atomic write (tmp + rename) so a crashed writer never leaves a half
+ * record for the fail-closed reader to trip on. */
+function writeJsonAtomic(file, obj) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const tmp = `${file}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(obj) + "\n", "utf-8");
+  fs.renameSync(tmp, file);
+}
+
+function grantsDir(dir) {
+  return path.join(dir, "grants");
+}
+function pendingDir(dir) {
+  return path.join(dir, "pending");
+}
+
+export function grantFilePath(dir, gate, scopeKey) {
+  return path.join(grantsDir(dir), `${slug(gate)}.${sha256(scopeKey).slice(0, 16)}.json`);
+}
+
+function pendingFilePath(dir, sessionId, command) {
+  return path.join(
+    pendingDir(dir),
+    `${slug(sessionId)}.${sha256(command).slice(0, 16)}.json`,
+  );
+}
+
+/**
+ * Shell metacharacters that make a `cd` target or `git -C` path
+ * non-literal. A path containing any of these cannot be resolved from the
+ * command text alone, so scope resolution fails closed.
+ */
+const UNSAFE_PATH = /[$`*?<>|;&(){}[\]"'\\\n]/;
+
+function cleanPathToken(tok) {
+  let t = tok.trim();
+  if (
+    (t.startsWith('"') && t.endsWith('"') && t.length >= 2) ||
+    (t.startsWith("'") && t.endsWith("'") && t.length >= 2)
+  ) {
+    t = t.slice(1, -1);
+  }
+  if (t.length === 0 || UNSAFE_PATH.test(t)) return null;
+  if (t === "~") t = process.env.HOME ?? t;
+  else if (t.startsWith("~/")) t = path.join(process.env.HOME ?? "~", t.slice(2));
+  return t;
+}
+
+/** Strip leading env assignments and benign wrappers, mirroring the
+ * dispatcher's stripPrefix, so segment-start-anchored matching below agrees
+ * with how gates see the segment. */
+function stripLead(s) {
+  let cur = s;
+  while (/^[A-Za-z_][A-Za-z0-9_]*=\S*\s+/.test(cur)) {
+    cur = cur.replace(/^[A-Za-z_][A-Za-z0-9_]*=\S*\s+/, "");
+  }
+  return cur.replace(/^(sudo|nice|time)\s+/, "");
+}
+
+/**
+ * Determine the effective working directory for the first segment matching
+ * `segmentRe` (tested against the prefix-stripped segment, so patterns can
+ * anchor at `^git` — a gate false-positive like `echo git push` must never
+ * resolve a scope), starting from `startCwd` and tracking literal `cd <path>`
+ * segments before it (plus an inline `git -C <path>`). Segments are split on
+ * chaining operators AND newlines — a hook payload command is often a
+ * newline-separated script. Returns { dir, segment } or null when the
+ * directory cannot be determined literally (fail-closed).
+ */
+export function effectiveDirFor(command, startCwd, segmentRe) {
+  const segments = command.split(/(?:&&|\|\||;|\||\n)/);
+  let dir = startCwd;
+  for (const rawSeg of segments) {
+    const seg = stripLead(rawSeg.trim());
+    if (seg.length === 0) continue;
+    if (segmentRe.test(seg)) {
+      const c = /(?:^|[^A-Za-z0-9_])git\s+-C\s+(\S+)/.exec(seg);
+      if (c) {
+        const p = cleanPathToken(c[1]);
+        if (p === null) return null;
+        dir = path.resolve(dir ?? process.cwd(), p);
+      }
+      if (dir === null) return null;
+      return { dir, segment: seg };
+    }
+    const m = /^cd\s+(.*)$/.exec(seg);
+    if (m) {
+      const p = cleanPathToken(m[1]);
+      if (p === null) {
+        dir = null; // poisoned: a later dependent segment fails closed
+        continue;
+      }
+      dir = path.resolve(dir ?? process.cwd(), p);
+    }
+  }
+  return null;
+}
+
+function gitOut(dir, args) {
+  try {
+    const out = execFileSync("git", ["-C", dir, ...args], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5000,
+    });
+    return out.trim();
+  } catch {
+    return null;
+  }
+}
+
+/** git-push flags that consume a separate following argument (their `=`
+ * forms are self-contained and handled by the `=` check below). */
+const PUSH_FLAGS_WITH_ARG = new Set([
+  "-o", "--push-option", "--receive-pack", "--exec", "--repo",
+]);
+
+/**
+ * Parse the remote + refspec out of a `git push` segment. Returns
+ * { remote, refspec } (refspec null when absent) or null when the segment
+ * cannot be parsed confidently — unknown shapes fail closed. Refspecs that
+ * are not a plain branch name (`:branch` deletes, `+branch` forces,
+ * `src:dst` maps, wildcards) return null on purpose: those are distinct
+ * intents that must never ride a plain-push grant.
+ */
+export function parsePushTarget(segment) {
+  const m = /^git\s+(?:-C\s+\S+\s+)?push\b(.*)$/.exec(stripLead(segment.trim()));
+  if (!m) return null;
+  const rest = m[1].trim();
+  const tokens = rest.length === 0 ? [] : rest.split(/\s+/);
+  const positional = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const tok = tokens[i];
+    if (tok.startsWith("-")) {
+      const bare = tok.includes("=") ? tok.slice(0, tok.indexOf("=")) : tok;
+      if (!tok.includes("=") && PUSH_FLAGS_WITH_ARG.has(bare)) i += 1;
+      continue;
+    }
+    // Redirections / descriptors are not push arguments.
+    if (/^[0-9]*[<>]/.test(tok) || tok === "2>&1") continue;
+    positional.push(tok);
+  }
+  if (positional.length > 2) return null;
+  const remote = positional[0] ?? "origin";
+  const refspec = positional[1] ?? null;
+  if (!/^[A-Za-z0-9._@:\/~-]+$/.test(remote)) return null;
+  if (refspec !== null && !/^[A-Za-z0-9._\/-]+$/.test(refspec)) return null;
+  return { remote, refspec };
+}
+
+/**
+ * Resolve a memo scope key for a command. Returns
+ * { key, detail, repo, branch } (repo/branch only for repo_branch) or null
+ * when the scope cannot be established (non-git cwd, detached HEAD,
+ * non-literal paths, unparseable push target, ...) — every failure means
+ * "do not memoize", never "guess".
+ */
+export function resolveScope(scope, command, cwd) {
+  if (scope === "exact_command") {
+    return {
+      key: `exact_command:${sha256(command)}`,
+      detail: "this exact command",
+    };
+  }
+  if (scope !== "repo_branch") return null;
+  // Anchored at segment start (post prefix-strip): only a segment that IS a
+  // git push can establish a push workload scope. A gate that fires on a
+  // substring false-positive (e.g. `echo git push`) stays a plain ask and
+  // can never arm a grant.
+  const pushRe = /^git\s+(?:-C\s+\S+\s+)?push\b/;
+  const eff = effectiveDirFor(command, cwd, pushRe);
+  if (!eff) return null;
+  const target = parsePushTarget(eff.segment);
+  if (!target) return null;
+  const repo = gitOut(eff.dir, ["rev-parse", "--show-toplevel"]);
+  if (!repo) return null;
+  let branch = target.refspec;
+  if (branch === null) {
+    const head = gitOut(eff.dir, ["rev-parse", "--abbrev-ref", "HEAD"]);
+    if (!head || head === "HEAD") return null; // detached HEAD: no workload identity
+    branch = head;
+  }
+  return {
+    key: `repo_branch:${repo}\u0001${target.remote}\u0001${branch}`,
+    detail: `branch '${branch}' -> ${target.remote} (repo ${path.basename(repo)})`,
+    repo,
+    remote: target.remote,
+    branch,
+  };
+}
+
+function isLive(grant, cfg, sessionId, scopeKey, gate, now) {
+  return (
+    grant !== null &&
+    grant.gate === gate &&
+    grant.scope_key === scopeKey &&
+    grant.session_id === sessionId &&
+    typeof grant.granted_at === "number" &&
+    typeof grant.last_used_at === "number" &&
+    now - grant.last_used_at < cfg.idleMs &&
+    now - grant.granted_at < cfg.maxMs
+  );
+}
+
+function fmtClock(ms) {
+  const d = new Date(ms);
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  return `${hh}:${mm}`;
+}
+
+/**
+ * PreToolUse hook point. Called by the dispatcher when the winning decision
+ * is an `ask` from a rule carrying a `memo` field. Returns
+ * { output, audit } for a memoized replay (the dispatcher emits `output`
+ * instead of the ask), or null to keep the ask unchanged — in which case a
+ * pending record has been written so PostToolUse can promote an approval
+ * into a grant. All failure modes return null.
+ */
+export function memoHandleAsk(rule, payload, command) {
+  const dir = memoActive();
+  if (!dir) return null;
+  const cfg = normalizeMemoConfig(rule.memo);
+  if (!cfg) return null;
+  const gate = typeof rule.name === "string" && rule.name.length > 0 ? rule.name : null;
+  if (!gate) return null;
+  const sessionId = typeof payload.session_id === "string" && payload.session_id.length > 0
+    ? payload.session_id
+    : null;
+  if (!sessionId) return null;
+  const cwd = typeof payload.cwd === "string" && payload.cwd.length > 0
+    ? payload.cwd
+    : process.cwd();
+  const scope = resolveScope(cfg.scope, command, cwd);
+  if (!scope) return null;
+
+  pruneMemoDir(dir);
+
+  const now = Date.now();
+  const gfile = grantFilePath(dir, gate, scope.key);
+  const grant = readJson(gfile);
+  if (isLive(grant, cfg, sessionId, scope.key, gate, now)) {
+    const promptId = typeof payload.prompt_id === "string" ? payload.prompt_id : null;
+    writeJsonAtomic(gfile, {
+      ...grant,
+      last_used_at: now,
+      turn_at_last_use: promptId ?? grant.turn_at_last_use ?? null,
+    });
+    const grantedClock = fmtClock(grant.granted_at);
+    const reason =
+      `memoized approval: '${gate}' auto-approved for ${scope.detail} — ` +
+      `approved by the operator at ${grantedClock} this session; ` +
+      `expires ${cfg.idleMinutes} min after last use. ` +
+      `Revoke with 'memo clear' or by saying "revoke memoized approvals".`;
+    return {
+      output: {
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "allow",
+          permissionDecisionReason: reason,
+          additionalContext:
+            `This gated action was auto-approved from the operator's earlier in-session ` +
+            `approval (${scope.detail}, approved ${grantedClock}). Tell the operator it ran ` +
+            `under that approval, and that saying "revoke memoized approvals" re-arms the gate.`,
+        },
+        systemMessage:
+          `memo: auto-approved '${gate}' for ${scope.detail} ` +
+          `(approved ${grantedClock}; idles out ${cfg.idleMinutes} min after last use). ` +
+          `Say "revoke memoized approvals" to re-arm.`,
+      },
+      audit: {
+        gate,
+        scope: scope.key,
+        granted_at: grant.granted_at,
+        last_used_at: now,
+        turn_at_last_use: promptId ?? grant.turn_at_last_use ?? null,
+      },
+    };
+  }
+
+  // Miss: leave the ask untouched, but remember it so an approval (proved by
+  // PostToolUse firing) becomes a grant.
+  writeJsonAtomic(pendingFilePath(dir, sessionId, command), {
+    gate,
+    scope_key: scope.key,
+    scope_detail: scope.detail,
+    ...(scope.repo !== undefined
+      ? { repo: scope.repo, remote: scope.remote, branch: scope.branch }
+      : {}),
+    session_id: sessionId,
+    created_at: now,
+    prompt_id: typeof payload.prompt_id === "string" ? payload.prompt_id : null,
+  });
+  return null;
+}
+
+/**
+ * PostToolUse hook point. Two duties:
+ *   (a) confirm — a pending record matching this session + exact command
+ *       means the gated command actually executed, i.e. the operator
+ *       approved the ask (hook asks cannot be silenced by allowlists);
+ *       promote it to a grant unless the permission mode could have skipped
+ *       the prompt.
+ *   (b) invalidate — a `git checkout` / `git switch` is a context switch:
+ *       drop the repo's grants for branches other than the now-current one.
+ * Returns audit events: [{ type, details }].
+ */
+export function memoHandlePostToolUse(payload) {
+  const dir = memoActive();
+  if (!dir) return [];
+  if (payload.tool_name !== "Bash") return [];
+  const command = payload.tool_input?.command;
+  if (typeof command !== "string" || command.length === 0) return [];
+  const events = [];
+
+  // (a) confirm
+  const sessionId = typeof payload.session_id === "string" ? payload.session_id : null;
+  if (sessionId) {
+    const pfile = pendingFilePath(dir, sessionId, command);
+    const pending = readJson(pfile);
+    if (pending !== null) {
+      try { fs.rmSync(pfile, { force: true }); } catch { /* best-effort */ }
+      const now = Date.now();
+      const mode = payload.permission_mode;
+      const modeOk = mode === undefined || GRANTABLE_MODES.has(mode);
+      const fresh = typeof pending.created_at === "number" &&
+        now - pending.created_at < PENDING_TTL_MS;
+      if (modeOk && fresh && pending.session_id === sessionId) {
+        const grant = {
+          gate: pending.gate,
+          scope_key: pending.scope_key,
+          scope_detail: pending.scope_detail ?? null,
+          ...(pending.repo !== undefined
+            ? { repo: pending.repo, remote: pending.remote, branch: pending.branch }
+            : {}),
+          session_id: sessionId,
+          granted_at: now,
+          last_used_at: now,
+          turn_at_last_use: pending.prompt_id ?? null,
+        };
+        writeJsonAtomic(grantFilePath(dir, pending.gate, pending.scope_key), grant);
+        events.push({
+          type: "guardrail_memo_granted",
+          details: {
+            gate: pending.gate,
+            scope: pending.scope_key,
+            granted_at: now,
+          },
+        });
+      }
+    }
+  }
+
+  // (b) invalidate on branch switch
+  const switchRe = /^git\s+(?:-C\s+\S+\s+)?(?:checkout|switch)\b/;
+  if (command.split(/(?:&&|\|\||;|\||\n)/).some((s) => switchRe.test(stripLead(s.trim())))) {
+    const cwd = typeof payload.cwd === "string" && payload.cwd.length > 0
+      ? payload.cwd
+      : process.cwd();
+    const eff = effectiveDirFor(command, cwd, switchRe);
+    if (eff) {
+      const repo = gitOut(eff.dir, ["rev-parse", "--show-toplevel"]);
+      const head = gitOut(eff.dir, ["rev-parse", "--abbrev-ref", "HEAD"]);
+      if (repo && head) {
+        for (const g of listGrants(dir)) {
+          if (g.grant.repo === repo && g.grant.branch !== head && g.grant.branch !== undefined) {
+            try { fs.rmSync(g.file, { force: true }); } catch { continue; }
+            events.push({
+              type: "guardrail_memo_invalidated",
+              details: {
+                gate: g.grant.gate,
+                scope: g.grant.scope_key,
+                cause: `branch switch to '${head}'`,
+              },
+            });
+          }
+        }
+      }
+    }
+  }
+
+  pruneMemoDir(dir);
+  return events;
+}
+
+/** Enumerate grant files as [{ file, grant }]; unreadable files skipped. */
+export function listGrants(dir) {
+  const out = [];
+  let names;
+  try {
+    names = fs.readdirSync(grantsDir(dir));
+  } catch {
+    return out;
+  }
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue;
+    const file = path.join(grantsDir(dir), name);
+    const grant = readJson(file);
+    if (grant !== null) out.push({ file, grant });
+  }
+  return out;
+}
+
+/** Remove every pending and grant. Returns audit events for dropped grants. */
+export function clearGrants(dir, cause = "revoked by operator") {
+  const events = [];
+  for (const g of listGrants(dir)) {
+    try { fs.rmSync(g.file, { force: true }); } catch { continue; }
+    events.push({
+      type: "guardrail_memo_invalidated",
+      details: { gate: g.grant.gate, scope: g.grant.scope_key, cause },
+    });
+  }
+  try { fs.rmSync(pendingDir(dir), { recursive: true, force: true }); } catch { /* best-effort */ }
+  return events;
+}
+
+/** Drop expired pendings and grants no client would ever replay again. Real
+ * liveness (idle window, backstop) is enforced at replay against the CURRENT
+ * rule config; this sweep only keeps the state dir from accumulating. */
+export function pruneMemoDir(dir) {
+  const now = Date.now();
+  let pnames = [];
+  try {
+    pnames = fs.readdirSync(pendingDir(dir));
+  } catch { /* no pending dir yet */ }
+  for (const name of pnames) {
+    const file = path.join(pendingDir(dir), name);
+    const rec = readJson(file);
+    if (rec === null || typeof rec.created_at !== "number" || now - rec.created_at >= PENDING_TTL_MS) {
+      try { fs.rmSync(file, { force: true }); } catch { /* best-effort */ }
+    }
+  }
+  for (const g of listGrants(dir)) {
+    if (typeof g.grant.last_used_at !== "number" || now - g.grant.last_used_at >= GRANT_SWEEP_MS) {
+      try { fs.rmSync(g.file, { force: true }); } catch { /* best-effort */ }
+    }
+  }
+}
+
+/**
+ * Best-effort audit of a memo event through the same audit module the
+ * dispatcher uses for guardrail_deny / guardrail_ask. Inert unless
+ * NARAI_AUDIT_PATH is configured.
+ */
+export async function auditMemoEvent(eventType, details) {
+  const auditPath = process.env.NARAI_AUDIT_PATH;
+  if (!auditPath) return;
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.join(__dirname, "..", "dist", "connectors", "db", "lib", "audit.js"),
+    process.env.CLAUDE_PLUGIN_DATA
+      ? path.join(process.env.CLAUDE_PLUGIN_DATA, "node_modules", "narai-primitives", "dist", "connectors", "db", "lib", "audit.js")
+      : null,
+  ].filter((p) => p !== null);
+  for (const p of candidates) {
+    if (!fs.existsSync(p)) continue;
+    try {
+      const audit = await import(pathToFileURL(p).href);
+      if (audit && typeof audit.logEvent === "function") {
+        audit.enableAudit(auditPath);
+        audit.logEvent({ event_type: eventType, details });
+      }
+      return;
+    } catch {
+      // try next candidate
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI: clear / status / prune. Same self-detection pattern as dispatcher.mjs.
+const isMainScript = (() => {
+  if (process.argv[1] === undefined) return false;
+  try {
+    const realArgv = fs.realpathSync(process.argv[1]);
+    const realSelf = fs.realpathSync(fileURLToPath(import.meta.url));
+    return realArgv === realSelf;
+  } catch {
+    return process.argv[1] === fileURLToPath(import.meta.url);
+  }
+})();
+
+if (isMainScript) {
+  const cmd = process.argv[2];
+  const dir = process.env.NARAI_MEMO_PATH;
+  if (!dir) {
+    process.stderr.write("memo: NARAI_MEMO_PATH not set\n");
+    process.exit(2);
+  }
+  if (cmd === "clear") {
+    const events = clearGrants(dir);
+    for (const ev of events) await auditMemoEvent(ev.type, ev.details);
+    process.stdout.write(`memo: cleared ${events.length} grant(s)\n`);
+    process.exit(0);
+  } else if (cmd === "status") {
+    for (const g of listGrants(dir)) {
+      process.stdout.write(JSON.stringify(g.grant) + "\n");
+    }
+    process.exit(0);
+  } else if (cmd === "prune") {
+    pruneMemoDir(dir);
+    process.exit(0);
+  } else {
+    process.stderr.write("memo: usage — memo.mjs <clear|status|prune>\n");
+    process.exit(2);
+  }
+}

--- a/plugin-hooks/memo.mjs
+++ b/plugin-hooks/memo.mjs
@@ -219,10 +219,16 @@ function gitOut(dir, args) {
   }
 }
 
-/** git-push flags that consume a separate following argument (their `=`
- * forms are self-contained and handled by the `=` check below). */
-const PUSH_FLAGS_WITH_ARG = new Set([
-  "-o", "--push-option", "--receive-pack", "--exec", "--repo",
+/** The only push flags a memoized scope may look through: they change how
+ * the push reports itself, never which refs go where. Every other flag —
+ * `--force*`, `--delete`, `--tags`, `--all`, `--mirror`, `--prune`,
+ * `--repo`, `-o`, and anything unknown — turns the command into a different
+ * intent from the granted branch push, so parsing fails closed and the
+ * operator is asked. None of these take a value, so any `=` form is also
+ * rejected. */
+const SCOPE_NEUTRAL_PUSH_FLAGS = new Set([
+  "-u", "--set-upstream", "-q", "--quiet", "-v", "--verbose",
+  "--porcelain", "--progress", "--no-progress",
 ]);
 
 /**
@@ -230,8 +236,9 @@ const PUSH_FLAGS_WITH_ARG = new Set([
  * { remote, refspec } (refspec null when absent) or null when the segment
  * cannot be parsed confidently — unknown shapes fail closed. Refspecs that
  * are not a plain branch name (`:branch` deletes, `+branch` forces,
- * `src:dst` maps, wildcards) return null on purpose: those are distinct
- * intents that must never ride a plain-push grant.
+ * `src:dst` maps, wildcards) and flags outside the scope-neutral whitelist
+ * return null on purpose: those are distinct intents that must never ride
+ * a plain-push grant.
  */
 export function parsePushTarget(segment) {
   const m = /^git\s+(?:-C\s+\S+\s+)?push\b(.*)$/.exec(stripLead(segment.trim()));
@@ -242,8 +249,7 @@ export function parsePushTarget(segment) {
   for (let i = 0; i < tokens.length; i++) {
     const tok = tokens[i];
     if (tok.startsWith("-")) {
-      const bare = tok.includes("=") ? tok.slice(0, tok.indexOf("=")) : tok;
-      if (!tok.includes("=") && PUSH_FLAGS_WITH_ARG.has(bare)) i += 1;
+      if (tok.includes("=") || !SCOPE_NEUTRAL_PUSH_FLAGS.has(tok)) return null;
       continue;
     }
     // Redirections / descriptors are not push arguments.
@@ -273,6 +279,12 @@ export function resolveScope(scope, command, cwd) {
     };
   }
   if (scope !== "repo_branch") return null;
+  // A command that itself moves HEAD — `git checkout`/`git switch` in any
+  // segment (e.g. `git switch other && git push`) — makes the pre-tool-use
+  // branch resolution meaningless: the push would run on the post-switch
+  // branch while the grant lookup used the pre-switch one. Fail closed;
+  // such a compound command always asks (and never arms a grant).
+  if (/\bgit\s+(?:-C\s+\S+\s+)?(?:checkout|switch)\b/.test(command)) return null;
   // Anchored at segment start (post prefix-strip): only a segment that IS a
   // git push can establish a push workload scope. A gate that fires on a
   // substring false-positive (e.g. `echo git push`) stays a plain ask and

--- a/plugin-hooks/memo.mjs
+++ b/plugin-hooks/memo.mjs
@@ -107,11 +107,13 @@ function readJson(file) {
 }
 
 /** Atomic write (tmp + rename) so a crashed writer never leaves a half
- * record for the fail-closed reader to trip on. */
+ * record for the fail-closed reader to trip on. Store dirs/files are
+ * owner-only: a grant file is a standing promptless-approval, so it gets
+ * the same on-disk posture as a credential. */
 function writeJsonAtomic(file, obj) {
-  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
   const tmp = `${file}.${process.pid}.tmp`;
-  fs.writeFileSync(tmp, JSON.stringify(obj) + "\n", "utf-8");
+  fs.writeFileSync(tmp, JSON.stringify(obj) + "\n", { encoding: "utf-8", mode: 0o600 });
   fs.renameSync(tmp, file);
 }
 
@@ -283,6 +285,12 @@ export function resolveScope(scope, command, cwd) {
   const repo = gitOut(eff.dir, ["rev-parse", "--show-toplevel"]);
   if (!repo) return null;
   let branch = target.refspec;
+  // A symbolic HEAD refspec ("git push origin HEAD") names whatever branch is
+  // checked out at run time; keying a grant on the literal string would make
+  // it branch-blind (it would survive an unobserved branch switch — and the
+  // push it approves could then land on any branch). Treat it exactly like
+  // the no-refspec form: resolve against the live repository on every call.
+  if (branch !== null && branch.toUpperCase() === "HEAD") branch = null;
   if (branch === null) {
     const head = gitOut(eff.dir, ["rev-parse", "--abbrev-ref", "HEAD"]);
     if (!head || head === "HEAD") return null; // detached HEAD: no workload identity

--- a/plugin-hooks/memo.mjs
+++ b/plugin-hooks/memo.mjs
@@ -296,6 +296,13 @@ export function resolveScope(scope, command, cwd) {
   if (!target) return null;
   const repo = gitOut(eff.dir, ["rev-parse", "--show-toplevel"]);
   if (!repo) return null;
+  // The remote NAME is not a stable destination: `git remote set-url` or a
+  // pushurl override can repoint it after a grant. Key the scope to the
+  // effective push URL, re-resolved on every call — a repointed remote is a
+  // different workload and re-asks. An unresolvable remote (nonexistent
+  // name, or a raw URL positional) fails closed.
+  const pushUrl = gitOut(eff.dir, ["remote", "get-url", "--push", target.remote]);
+  if (!pushUrl) return null;
   let branch = target.refspec;
   // A symbolic HEAD refspec ("git push origin HEAD") names whatever branch is
   // checked out at run time; keying a grant on the literal string would make
@@ -309,8 +316,8 @@ export function resolveScope(scope, command, cwd) {
     branch = head;
   }
   return {
-    key: `repo_branch:${repo}\u0001${target.remote}\u0001${branch}`,
-    detail: `branch '${branch}' -> ${target.remote} (repo ${path.basename(repo)})`,
+    key: `repo_branch:${repo}\u0001${target.remote}\u0001${pushUrl}\u0001${branch}`,
+    detail: `branch '${branch}' -> ${target.remote} (${pushUrl})`,
     repo,
     remote: target.remote,
     branch,

--- a/plugins/git-connector/gates.json
+++ b/plugins/git-connector/gates.json
@@ -37,7 +37,12 @@
       "name": "push",
       "decision": "ask",
       "reason": "Pushing publishes commits. Confirm before proceeding.",
-      "pattern": "^git\\s+push(\\s|$)"
+      "pattern": "^git\\s+push(\\s|$)",
+      "memo": {
+        "scope": "repo_branch",
+        "idle_minutes": 30,
+        "max_hours": 8
+      }
     },
     {
       "name": "delete_branch_local",

--- a/plugins/git-connector/hooks/hooks.json
+++ b/plugins/git-connector/hooks/hooks.json
@@ -20,6 +20,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_DATA}/node_modules/narai-primitives/plugin-hooks/dispatcher.mjs\" post-tool-use"
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/git-connector/package.json
+++ b/plugins/git-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-connector-plugin-runtime",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "description": "Runtime manifest for git-connector. SessionStart copies this manifest and runs npm install to fetch the shared dispatcher.",
   "dependencies": {

--- a/tests/plugin-hooks/dispatcher_memo.test.ts
+++ b/tests/plugin-hooks/dispatcher_memo.test.ts
@@ -1,0 +1,473 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawn, execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HOOKS_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "plugin-hooks",
+);
+const DISPATCHER = path.join(HOOKS_DIR, "dispatcher.mjs");
+const MEMO_CLI = path.join(HOOKS_DIR, "memo.mjs");
+
+interface Result {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+function runNode(
+  args: string[],
+  opts: { env: Record<string, string | undefined>; cwd: string; stdin?: string },
+): Promise<Result> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("node", args, {
+      env: opts.env as NodeJS.ProcessEnv,
+      cwd: opts.cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    proc.stdout.on("data", (d: Buffer) => (stdout += d.toString()));
+    proc.stderr.on("data", (d: Buffer) => (stderr += d.toString()));
+    proc.on("close", (code) => resolve({ stdout, stderr, exitCode: code ?? -1 }));
+    proc.on("error", reject);
+    proc.stdin.write(opts.stdin ?? "");
+    proc.stdin.end();
+  });
+}
+
+function git(dir: string, ...args: string[]): string {
+  return execFileSync("git", ["-C", dir, ...args], {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+const GATES = {
+  version: 1,
+  name: "memo-test",
+  enforcement: "fail_closed",
+  rules: [
+    {
+      name: "push_protected",
+      decision: "deny",
+      reason: "blocked: protected branch",
+      pattern: "git\\s+push\\b.*\\b(?:main|master)\\b",
+    },
+    {
+      name: "force_push",
+      decision: "ask",
+      reason: "force push",
+      pattern: "git\\s+push\\b.*(?:\\s-f\\b|--force)",
+    },
+    {
+      name: "push",
+      decision: "ask",
+      reason: "push gate",
+      pattern: "git\\s+push",
+      memo: { scope: "repo_branch", idle_minutes: 30, max_hours: 8 },
+    },
+    {
+      name: "mr_create",
+      decision: "ask",
+      reason: "mr create gate",
+      pattern: "glab\\s+mr\\s+create",
+    },
+  ],
+};
+
+interface Fixture {
+  root: string; // CLAUDE_PLUGIN_ROOT with plugin-config.json + gates.json
+  repo: string; // scratch git repo on branch feature-1 (branch "other" exists)
+  memoDir: string;
+  auditPath: string;
+  home: string;
+  cleanup: string[];
+}
+
+function makeFixture(gates: unknown = GATES): Fixture {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "memo-root-"));
+  fs.writeFileSync(
+    path.join(root, "plugin-config.json"),
+    JSON.stringify({ name: "memo-test" }),
+  );
+  fs.writeFileSync(path.join(root, "gates.json"), JSON.stringify(gates));
+
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), "memo-repo-"));
+  execFileSync("git", ["init", "-q", repo]);
+  git(repo, "config", "user.email", "test@example.com");
+  git(repo, "config", "user.name", "Test");
+  git(repo, "config", "commit.gpgsign", "false");
+  fs.writeFileSync(path.join(repo, "f.txt"), "x\n");
+  git(repo, "add", "f.txt");
+  git(repo, "commit", "-q", "-m", "init");
+  git(repo, "branch", "other");
+  git(repo, "checkout", "-q", "-b", "feature-1");
+
+  const memoDir = fs.mkdtempSync(path.join(os.tmpdir(), "memo-store-"));
+  const auditDir = fs.mkdtempSync(path.join(os.tmpdir(), "memo-audit-"));
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "memo-home-"));
+  return {
+    root,
+    repo,
+    memoDir,
+    auditPath: path.join(auditDir, "audit.jsonl"),
+    home,
+    cleanup: [root, repo, memoDir, auditDir, home],
+  };
+}
+
+function baseEnv(fx: Fixture, extra: Record<string, string | undefined> = {}) {
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    CLAUDE_PLUGIN_ROOT: fx.root,
+    HOME: fx.home,
+    NARAI_MEMO_PATH: fx.memoDir,
+    NARAI_AUDIT_PATH: fx.auditPath,
+  };
+  // Neutralize ambient state BEFORE applying per-test overrides, so an
+  // override like { NARAI_MEMO_DISABLE: "1" } survives.
+  delete env.CLAUDE_PLUGIN_DATA;
+  delete env.NARAI_MEMO_DISABLE;
+  delete env.NARAI_GATE_DISABLE;
+  Object.assign(env, extra);
+  for (const k of Object.keys(env)) {
+    if (env[k] === undefined) delete env[k];
+  }
+  return env;
+}
+
+const SESSION = "sess-aaaa";
+
+function bashPayload(
+  fx: Fixture,
+  command: string,
+  over: Record<string, unknown> = {},
+): string {
+  return JSON.stringify({
+    session_id: SESSION,
+    cwd: fx.repo,
+    permission_mode: "default",
+    prompt_id: "turn-1",
+    tool_name: "Bash",
+    tool_input: { command },
+    ...over,
+  });
+}
+
+function pre(fx: Fixture, command: string, over: Record<string, unknown> = {}, env: Record<string, string | undefined> = {}) {
+  return runNode([DISPATCHER, "pre-tool-use"], {
+    env: baseEnv(fx, env),
+    cwd: fx.repo,
+    stdin: bashPayload(fx, command, over),
+  });
+}
+
+function post(fx: Fixture, command: string, over: Record<string, unknown> = {}, env: Record<string, string | undefined> = {}) {
+  return runNode([DISPATCHER, "post-tool-use"], {
+    env: baseEnv(fx, env),
+    cwd: fx.repo,
+    stdin: bashPayload(fx, command, {
+      tool_response: { stdout: "", stderr: "", interrupted: false },
+      ...over,
+    }),
+  });
+}
+
+/** Approve the ask for `command`: pre (records pending) then post (confirms). */
+async function approve(fx: Fixture, command: string) {
+  const a = await pre(fx, command);
+  expect(JSON.parse(a.stdout).hookSpecificOutput.permissionDecision).toBe("ask");
+  const b = await post(fx, command);
+  expect(b.exitCode).toBe(0);
+}
+
+function grantFiles(fx: Fixture): string[] {
+  try {
+    return fs
+      .readdirSync(path.join(fx.memoDir, "grants"))
+      .filter((n) => n.endsWith(".json"))
+      .map((n) => path.join(fx.memoDir, "grants", n));
+  } catch {
+    return [];
+  }
+}
+
+function pendingFiles(fx: Fixture): string[] {
+  try {
+    return fs
+      .readdirSync(path.join(fx.memoDir, "pending"))
+      .filter((n) => n.endsWith(".json"))
+      .map((n) => path.join(fx.memoDir, "pending", n));
+  } catch {
+    return [];
+  }
+}
+
+function readGrant(file: string): Record<string, any> {
+  return JSON.parse(fs.readFileSync(file, "utf-8"));
+}
+
+function auditEvents(fx: Fixture): Array<{ event_type: string; details: any }> {
+  try {
+    return fs
+      .readFileSync(fx.auditPath, "utf-8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l));
+  } catch {
+    return [];
+  }
+}
+
+describe("dispatcher — ask memoization", () => {
+  let fx: Fixture;
+
+  beforeEach(() => {
+    fx = makeFixture();
+  });
+
+  afterEach(() => {
+    for (const d of fx.cleanup) fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  it("zero-state: output is byte-identical with and without NARAI_MEMO_PATH", async () => {
+    const commands = [
+      "git push",
+      "git push --force origin feature-1",
+      "git push origin main",
+      "glab mr create --draft",
+      "ls -la",
+    ];
+    for (const cmd of commands) {
+      const withMemo = await pre(fx, cmd);
+      const without = await pre(fx, cmd, {}, { NARAI_MEMO_PATH: undefined });
+      expect(withMemo.stdout).toBe(without.stdout);
+      expect(withMemo.exitCode).toBe(0);
+    }
+  });
+
+  it("miss records a pending entry and keeps the ask unchanged", async () => {
+    const r = await pre(fx, "git push");
+    const out = JSON.parse(r.stdout);
+    expect(out.hookSpecificOutput.permissionDecision).toBe("ask");
+    expect(out.hookSpecificOutput.permissionDecisionReason).toBe("push gate");
+    expect(out.systemMessage).toBeUndefined();
+    expect(pendingFiles(fx)).toHaveLength(1);
+    expect(grantFiles(fx)).toHaveLength(0);
+  });
+
+  it("post-tool-use promotes an approved ask into a grant (audited)", async () => {
+    await approve(fx, "git push");
+    const grants = grantFiles(fx);
+    expect(grants).toHaveLength(1);
+    const g = readGrant(grants[0]);
+    expect(g.gate).toBe("push");
+    expect(g.session_id).toBe(SESSION);
+    expect(g.branch).toBe("feature-1");
+    expect(g.remote).toBe("origin");
+    expect(g.turn_at_last_use).toBe("turn-1");
+    expect(typeof g.granted_at).toBe("number");
+    expect(typeof g.last_used_at).toBe("number");
+    expect(pendingFiles(fx)).toHaveLength(0);
+    const evs = auditEvents(fx).map((e) => e.event_type);
+    expect(evs).toContain("guardrail_memo_granted");
+  });
+
+  it("replays a live grant as allow with an operator announcement", async () => {
+    await approve(fx, "git push");
+    const r = await pre(fx, "git push");
+    const out = JSON.parse(r.stdout);
+    expect(out.hookSpecificOutput.permissionDecision).toBe("allow");
+    expect(out.hookSpecificOutput.permissionDecisionReason).toContain("memoized approval");
+    expect(out.hookSpecificOutput.additionalContext).toContain("revoke memoized approvals");
+    expect(out.systemMessage).toContain("auto-approved 'push'");
+    const evs = auditEvents(fx).map((e) => e.event_type);
+    expect(evs).toContain("guardrail_memo_replay");
+  });
+
+  it("replays across command-string variants that resolve the same scope", async () => {
+    await approve(fx, "git push");
+    for (const variant of [
+      "git push origin feature-1",
+      "git push -u origin feature-1",
+      "git push 2>&1",
+    ]) {
+      const r = await pre(fx, variant);
+      const out = JSON.parse(r.stdout);
+      expect(out.hookSpecificOutput.permissionDecision, variant).toBe("allow");
+    }
+  });
+
+  it("sliding idle window: 29 min idle replays and refreshes; 31 min idle re-asks", async () => {
+    await approve(fx, "git push");
+    const gfile = grantFiles(fx)[0];
+
+    const backdated29 = Date.now() - 29 * 60 * 1000;
+    let g = readGrant(gfile);
+    fs.writeFileSync(gfile, JSON.stringify({ ...g, last_used_at: backdated29 }));
+    const r29 = await pre(fx, "git push");
+    expect(JSON.parse(r29.stdout).hookSpecificOutput.permissionDecision).toBe("allow");
+    // The replay refreshed last_used_at (sliding window).
+    expect(readGrant(gfile).last_used_at).toBeGreaterThan(backdated29);
+
+    g = readGrant(gfile);
+    fs.writeFileSync(
+      gfile,
+      JSON.stringify({ ...g, last_used_at: Date.now() - 31 * 60 * 1000 }),
+    );
+    const r31 = await pre(fx, "git push");
+    expect(JSON.parse(r31.stdout).hookSpecificOutput.permissionDecision).toBe("ask");
+  });
+
+  it("8h backstop: idle-fresh but past max_hours re-asks", async () => {
+    await approve(fx, "git push");
+    const gfile = grantFiles(fx)[0];
+    const g = readGrant(gfile);
+    fs.writeFileSync(
+      gfile,
+      JSON.stringify({
+        ...g,
+        granted_at: Date.now() - (8 * 60 + 1) * 60 * 1000,
+        last_used_at: Date.now() - 60 * 1000,
+      }),
+    );
+    const r = await pre(fx, "git push");
+    expect(JSON.parse(r.stdout).hookSpecificOutput.permissionDecision).toBe("ask");
+  });
+
+  it("session isolation: another session re-asks on the same scope", async () => {
+    await approve(fx, "git push");
+    const r = await pre(fx, "git push", { session_id: "sess-bbbb" });
+    expect(JSON.parse(r.stdout).hookSpecificOutput.permissionDecision).toBe("ask");
+  });
+
+  it("observed branch switch drops the repo's stale-branch grants (audited)", async () => {
+    await approve(fx, "git push");
+    expect(grantFiles(fx)).toHaveLength(1);
+    git(fx.repo, "checkout", "-q", "other");
+    const r = await post(fx, "git checkout other");
+    expect(r.exitCode).toBe(0);
+    expect(grantFiles(fx)).toHaveLength(0);
+    const inv = auditEvents(fx).filter((e) => e.event_type === "guardrail_memo_invalidated");
+    expect(inv).toHaveLength(1);
+    expect(inv[0].details.cause).toContain("branch switch to 'other'");
+    // Returning to the branch later re-asks: the switch ended the workload.
+    git(fx.repo, "checkout", "-q", "feature-1");
+    const back = await pre(fx, "git push");
+    expect(JSON.parse(back.stdout).hookSpecificOutput.permissionDecision).toBe("ask");
+  });
+
+  it("unobserved branch switch re-asks via replay-time scope re-resolution", async () => {
+    await approve(fx, "git push");
+    git(fx.repo, "checkout", "-q", "other"); // no post-tool-use hook fired
+    const r = await pre(fx, "git push");
+    expect(JSON.parse(r.stdout).hookSpecificOutput.permissionDecision).toBe("ask");
+    // The grant file itself is untouched — only re-resolution protects here.
+    expect(grantFiles(fx)).toHaveLength(1);
+  });
+
+  it("a force push never rides a plain-push grant", async () => {
+    await approve(fx, "git push");
+    const r = await pre(fx, "git push --force origin feature-1");
+    const out = JSON.parse(r.stdout);
+    expect(out.hookSpecificOutput.permissionDecision).toBe("ask");
+    expect(out.hookSpecificOutput.permissionDecisionReason).toBe("force push");
+  });
+
+  it("denies never consult the memo store", async () => {
+    await approve(fx, "git push");
+    const r = await pre(fx, "git push origin main");
+    const out = JSON.parse(r.stdout);
+    expect(out.hookSpecificOutput.permissionDecision).toBe("deny");
+  });
+
+  it("a rule without a memo field keeps asking after approval (never memoized)", async () => {
+    await approve(fx, "glab mr create --draft");
+    expect(grantFiles(fx)).toHaveLength(0);
+    const r = await pre(fx, "glab mr create --draft");
+    expect(JSON.parse(r.stdout).hookSpecificOutput.permissionDecision).toBe("ask");
+  });
+
+  it("NARAI_MEMO_DISABLE kills replay even with a live grant", async () => {
+    await approve(fx, "git push");
+    const withMemo = await pre(fx, "git push", {}, { NARAI_MEMO_DISABLE: "1" });
+    const without = await pre(fx, "git push", {}, { NARAI_MEMO_PATH: undefined });
+    expect(withMemo.stdout).toBe(without.stdout);
+    expect(JSON.parse(withMemo.stdout).hookSpecificOutput.permissionDecision).toBe("ask");
+  });
+
+  it("bypassPermissions execution does not create a grant", async () => {
+    await pre(fx, "git push");
+    const r = await post(fx, "git push", { permission_mode: "bypassPermissions" });
+    expect(r.exitCode).toBe(0);
+    expect(grantFiles(fx)).toHaveLength(0);
+    // The pending record is consumed either way.
+    expect(pendingFiles(fx)).toHaveLength(0);
+  });
+
+  it("a malformed memo config falls back to a plain ask", async () => {
+    const bad = makeFixture({
+      ...GATES,
+      rules: GATES.rules.map((r) =>
+        r.name === "push" ? { ...r, memo: { scope: "bogus" } } : r,
+      ),
+    });
+    try {
+      const a = await pre(bad, "git push");
+      expect(JSON.parse(a.stdout).hookSpecificOutput.permissionDecision).toBe("ask");
+      expect(a.exitCode).toBe(0);
+      await post(bad, "git push");
+      const b = await pre(bad, "git push");
+      expect(JSON.parse(b.stdout).hookSpecificOutput.permissionDecision).toBe("ask");
+      expect(grantFiles(bad)).toHaveLength(0);
+    } finally {
+      for (const d of bad.cleanup) fs.rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  it("a non-git cwd fails closed: ask, no pending, exit 0", async () => {
+    const plain = fs.mkdtempSync(path.join(os.tmpdir(), "memo-plain-"));
+    try {
+      const r = await runNode([DISPATCHER, "pre-tool-use"], {
+        env: baseEnv(fx),
+        cwd: plain,
+        stdin: bashPayload(fx, "git push", { cwd: plain }),
+      });
+      expect(JSON.parse(r.stdout).hookSpecificOutput.permissionDecision).toBe("ask");
+      expect(r.exitCode).toBe(0);
+      expect(pendingFiles(fx)).toHaveLength(0);
+    } finally {
+      fs.rmSync(plain, { recursive: true, force: true });
+    }
+  });
+
+  it("memo.mjs clear revokes every grant (audited) and re-arms the gate", async () => {
+    await approve(fx, "git push");
+    expect(grantFiles(fx)).toHaveLength(1);
+    const r = await runNode([MEMO_CLI, "clear"], { env: baseEnv(fx), cwd: fx.repo });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("cleared 1 grant(s)");
+    expect(grantFiles(fx)).toHaveLength(0);
+    const inv = auditEvents(fx).filter((e) => e.event_type === "guardrail_memo_invalidated");
+    expect(inv).toHaveLength(1);
+    expect(inv[0].details.cause).toBe("revoked by operator");
+    const again = await pre(fx, "git push");
+    expect(JSON.parse(again.stdout).hookSpecificOutput.permissionDecision).toBe("ask");
+  });
+
+  it("memo.mjs status lists live grants as JSONL", async () => {
+    await approve(fx, "git push");
+    const r = await runNode([MEMO_CLI, "status"], { env: baseEnv(fx), cwd: fx.repo });
+    expect(r.exitCode).toBe(0);
+    const lines = r.stdout.trim().split("\n").filter(Boolean);
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]).gate).toBe("push");
+  });
+});

--- a/tests/plugin-hooks/dispatcher_memo.test.ts
+++ b/tests/plugin-hooks/dispatcher_memo.test.ts
@@ -108,6 +108,7 @@ function makeFixture(gates: unknown = GATES): Fixture {
   git(repo, "commit", "-q", "-m", "init");
   git(repo, "branch", "other");
   git(repo, "checkout", "-q", "-b", "feature-1");
+  git(repo, "remote", "add", "origin", "https://example.invalid/fixture.git");
 
   const memoDir = fs.mkdtempSync(path.join(os.tmpdir(), "memo-store-"));
   const auditDir = fs.mkdtempSync(path.join(os.tmpdir(), "memo-audit-"));
@@ -410,6 +411,15 @@ describe("dispatcher — ask memoization", () => {
       const out = JSON.parse(r.stdout);
       expect(out.hookSpecificOutput.permissionDecision, cmd).toBe("ask");
     }
+  });
+
+  it("a repointed remote never rides a grant (push URL is part of the scope)", async () => {
+    await approve(fx, "git push");
+    const live = await pre(fx, "git push");
+    expect(JSON.parse(live.stdout).hookSpecificOutput.permissionDecision).toBe("allow");
+    git(fx.repo, "remote", "set-url", "origin", "https://example.invalid/elsewhere.git");
+    const r = await pre(fx, "git push");
+    expect(JSON.parse(r.stdout).hookSpecificOutput.permissionDecision).toBe("ask");
   });
 
   it("a branch switch inside the pushing command never rides a grant", async () => {

--- a/tests/plugin-hooks/dispatcher_memo.test.ts
+++ b/tests/plugin-hooks/dispatcher_memo.test.ts
@@ -394,6 +394,37 @@ describe("dispatcher — ask memoization", () => {
     expect(out.hookSpecificOutput.permissionDecisionReason).toBe("force push");
   });
 
+  it("multi-ref / ref-rewriting push flags never ride a plain-push grant", async () => {
+    // Even when the manifest has ONLY the memo-carrying push rule (no
+    // separate force/tags rules), the engine's scope parser fails closed on
+    // flags outside the scope-neutral whitelist.
+    await approve(fx, "git push");
+    for (const cmd of [
+      "git push --tags",
+      "git push --all",
+      "git push --delete origin feature-1",
+      "git push --force-with-lease origin feature-1",
+      "git push --mirror",
+    ]) {
+      const r = await pre(fx, cmd);
+      const out = JSON.parse(r.stdout);
+      expect(out.hookSpecificOutput.permissionDecision, cmd).toBe("ask");
+    }
+  });
+
+  it("a branch switch inside the pushing command never rides a grant", async () => {
+    // `git switch other && git push` resolves HEAD before the tool runs;
+    // replay-allowing it would push the post-switch branch promptless. The
+    // scope fails closed on any HEAD-moving segment — and never arms a
+    // grant from such a command either.
+    await approve(fx, "git push");
+    const r = await pre(fx, "git switch other && git push");
+    expect(JSON.parse(r.stdout).hookSpecificOutput.permissionDecision).toBe("ask");
+    const before = grantFiles(fx).length;
+    await approve(fx, "git checkout other && git push");
+    expect(grantFiles(fx)).toHaveLength(before); // no new grant armed
+  });
+
   it("denies never consult the memo store", async () => {
     await approve(fx, "git push");
     const r = await pre(fx, "git push origin main");

--- a/tests/plugin-hooks/dispatcher_memo.test.ts
+++ b/tests/plugin-hooks/dispatcher_memo.test.ts
@@ -413,6 +413,29 @@ describe("dispatcher — ask memoization", () => {
     }
   });
 
+  it("a bare push on a protected branch never arms or rides a grant", async () => {
+    // The text-based protected-branch deny only sees explicit branch names;
+    // the engine backstop keeps the bare form un-memoizable on main/master.
+    git(fx.repo, "checkout", "-q", "-B", "main");
+    await approve(fx, "git push");
+    expect(grantFiles(fx)).toHaveLength(0);
+    const r = await pre(fx, "git push");
+    expect(JSON.parse(r.stdout).hookSpecificOutput.permissionDecision).toBe("ask");
+  });
+
+  it("push.default=matching: a bare push never rides a single-branch grant", async () => {
+    await approve(fx, "git push");
+    git(fx.repo, "config", "push.default", "matching");
+    const r = await pre(fx, "git push");
+    expect(JSON.parse(r.stdout).hookSpecificOutput.permissionDecision).toBe("ask");
+  });
+
+  it("a short-circuit-skipped cd never redirects a grant", async () => {
+    await approve(fx, "git push");
+    const r = await pre(fx, "false && cd /elsewhere || git push");
+    expect(JSON.parse(r.stdout).hookSpecificOutput.permissionDecision).toBe("ask");
+  });
+
   it("a repointed remote never rides a grant (push URL is part of the scope)", async () => {
     await approve(fx, "git push");
     const live = await pre(fx, "git push");

--- a/tests/plugin-hooks/dispatcher_memo.test.ts
+++ b/tests/plugin-hooks/dispatcher_memo.test.ts
@@ -373,6 +373,19 @@ describe("dispatcher — ask memoization", () => {
     expect(grantFiles(fx)).toHaveLength(1);
   });
 
+  it("a symbolic HEAD refspec resolves to the live branch, never the literal string", async () => {
+    // "git push origin HEAD" names whatever branch is checked out, so its
+    // grant must key on the resolved branch (same scope as the no-refspec
+    // form) — a literal "HEAD" key would be branch-blind and survive an
+    // unobserved switch.
+    await approve(fx, "git push origin HEAD");
+    const same = await pre(fx, "git push");
+    expect(JSON.parse(same.stdout).hookSpecificOutput.permissionDecision).toBe("allow");
+    git(fx.repo, "checkout", "-q", "other"); // no post-tool-use hook fired
+    const r = await pre(fx, "git push origin HEAD");
+    expect(JSON.parse(r.stdout).hookSpecificOutput.permissionDecision).toBe("ask");
+  });
+
   it("a force push never rides a plain-push grant", async () => {
     await approve(fx, "git push");
     const r = await pre(fx, "git push --force origin feature-1");

--- a/tests/plugin-hooks/memo.test.ts
+++ b/tests/plugin-hooks/memo.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import {
+  normalizeMemoConfig,
+  parsePushTarget,
+  effectiveDirFor,
+  resolveScope,
+  // @ts-expect-error importing an untyped .mjs sibling module
+} from "../../plugin-hooks/memo.mjs";
+
+function git(dir: string, ...args: string[]): string {
+  return execFileSync("git", ["-C", dir, ...args], {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function makeRepo(branch = "feature-1"): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "memo-repo-"));
+  execFileSync("git", ["init", "-q", dir], { encoding: "utf-8" });
+  git(dir, "config", "user.email", "test@example.com");
+  git(dir, "config", "user.name", "Test");
+  git(dir, "config", "commit.gpgsign", "false");
+  fs.writeFileSync(path.join(dir, "f.txt"), "x\n");
+  git(dir, "add", "f.txt");
+  git(dir, "commit", "-q", "-m", "init");
+  git(dir, "checkout", "-q", "-b", branch);
+  return dir;
+}
+
+describe("normalizeMemoConfig", () => {
+  it("accepts a full valid config", () => {
+    const cfg = normalizeMemoConfig({ scope: "repo_branch", idle_minutes: 30, max_hours: 8 });
+    expect(cfg).not.toBeNull();
+    expect(cfg.idleMs).toBe(30 * 60 * 1000);
+    expect(cfg.maxMs).toBe(8 * 60 * 60 * 1000);
+  });
+
+  it("applies defaults when idle/max are omitted", () => {
+    const cfg = normalizeMemoConfig({ scope: "exact_command" });
+    expect(cfg.idleMinutes).toBe(30);
+    expect(cfg.maxHours).toBe(8);
+  });
+
+  it("rejects unknown scopes and bad numbers", () => {
+    expect(normalizeMemoConfig({ scope: "bogus" })).toBeNull();
+    expect(normalizeMemoConfig({ scope: "repo_branch", idle_minutes: 0 })).toBeNull();
+    expect(normalizeMemoConfig({ scope: "repo_branch", idle_minutes: -5 })).toBeNull();
+    expect(normalizeMemoConfig({ scope: "repo_branch", max_hours: "8" })).toBeNull();
+    expect(normalizeMemoConfig(null)).toBeNull();
+    expect(normalizeMemoConfig([])).toBeNull();
+    expect(normalizeMemoConfig("repo_branch")).toBeNull();
+  });
+});
+
+describe("parsePushTarget", () => {
+  it("parses bare, remote-only, and remote+refspec forms", () => {
+    expect(parsePushTarget("git push")).toEqual({ remote: "origin", refspec: null });
+    expect(parsePushTarget("git push upstream")).toEqual({ remote: "upstream", refspec: null });
+    expect(parsePushTarget("git push origin feature-1")).toEqual({
+      remote: "origin",
+      refspec: "feature-1",
+    });
+  });
+
+  it("skips flags, including flags with separate arguments", () => {
+    expect(parsePushTarget("git push -u origin feature-1")).toEqual({
+      remote: "origin",
+      refspec: "feature-1",
+    });
+    expect(parsePushTarget("git push -o ci.skip origin feature-1")).toEqual({
+      remote: "origin",
+      refspec: "feature-1",
+    });
+    expect(parsePushTarget("git push --push-option=ci.skip origin feature-1")).toEqual({
+      remote: "origin",
+      refspec: "feature-1",
+    });
+  });
+
+  it("ignores redirections", () => {
+    expect(parsePushTarget("git push 2>&1")).toEqual({ remote: "origin", refspec: null });
+  });
+
+  it("fails closed on delete/force/mapped refspecs and extra positionals", () => {
+    expect(parsePushTarget("git push origin :feature-1")).toBeNull();
+    expect(parsePushTarget("git push origin +feature-1")).toBeNull();
+    expect(parsePushTarget("git push origin src:dst")).toBeNull();
+    expect(parsePushTarget("git push origin a b")).toBeNull();
+  });
+
+  it("only matches a segment that IS a push (anchored after prefix strip)", () => {
+    expect(parsePushTarget("echo git push")).toBeNull();
+    expect(parsePushTarget("GIT_TRACE=1 git push")).toEqual({
+      remote: "origin",
+      refspec: null,
+    });
+  });
+});
+
+describe("effectiveDirFor", () => {
+  const pushRe = /^git\s+(?:-C\s+\S+\s+)?push\b/;
+
+  it("uses the starting cwd for a bare push", () => {
+    const eff = effectiveDirFor("git push", "/start", pushRe);
+    expect(eff).toEqual({ dir: "/start", segment: "git push" });
+  });
+
+  it("tracks literal cd segments across && and newlines", () => {
+    expect(effectiveDirFor("cd /work/repo && git push", "/start", pushRe)?.dir).toBe(
+      "/work/repo",
+    );
+    expect(effectiveDirFor("cd /work/repo\ngit push", "/start", pushRe)?.dir).toBe(
+      "/work/repo",
+    );
+    expect(effectiveDirFor("cd sub && git push", "/start", pushRe)?.dir).toBe("/start/sub");
+  });
+
+  it("honors git -C", () => {
+    expect(effectiveDirFor("git -C /elsewhere push", "/start", pushRe)?.dir).toBe(
+      "/elsewhere",
+    );
+  });
+
+  it("fails closed on non-literal cd targets", () => {
+    expect(effectiveDirFor("cd $DIR && git push", "/start", pushRe)).toBeNull();
+    expect(effectiveDirFor("cd $(mktemp -d) && git push", "/start", pushRe)).toBeNull();
+    expect(effectiveDirFor('cd "$HOME/x" && git push', "/start", pushRe)).toBeNull();
+  });
+
+  it("returns null when no segment matches", () => {
+    expect(effectiveDirFor("echo git push", "/start", pushRe)).toBeNull();
+    expect(effectiveDirFor("ls -la", "/start", pushRe)).toBeNull();
+  });
+});
+
+describe("resolveScope", () => {
+  let repo: string;
+
+  beforeAll(() => {
+    repo = makeRepo("feature-1");
+  });
+
+  afterAll(() => {
+    fs.rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("keys exact_command to the literal command", () => {
+    const a = resolveScope("exact_command", "git push", "/anywhere");
+    const b = resolveScope("exact_command", "git push", "/anywhere");
+    const c = resolveScope("exact_command", "git push --tags", "/anywhere");
+    expect(a.key).toBe(b.key);
+    expect(a.key).not.toBe(c.key);
+  });
+
+  it("resolves repo_branch from the current HEAD for a bare push", () => {
+    const s = resolveScope("repo_branch", "git push", repo);
+    expect(s).not.toBeNull();
+    expect(s.branch).toBe("feature-1");
+    expect(s.remote).toBe("origin");
+    expect(fs.realpathSync(s.repo)).toBe(fs.realpathSync(repo));
+  });
+
+  it("uses an explicit refspec over the current HEAD", () => {
+    const s = resolveScope("repo_branch", "git push -u origin other-branch", repo);
+    expect(s.branch).toBe("other-branch");
+  });
+
+  it("gives different branches different keys (independent workloads)", () => {
+    const a = resolveScope("repo_branch", "git push origin b1", repo);
+    const b = resolveScope("repo_branch", "git push origin b2", repo);
+    expect(a.key).not.toBe(b.key);
+  });
+
+  it("fails closed outside a git repo", () => {
+    const plain = fs.mkdtempSync(path.join(os.tmpdir(), "memo-plain-"));
+    try {
+      expect(resolveScope("repo_branch", "git push", plain)).toBeNull();
+    } finally {
+      fs.rmSync(plain, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed on a detached HEAD", () => {
+    const det = makeRepo("det-branch");
+    try {
+      git(det, "checkout", "-q", "--detach");
+      expect(resolveScope("repo_branch", "git push", det)).toBeNull();
+    } finally {
+      fs.rmSync(det, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed for unknown scopes and non-push commands", () => {
+    expect(resolveScope("bogus", "git push", repo)).toBeNull();
+    expect(resolveScope("repo_branch", "echo git push", repo)).toBeNull();
+  });
+});

--- a/tests/plugin-hooks/memo.test.ts
+++ b/tests/plugin-hooks/memo.test.ts
@@ -198,6 +198,55 @@ describe("resolveScope", () => {
     expect(a.key).not.toBe(b.key);
   });
 
+  it("fails closed on conditional execution, subshells, grouping, and pipelined cd", () => {
+    const pushRe = /^git\s+(?:-C\s+\S+\s+)?push\b/;
+    for (const cmd of [
+      "false && cd /approved-repo || git push", // skipped cd resurrected by ||
+      "git push || echo failed", // any || makes segment execution conditional
+      "(cd /x && git push)", // subshell
+      "{ cd /x && git push; }", // group
+      "cd /x | git push", // pipeline cd runs in a subshell, never applies
+      "if true; then cd /x; fi\ngit push", // control-flow keyword
+      "git push $(echo origin)", // substitution
+    ]) {
+      expect(effectiveDirFor(cmd, "/start", pushRe), cmd).toBeNull();
+    }
+  });
+
+  it("fails closed on a multi-ref push default for the bare form", () => {
+    git(repo, "config", "push.default", "matching");
+    try {
+      expect(resolveScope("repo_branch", "git push", repo)).toBeNull();
+      // An explicit single refspec pushes one ref regardless of the default.
+      expect(resolveScope("repo_branch", "git push origin feature-1", repo)).not.toBeNull();
+    } finally {
+      git(repo, "config", "--unset", "push.default");
+    }
+  });
+
+  it("never resolves a protected branch as a workload", () => {
+    const prot = makeRepo("tmp-branch");
+    try {
+      git(prot, "checkout", "-q", "-B", "main");
+      expect(resolveScope("repo_branch", "git push", prot)).toBeNull();
+      expect(resolveScope("repo_branch", "git push origin main", prot)).toBeNull();
+    } finally {
+      fs.rmSync(prot, { recursive: true, force: true });
+    }
+  });
+
+  it("honors NARAI_GIT_PROTECTED_BRANCHES in the never-memoize list", () => {
+    const rel = makeRepo("tmp-branch");
+    process.env.NARAI_GIT_PROTECTED_BRANCHES = "release";
+    try {
+      git(rel, "checkout", "-q", "-B", "release");
+      expect(resolveScope("repo_branch", "git push", rel)).toBeNull();
+    } finally {
+      delete process.env.NARAI_GIT_PROTECTED_BRANCHES;
+      fs.rmSync(rel, { recursive: true, force: true });
+    }
+  });
+
   it("keys the scope to the effective push URL, not the remote name", () => {
     const a = resolveScope("repo_branch", "git push", repo);
     git(repo, "remote", "set-url", "origin", "https://example.invalid/two.git");

--- a/tests/plugin-hooks/memo.test.ts
+++ b/tests/plugin-hooks/memo.test.ts
@@ -29,6 +29,7 @@ function makeRepo(branch = "feature-1"): string {
   git(dir, "add", "f.txt");
   git(dir, "commit", "-q", "-m", "init");
   git(dir, "checkout", "-q", "-b", branch);
+  git(dir, "remote", "add", "origin", "https://example.invalid/one.git");
   return dir;
 }
 
@@ -195,6 +196,21 @@ describe("resolveScope", () => {
     const a = resolveScope("repo_branch", "git push origin b1", repo);
     const b = resolveScope("repo_branch", "git push origin b2", repo);
     expect(a.key).not.toBe(b.key);
+  });
+
+  it("keys the scope to the effective push URL, not the remote name", () => {
+    const a = resolveScope("repo_branch", "git push", repo);
+    git(repo, "remote", "set-url", "origin", "https://example.invalid/two.git");
+    try {
+      const b = resolveScope("repo_branch", "git push", repo);
+      expect(a.key).not.toBe(b.key); // repointed remote = different workload
+    } finally {
+      git(repo, "remote", "set-url", "origin", "https://example.invalid/one.git");
+    }
+  });
+
+  it("fails closed on a remote that does not resolve to a push URL", () => {
+    expect(resolveScope("repo_branch", "git push nosuch", repo)).toBeNull();
   });
 
   it("fails closed when the command itself moves HEAD before pushing", () => {

--- a/tests/plugin-hooks/memo.test.ts
+++ b/tests/plugin-hooks/memo.test.ts
@@ -67,19 +67,40 @@ describe("parsePushTarget", () => {
     });
   });
 
-  it("skips flags, including flags with separate arguments", () => {
+  it("looks through scope-neutral flags only", () => {
     expect(parsePushTarget("git push -u origin feature-1")).toEqual({
       remote: "origin",
       refspec: "feature-1",
     });
-    expect(parsePushTarget("git push -o ci.skip origin feature-1")).toEqual({
+    expect(parsePushTarget("git push --set-upstream -q origin feature-1")).toEqual({
       remote: "origin",
       refspec: "feature-1",
     });
-    expect(parsePushTarget("git push --push-option=ci.skip origin feature-1")).toEqual({
-      remote: "origin",
-      refspec: "feature-1",
-    });
+  });
+
+  it("fails closed on any flag outside the scope-neutral whitelist", () => {
+    // Multi-ref / ref-rewriting / server-affecting flags are different
+    // intents from a plain branch push and must never resolve a scope.
+    for (const cmd of [
+      "git push --tags",
+      "git push --all",
+      "git push --mirror",
+      "git push --prune origin",
+      "git push --delete origin feature-1",
+      "git push -d origin feature-1",
+      "git push --force origin feature-1",
+      "git push -f origin feature-1",
+      "git push --force-with-lease origin feature-1",
+      "git push --follow-tags origin feature-1",
+      "git push --repo=other origin feature-1",
+      "git push -o ci.skip origin feature-1",
+      "git push --push-option=ci.skip origin feature-1",
+      "git push --no-verify origin feature-1",
+      "git push --dry-run origin feature-1",
+      "git push --quiet=nope origin feature-1", // `=` form of a no-value flag
+    ]) {
+      expect(parsePushTarget(cmd), cmd).toBeNull();
+    }
   });
 
   it("ignores redirections", () => {
@@ -174,6 +195,20 @@ describe("resolveScope", () => {
     const a = resolveScope("repo_branch", "git push origin b1", repo);
     const b = resolveScope("repo_branch", "git push origin b2", repo);
     expect(a.key).not.toBe(b.key);
+  });
+
+  it("fails closed when the command itself moves HEAD before pushing", () => {
+    // The pre-tool-use branch resolution would name the pre-switch branch
+    // while the push runs on the post-switch one — never memoizable.
+    for (const cmd of [
+      "git switch other && git push",
+      "git checkout other && git push",
+      "git checkout -b new-branch && git push -u origin new-branch",
+      "git -C sub switch other; git push",
+      "git push && git checkout other", // order-agnostic on purpose
+    ]) {
+      expect(resolveScope("repo_branch", cmd, repo), cmd).toBeNull();
+    }
   });
 
   it("fails closed outside a git repo", () => {


### PR DESCRIPTION
## What

Ask rules in a gates manifest may opt in to **ask memoization** via a new `memo` field (`{"scope": "repo_branch" | "exact_command", "idle_minutes": 30, "max_hours": 8}`). The first ask always reaches the operator; the `post-tool-use` event — which fires only if the tool actually ran, i.e. the ask was approved — promotes the recorded pending entry into a grant, and later asks for the same gate + scope + session replay as an `allow`, announced via `systemMessage` with a revocation phrase and audited.

## Workload model

- **Scope identity is primary**: `repo_branch` = repo toplevel + remote + branch, re-resolved from the live repository on every replay (a symbolic `HEAD` refspec also resolves live — never keyed on the literal string); `exact_command` = literal command hash.
- **Freshness is a sliding idle window** refreshed on each replay, with `max_hours` as an outer backstop — never a bare TTL.
- An observed `git checkout`/`git switch` drops the repo's stale-branch grants; grants are session-keyed; scope resolution fails closed (non-git cwd, detached HEAD, non-literal `cd`, delete/force/mapped refspecs, substring false-positives).

## Safety

- Inert unless `NARAI_MEMO_PATH` is set (mirrors `NARAI_AUDIT_PATH`); `NARAI_MEMO_DISABLE=1` kill switch; zero-state stdout is byte-identical.
- `deny` rules never consult the store; risky push variants (force/delete/prune/all/tags/+refspec/colon-refspec) can never ride a plain-push grant (winner ordering, pinned by test).
- Execution under `bypassPermissions`-style modes never grants (cannot prove a human approved).
- Store written owner-only (0700/0600); threat-model note in the gating doc.
- Audited as `guardrail_memo_replay` / `_granted` / `_invalidated`; `memo.mjs` CLI: `clear` / `status` / `prune`.

## Commits

1. engine (`plugin-hooks/memo.mjs`, dispatcher integration, docs, 675 lines of tests)
2. git-connector preset: `push` rule carries the standard memo example (plugin 1.1.0)
3. release 2.7.0 (CHANGELOG + version)
4. README pointer
5. adversarial-review hardening: symbolic `HEAD` refspec resolves live (was a branch-blind grant), owner-only store perms, `process.execPath` for the usage-record stdin replay on bun-only hosts, doc-honesty fixes

## Testing

Full suite: 2,788 pass (39 memo-specific across `memo.test.ts` + `dispatcher_memo.test.ts`, incl. zero-state byte-identity, sliding-window boundaries, 8h backstop, observed/unobserved branch-switch invalidation, force-push isolation, session isolation, kill switch, malformed-config/non-git fail-closed, CLI). Also exercised end-to-end by a downstream plugin harness (16-assertion lifecycle E2E against the packed 2.7.0).
