### PR TITLE
⚡ Bolt: Remove Set and sort overhead in SQL boundary tracking

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,4 @@
 ## 2024-06-25 - Avoid array sort for Top-K in hot paths
 **Learning:** V8 engine sorting (`[...arr].sort()`) is surprisingly slow and blocks the event loop for thousands of records when fetching Top-K elements (e.g. usage statistics). It scales at O(N log N) when O(N) is sufficient for a fixed K.
 **Action:** When gathering top elements from a large data array in this codebase, manually track the top items in a single O(N) pass rather than sorting a full copy.
+## 2026-08-12 - Remove Set and sort overhead in SQL boundary tracking\n**Learning:** When parsing strings to find boundary indices, sequentially pushing to a number array is faster and automatically sorted.\n**Action:** Avoid using `Set` and `Array.from(set).sort()` for simple sequential index tracking to prevent O(N log N) performance bottlenecks.

--- a/src/connectors/db/lib/policy.ts
+++ b/src/connectors/db/lib/policy.ts
@@ -251,8 +251,8 @@ function _boundarySemicolons(
   sql: string,
   treatBackslashAsEscape: boolean,
   dialect: SqlDialect = "generic",
-): Set<number> {
-  const boundaries = new Set<number>();
+): number[] {
+  const boundaries: number[] = [];
   let inString: string | null = null; // Either null, "'", '"', or '`'
 
   for (let i = 0; i < sql.length; i++) {
@@ -280,7 +280,7 @@ function _boundarySemicolons(
           i = dEnd - 1; // Advance loop to end of dollar quote
         }
       } else if (c === ";") {
-        boundaries.add(i);
+        boundaries.push(i);
       }
     }
   }
@@ -303,14 +303,12 @@ function _boundarySemicolons(
 function _splitStatements(sql: string, dialect: SqlDialect = "generic"): string[] {
   const cleaned = Policy._stripComments(sql, dialect);
 
-  const b1 = _boundarySemicolons(cleaned, false, dialect);
-  const b2 = _boundarySemicolons(cleaned, true, dialect);
+  const b1Array = _boundarySemicolons(cleaned, false, dialect);
+  const b2Array = _boundarySemicolons(cleaned, true, dialect);
 
-  if (b1.size !== b2.size) {
+  if (b1Array.length !== b2Array.length) {
     throw new Error("Ambiguous SQL statement boundaries");
   }
-  const b1Array = Array.from(b1).sort((a, b) => a - b);
-  const b2Array = Array.from(b2).sort((a, b) => a - b);
   for (let i = 0; i < b1Array.length; i++) {
     if (b1Array[i] !== b2Array[i]) {
       throw new Error("Ambiguous SQL statement boundaries");


### PR DESCRIPTION
💡 What: Refactored `_boundarySemicolons` in `src/connectors/db/lib/policy.ts` to push sequential indices into a standard array instead of accumulating them in a `Set`. This removes the `Array.from(set).sort()` overhead in `_splitStatements`.

🎯 Why: The parsing loop naturally iterates over the string sequentially (`let i = 0; i < sql.length; i++`). This guarantees that any discovered boundaries are inherently unique and already in ascending order. Using a `Set` followed by a sort introduces unnecessary allocations and an O(N log N) algorithmic bottleneck on large SQL statements.

📊 Impact: Reduces O(N log N) sorting overhead to O(1) appending per boundary, which speeds up compound statement evaluation under load.

🔬 Measurement: Verify by running `pnpm test tests/connectors/db/policy.test.ts`. All 59 tests should pass, confirming behavior remains completely identical.

---
*PR created automatically by Jules for task [17213055597281726997](https://jules.google.com/task/17213055597281726997) started by @rfv-code*