### PR TITLE
⚡ Bolt: Optimize SQL statement boundaries splitting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,6 @@
 ## 2024-06-25 - Avoid array sort for Top-K in hot paths
 **Learning:** V8 engine sorting (`[...arr].sort()`) is surprisingly slow and blocks the event loop for thousands of records when fetching Top-K elements (e.g. usage statistics). It scales at O(N log N) when O(N) is sufficient for a fixed K.
 **Action:** When gathering top elements from a large data array in this codebase, manually track the top items in a single O(N) pass rather than sorting a full copy.
+## 2024-05-27 - Sequential Array Population Avoids Sorting
+**Learning:** Using `Set<number>` to collect monotonically increasing indices from left-to-right string iteration requires a redundant `Array.from(set).sort(...)` step, introducing $O(N \log N)$ sorting overhead where $O(N)$ is achievable.
+**Action:** Track naturally ordered index sequences using `number[]` arrays and `.push()`, completely eliminating the need for sorting steps.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "narai-primitives",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "narai-primitives",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.119",
         "adf-to-markdown": "^1.0.1",
@@ -5376,22 +5376,6 @@
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
         "node-fetch": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/gcp-metadata": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
-      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
-        "json-bigint": "^1.0.0"
       },
       "engines": {
         "node": ">=18"

--- a/src/connectors/db/lib/policy.ts
+++ b/src/connectors/db/lib/policy.ts
@@ -251,8 +251,8 @@ function _boundarySemicolons(
   sql: string,
   treatBackslashAsEscape: boolean,
   dialect: SqlDialect = "generic",
-): Set<number> {
-  const boundaries = new Set<number>();
+): number[] {
+  const boundaries: number[] = [];
   let inString: string | null = null; // Either null, "'", '"', or '`'
 
   for (let i = 0; i < sql.length; i++) {
@@ -280,7 +280,7 @@ function _boundarySemicolons(
           i = dEnd - 1; // Advance loop to end of dollar quote
         }
       } else if (c === ";") {
-        boundaries.add(i);
+        boundaries.push(i);
       }
     }
   }
@@ -303,14 +303,12 @@ function _boundarySemicolons(
 function _splitStatements(sql: string, dialect: SqlDialect = "generic"): string[] {
   const cleaned = Policy._stripComments(sql, dialect);
 
-  const b1 = _boundarySemicolons(cleaned, false, dialect);
-  const b2 = _boundarySemicolons(cleaned, true, dialect);
+  const b1Array = _boundarySemicolons(cleaned, false, dialect);
+  const b2Array = _boundarySemicolons(cleaned, true, dialect);
 
-  if (b1.size !== b2.size) {
+  if (b1Array.length !== b2Array.length) {
     throw new Error("Ambiguous SQL statement boundaries");
   }
-  const b1Array = Array.from(b1).sort((a, b) => a - b);
-  const b2Array = Array.from(b2).sort((a, b) => a - b);
   for (let i = 0; i < b1Array.length; i++) {
     if (b1Array[i] !== b2Array[i]) {
       throw new Error("Ambiguous SQL statement boundaries");


### PR DESCRIPTION
💡 **What**: Changed `_boundarySemicolons` to return `number[]` instead of `Set<number>`, eliminating the need for `Array.from(set).sort()` inside `_splitStatements`.

🎯 **Why**: When iterating over the SQL string, the loop processes indices strictly from left to right. Pushing the semicolon index `i` into an array guarantees the indices are in increasing order. The use of a `Set` required a conversion to array and a redundant O(N log N) `.sort()` operation.

📊 **Impact**: Removes an unnecessary O(N log N) sorting operation on SQL statement splitting, replacing it with an O(1) `.push()` append per delimiter. Reduces overhead and memory allocation (no `Set` or `Array.from()`).

🔬 **Measurement**: Run the full test suite (`pnpm test`) to verify correctness, specifically focusing on `policy.test.ts` where statement splitting occurs.

---
*PR created automatically by Jules for task [6412043930090151444](https://jules.google.com/task/6412043930090151444) started by @rfv-code*