### PR TITLE
⚡ Bolt: Optimize SQL statement boundary extraction

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,6 @@
 ## 2024-06-25 - Avoid array sort for Top-K in hot paths
 **Learning:** V8 engine sorting (`[...arr].sort()`) is surprisingly slow and blocks the event loop for thousands of records when fetching Top-K elements (e.g. usage statistics). It scales at O(N log N) when O(N) is sufficient for a fixed K.
 **Action:** When gathering top elements from a large data array in this codebase, manually track the top items in a single O(N) pass rather than sorting a full copy.
+## 2024-05-15 - Array collection for monotonically increasing indices
+**Learning:** Collecting indices during a sequential string/array pass (e.g. finding statement boundaries) naturally results in a sorted list with unique items. Using a `Set` and subsequently converting to an Array and sorting it (`Array.from(set).sort()`) introduces unnecessary object allocation and O(N log N) sorting overhead for something that is already O(N) and sorted.
+**Action:** When gathering positions/indices during a forward pass over a string or array, use standard arrays (`number[]`) and `.push(i)` to avoid redundant post-processing overhead.

--- a/src/connectors/db/lib/policy.ts
+++ b/src/connectors/db/lib/policy.ts
@@ -251,8 +251,9 @@ function _boundarySemicolons(
   sql: string,
   treatBackslashAsEscape: boolean,
   dialect: SqlDialect = "generic",
-): Set<number> {
-  const boundaries = new Set<number>();
+): number[] {
+  // ⚡ Bolt: Use number[] instead of Set to avoid O(N log N) sorting overhead for monotonically increasing indices.
+  const boundaries: number[] = [];
   let inString: string | null = null; // Either null, "'", '"', or '`'
 
   for (let i = 0; i < sql.length; i++) {
@@ -280,7 +281,7 @@ function _boundarySemicolons(
           i = dEnd - 1; // Advance loop to end of dollar quote
         }
       } else if (c === ";") {
-        boundaries.add(i);
+        boundaries.push(i);
       }
     }
   }
@@ -303,14 +304,12 @@ function _boundarySemicolons(
 function _splitStatements(sql: string, dialect: SqlDialect = "generic"): string[] {
   const cleaned = Policy._stripComments(sql, dialect);
 
-  const b1 = _boundarySemicolons(cleaned, false, dialect);
-  const b2 = _boundarySemicolons(cleaned, true, dialect);
+  const b1Array = _boundarySemicolons(cleaned, false, dialect);
+  const b2Array = _boundarySemicolons(cleaned, true, dialect);
 
-  if (b1.size !== b2.size) {
+  if (b1Array.length !== b2Array.length) {
     throw new Error("Ambiguous SQL statement boundaries");
   }
-  const b1Array = Array.from(b1).sort((a, b) => a - b);
-  const b2Array = Array.from(b2).sort((a, b) => a - b);
   for (let i = 0; i < b1Array.length; i++) {
     if (b1Array[i] !== b2Array[i]) {
       throw new Error("Ambiguous SQL statement boundaries");


### PR DESCRIPTION
💡 **What:** 
Replaced `Set<number>` with a standard `number[]` array in the `_boundarySemicolons` function, and removed the subsequent `Array.from(...).sort(...)` calls in `_splitStatements`.

🎯 **Why:** 
When iterating over a SQL string sequentially (`for (let i = 0; i < sql.length; i++)`), the matched boundary indices are naturally distinct and monotonically increasing. Storing them in a `Set` and then converting to an array to sort it introduces unnecessary object allocations and a redundant $O(N \log N)$ sorting step for data that is already strictly sorted in $O(N)$ time. 

📊 **Impact:** 
Eliminates unnecessary $O(N \log N)$ sorting and Set-to-Array object allocations during SQL statement parsing in the DB connector policy engine, slightly improving throughput for policy evaluation on large, compound SQL scripts without sacrificing any readability.

🔬 **Measurement:** 
Run `pnpm test tests/connectors/db/policy.test.ts` to verify the boundary logic remains exactly correct and passes all existing policy assertions.

---
*PR created automatically by Jules for task [11414394881458612655](https://jules.google.com/task/11414394881458612655) started by @rfv-code*