### PR TITLE
⚡ Bolt: Replace Set with Array to eliminate O(N log N) sorting in SQL parser

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,6 @@
 ## 2024-06-25 - Avoid array sort for Top-K in hot paths
 **Learning:** V8 engine sorting (`[...arr].sort()`) is surprisingly slow and blocks the event loop for thousands of records when fetching Top-K elements (e.g. usage statistics). It scales at O(N log N) when O(N) is sufficient for a fixed K.
 **Action:** When gathering top elements from a large data array in this codebase, manually track the top items in a single O(N) pass rather than sorting a full copy.
+## 2026-05-25 - Avoid Sets for sequential iteration tracking
+**Learning:** Using a `Set` to track index positions during string parsing and later converting it to an array and sorting it with `Array.from(set).sort((a,b) => a-b)` is redundant and introduces an O(N log N) bottleneck. String loops naturally produce monotonically increasing indices.
+**Action:** When gathering boundary positions in a sequential loop (like SQL parsing), push directly to a standard `number[]` array and skip sorting entirely.

--- a/src/connectors/db/lib/policy.ts
+++ b/src/connectors/db/lib/policy.ts
@@ -251,8 +251,9 @@ function _boundarySemicolons(
   sql: string,
   treatBackslashAsEscape: boolean,
   dialect: SqlDialect = "generic",
-): Set<number> {
-  const boundaries = new Set<number>();
+): number[] {
+  // ⚡ Bolt: Replace Set with a simple sequentially populated array to avoid O(N log N) sorting
+  const boundaries: number[] = [];
   let inString: string | null = null; // Either null, "'", '"', or '`'
 
   for (let i = 0; i < sql.length; i++) {
@@ -280,7 +281,7 @@ function _boundarySemicolons(
           i = dEnd - 1; // Advance loop to end of dollar quote
         }
       } else if (c === ";") {
-        boundaries.add(i);
+        boundaries.push(i);
       }
     }
   }
@@ -306,18 +307,16 @@ function _splitStatements(sql: string, dialect: SqlDialect = "generic"): string[
   const b1 = _boundarySemicolons(cleaned, false, dialect);
   const b2 = _boundarySemicolons(cleaned, true, dialect);
 
-  if (b1.size !== b2.size) {
+  if (b1.length !== b2.length) {
     throw new Error("Ambiguous SQL statement boundaries");
   }
-  const b1Array = Array.from(b1).sort((a, b) => a - b);
-  const b2Array = Array.from(b2).sort((a, b) => a - b);
-  for (let i = 0; i < b1Array.length; i++) {
-    if (b1Array[i] !== b2Array[i]) {
+  for (let i = 0; i < b1.length; i++) {
+    if (b1[i] !== b2[i]) {
       throw new Error("Ambiguous SQL statement boundaries");
     }
   }
 
-  const boundaries = b1Array;
+  const boundaries = b1;
 
   const out: string[] = [];
   let start = 0;


### PR DESCRIPTION
💡 What: Replaced a `Set<number>` with a sequentially populated `number[]` array in the `_boundarySemicolons` function, which eliminated the need for a redundant `Array.from(b).sort((a,b) => a-b)` step in `_splitStatements`.

🎯 Why: During string/SQL statement splitting, character indices are naturally processed in a sequentially increasing order (0, 1, 2...). Placing these indices into a `Set` and subsequently sorting them is redundant and introduces an unnecessary O(N log N) performance bottleneck (as well as `Set` object creation overhead) when an O(N) array push is perfectly sufficient.

📊 Impact: Reduces memory allocation (avoiding Set -> Array conversions) and eliminates an O(N log N) sorting step for every compound SQL query processed by the engine.

🔬 Measurement: Verify by executing the test suite (`pnpm test tests/connectors/db/policy.test.ts`), which ensures no regressions in the SQL statement splitting bounds logic.

---
*PR created automatically by Jules for task [5091237778420047036](https://jules.google.com/task/5091237778420047036) started by @rfv-code*