### PR TITLE
⚡ Bolt: Remove redundant sort and Set allocation in boundary tracking

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,6 @@
 ## 2024-06-25 - Avoid array sort for Top-K in hot paths
 **Learning:** V8 engine sorting (`[...arr].sort()`) is surprisingly slow and blocks the event loop for thousands of records when fetching Top-K elements (e.g. usage statistics). It scales at O(N log N) when O(N) is sufficient for a fixed K.
 **Action:** When gathering top elements from a large data array in this codebase, manually track the top items in a single O(N) pass rather than sorting a full copy.
+## 2024-05-18 - Optimize boundary tracking in string parsing
+**Learning:** When scanning a string left-to-right to collect boundary indexes, the indexes are naturally discovered in monotonically increasing order. Using a `Set` to track these requires later conversion to an array and redundant sorting, introducing unnecessary O(N log N) overhead.
+**Action:** When tracking index positions during sequential string or array iteration, directly use an array (`number[]`) populated with `push()` instead of `Set`s, avoiding redundant sorting.

--- a/src/connectors/db/lib/policy.ts
+++ b/src/connectors/db/lib/policy.ts
@@ -251,8 +251,8 @@ function _boundarySemicolons(
   sql: string,
   treatBackslashAsEscape: boolean,
   dialect: SqlDialect = "generic",
-): Set<number> {
-  const boundaries = new Set<number>();
+): number[] {
+  const boundaries: number[] = [];
   let inString: string | null = null; // Either null, "'", '"', or '`'
 
   for (let i = 0; i < sql.length; i++) {
@@ -280,7 +280,7 @@ function _boundarySemicolons(
           i = dEnd - 1; // Advance loop to end of dollar quote
         }
       } else if (c === ";") {
-        boundaries.add(i);
+        boundaries.push(i);
       }
     }
   }
@@ -306,18 +306,16 @@ function _splitStatements(sql: string, dialect: SqlDialect = "generic"): string[
   const b1 = _boundarySemicolons(cleaned, false, dialect);
   const b2 = _boundarySemicolons(cleaned, true, dialect);
 
-  if (b1.size !== b2.size) {
+  if (b1.length !== b2.length) {
     throw new Error("Ambiguous SQL statement boundaries");
   }
-  const b1Array = Array.from(b1).sort((a, b) => a - b);
-  const b2Array = Array.from(b2).sort((a, b) => a - b);
-  for (let i = 0; i < b1Array.length; i++) {
-    if (b1Array[i] !== b2Array[i]) {
+  for (let i = 0; i < b1.length; i++) {
+    if (b1[i] !== b2[i]) {
       throw new Error("Ambiguous SQL statement boundaries");
     }
   }
 
-  const boundaries = b1Array;
+  const boundaries = b1;
 
   const out: string[] = [];
   let start = 0;


### PR DESCRIPTION
💡 **What:** Replaced `Set<number>` with `number[]` to collect semicolon boundary indexes during sequential SQL parsing. Because the string is processed left-to-right, indexes naturally append in monotonically increasing order, making `Set` insertion and subsequent sorting redundant.
🎯 **Why:** To eliminate unnecessary O(N) allocation of a `Set`, O(N) array conversion, and O(N log N) array sorting overhead in `_splitStatements` every time a query is evaluated by the policy engine.
📊 **Impact:** Reduces time complexity for boundary sorting from O(N log N) to O(1) by removing the step entirely, reducing garbage collection pressure and speeding up policy checks on large compound statements.
🔬 **Measurement:** Verified via Vitest (`pnpm test tests/connectors/db/policy.test.ts`), which passes instantly.

---
*PR created automatically by Jules for task [14996889039220027532](https://jules.google.com/task/14996889039220027532) started by @rfv-code*