### PR TITLE
🛡️ Sentinel: [HIGH] Fix Slowloris DoS vulnerability in fetch_attachment streaming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "narai-primitives",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "narai-primitives",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.119",
         "adf-to-markdown": "^1.0.1",
@@ -5376,22 +5376,6 @@
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
         "node-fetch": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/gcp-metadata": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
-      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
-        "json-bigint": "^1.0.0"
       },
       "engines": {
         "node": ">=18"

--- a/src/toolkit/fetch_attachment.ts
+++ b/src/toolkit/fetch_attachment.ts
@@ -100,107 +100,106 @@ export async function fetchAttachment(
     init.headers = opts.headers;
   }
 
-  let response: Response;
   try {
-    response = await doFetch(url, init);
+    const response = await doFetch(url, init);
+
+    const contentLength = Number(response.headers.get("content-length") ?? "0");
+    if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+      throw new FetchCapExceeded(maxBytes, contentLength, url);
+    }
+
+    const buffer = await response.arrayBuffer();
+    const rawBytes = new Uint8Array(buffer);
+    if (rawBytes.byteLength > maxBytes) {
+      throw new FetchCapExceeded(maxBytes, rawBytes.byteLength, url);
+    }
+
+    const contentType = (
+      response.headers.get("content-type") ?? "application/octet-stream"
+    )
+      .split(";")[0]
+      ?.trim()
+      .toLowerCase() ?? "application/octet-stream";
+
+    const dispositionFilename = parseContentDispositionFilename(
+      response.headers.get("content-disposition"),
+    );
+    const rawFilename = dispositionFilename ?? filenameFromUrl(url);
+    const filename = sanitizeLabel(rawFilename, 255);
+
+    const checksum = createHash("sha256").update(rawBytes).digest("hex");
+
+    let extracted: FetchAttachmentResult["extracted"];
+
+    if (contentType.startsWith("text/")) {
+      extracted = {
+        format: "text",
+        text: new TextDecoder("utf-8").decode(rawBytes),
+      };
+    } else if (contentType in MIME_TO_FORMAT) {
+      const fmt = MIME_TO_FORMAT[contentType] as BinaryFormat;
+      const ext = formatExtension(fmt);
+      const tmp = path.join(os.tmpdir(), `toolkit-attach-${randomUUID()}${ext}`);
+      try {
+        fs.writeFileSync(tmp, rawBytes);
+        const r = await extractBinary(tmp, fmt, { maxBytes });
+        extracted = { format: r.format, text: r.text };
+      } catch (e) {
+        extracted = {
+          format: "skipped",
+          text: null,
+          warning: e instanceof Error ? e.message : String(e),
+        };
+      } finally {
+        try {
+          fs.unlinkSync(tmp);
+        } catch {
+          /* best-effort cleanup */
+        }
+      }
+    } else if (FORMAT_MAP[path.extname(filename).toLowerCase()]) {
+      // Server advertised a generic mime (octet-stream etc.) but the filename
+      // extension is one we can extract — still try.
+      const fmt = FORMAT_MAP[path.extname(filename).toLowerCase()] as BinaryFormat;
+      const tmp = path.join(
+        os.tmpdir(),
+        `toolkit-attach-${randomUUID()}${formatExtension(fmt)}`,
+      );
+      try {
+        fs.writeFileSync(tmp, rawBytes);
+        const r = await extractBinary(tmp, fmt, { maxBytes });
+        extracted = { format: r.format, text: r.text };
+      } catch (e) {
+        extracted = {
+          format: "skipped",
+          text: null,
+          warning: e instanceof Error ? e.message : String(e),
+        };
+      } finally {
+        try {
+          fs.unlinkSync(tmp);
+        } catch {
+          /* best-effort cleanup */
+        }
+      }
+    } else {
+      extracted = {
+        format: "skipped",
+        text: null,
+        warning: `Unsupported mime type '${contentType}' — no extractor configured`,
+      };
+    }
+
+    return {
+      rawBytes,
+      contentType,
+      filename,
+      checksum,
+      extracted,
+      sizeBytes: rawBytes.byteLength,
+      sourceUrl: url,
+    };
   } finally {
     clearTimeout(timer);
   }
-
-  const contentLength = Number(response.headers.get("content-length") ?? "0");
-  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
-    throw new FetchCapExceeded(maxBytes, contentLength, url);
-  }
-
-  const buffer = await response.arrayBuffer();
-  const rawBytes = new Uint8Array(buffer);
-  if (rawBytes.byteLength > maxBytes) {
-    throw new FetchCapExceeded(maxBytes, rawBytes.byteLength, url);
-  }
-
-  const contentType = (
-    response.headers.get("content-type") ?? "application/octet-stream"
-  )
-    .split(";")[0]
-    ?.trim()
-    .toLowerCase() ?? "application/octet-stream";
-
-  const dispositionFilename = parseContentDispositionFilename(
-    response.headers.get("content-disposition"),
-  );
-  const rawFilename = dispositionFilename ?? filenameFromUrl(url);
-  const filename = sanitizeLabel(rawFilename, 255);
-
-  const checksum = createHash("sha256").update(rawBytes).digest("hex");
-
-  let extracted: FetchAttachmentResult["extracted"];
-
-  if (contentType.startsWith("text/")) {
-    extracted = {
-      format: "text",
-      text: new TextDecoder("utf-8").decode(rawBytes),
-    };
-  } else if (contentType in MIME_TO_FORMAT) {
-    const fmt = MIME_TO_FORMAT[contentType] as BinaryFormat;
-    const ext = formatExtension(fmt);
-    const tmp = path.join(os.tmpdir(), `toolkit-attach-${randomUUID()}${ext}`);
-    try {
-      fs.writeFileSync(tmp, rawBytes);
-      const r = await extractBinary(tmp, fmt, { maxBytes });
-      extracted = { format: r.format, text: r.text };
-    } catch (e) {
-      extracted = {
-        format: "skipped",
-        text: null,
-        warning: e instanceof Error ? e.message : String(e),
-      };
-    } finally {
-      try {
-        fs.unlinkSync(tmp);
-      } catch {
-        /* best-effort cleanup */
-      }
-    }
-  } else if (FORMAT_MAP[path.extname(filename).toLowerCase()]) {
-    // Server advertised a generic mime (octet-stream etc.) but the filename
-    // extension is one we can extract — still try.
-    const fmt = FORMAT_MAP[path.extname(filename).toLowerCase()] as BinaryFormat;
-    const tmp = path.join(
-      os.tmpdir(),
-      `toolkit-attach-${randomUUID()}${formatExtension(fmt)}`,
-    );
-    try {
-      fs.writeFileSync(tmp, rawBytes);
-      const r = await extractBinary(tmp, fmt, { maxBytes });
-      extracted = { format: r.format, text: r.text };
-    } catch (e) {
-      extracted = {
-        format: "skipped",
-        text: null,
-        warning: e instanceof Error ? e.message : String(e),
-      };
-    } finally {
-      try {
-        fs.unlinkSync(tmp);
-      } catch {
-        /* best-effort cleanup */
-      }
-    }
-  } else {
-    extracted = {
-      format: "skipped",
-      text: null,
-      warning: `Unsupported mime type '${contentType}' — no extractor configured`,
-    };
-  }
-
-  return {
-    rawBytes,
-    contentType,
-    filename,
-    checksum,
-    extracted,
-    sizeBytes: rawBytes.byteLength,
-    sourceUrl: url,
-  };
 }

--- a/tests/toolkit/fetch_attachment.test.ts
+++ b/tests/toolkit/fetch_attachment.test.ts
@@ -61,4 +61,30 @@ describe("fetchAttachment", () => {
       }),
     ).rejects.toThrow();
   });
+
+  it("aborts request if body reading exceeds timeoutMs (Slowloris protection)", async () => {
+    const slowFetch: typeof fetch = (async (_url: unknown, init?: RequestInit) => {
+      // Simulate headers resolving immediately but body trickling slowly
+      return {
+        status: 200,
+        headers: new Headers({ "content-type": "text/plain" }),
+        arrayBuffer: async () => {
+          return new Promise((resolve, reject) => {
+            const onAbort = () => reject(init?.signal?.reason ?? new Error("aborted"));
+            if (init?.signal?.aborted) return onAbort();
+            init?.signal?.addEventListener("abort", onAbort);
+            // Simulate a slow read that takes longer than the timeout
+            setTimeout(() => resolve(new ArrayBuffer(0)), 500);
+          });
+        },
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    await expect(
+      fetchAttachment("https://example.com/slow", {
+        fetchImpl: slowFetch,
+        timeoutMs: 50, // Short timeout
+      }),
+    ).rejects.toThrow();
+  });
 });


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Slowloris DoS in `fetchAttachment` stream reading. The abort controller's `timer` was being cleared in a `finally` block immediately after the initial fetch resolved the headers, leaving the subsequent `await response.arrayBuffer()` completely unbound by the intended `timeoutMs` cap.
🎯 **Impact:** A malicious server (or compromised internal endpoint) could hold the socket open and trickle the response body indefinitely (e.g. 1 byte every 10 minutes), exhausting memory/connections and permanently hanging the application thread without triggering any fetch timeout.
🔧 **Fix:** Expanded the scope of the `try...finally` block. The `clearTimeout(timer)` call now executes after the entire body stream has been fully read and buffered, ensuring the `timeoutMs` correctly applies to the entire download lifecycle (headers + body).
✅ **Verification:** Added a custom Vitest test (`aborts request if body reading exceeds timeoutMs (Slowloris protection)`) simulating a server that resolves headers instantly but delays the body stream. Verified the test accurately fails against the old code and passes against the patched code. All existing tests pass.

---
*PR created automatically by Jules for task [15720968249660293826](https://jules.google.com/task/15720968249660293826) started by @rfv-code*