### PR TITLE
⚡ Bolt: Eliminate O(N log N) overhead in SQL boundary detection

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,6 @@
 ## 2024-06-25 - Avoid array sort for Top-K in hot paths
 **Learning:** V8 engine sorting (`[...arr].sort()`) is surprisingly slow and blocks the event loop for thousands of records when fetching Top-K elements (e.g. usage statistics). It scales at O(N log N) when O(N) is sufficient for a fixed K.
 **Action:** When gathering top elements from a large data array in this codebase, manually track the top items in a single O(N) pass rather than sorting a full copy.
+## 2024-05-18 - Avoid Set for sequential index tracking
+**Learning:** Using `Set` to track index boundaries during sequential string parsing introduces unnecessary O(N log N) overhead when later converted to an array and sorted, because sequential loops naturally produce monotonically increasing indices.
+**Action:** Use standard arrays (`number[]`) and populate them sequentially (`push`) instead of `Set`s when iterating forward through a string.

--- a/src/connectors/db/lib/policy.ts
+++ b/src/connectors/db/lib/policy.ts
@@ -251,8 +251,11 @@ function _boundarySemicolons(
   sql: string,
   treatBackslashAsEscape: boolean,
   dialect: SqlDialect = "generic",
-): Set<number> {
-  const boundaries = new Set<number>();
+): number[] {
+  // Bolt: Use standard arrays instead of Set to avoid O(N log N) overhead
+  // from subsequent Array.from().sort() conversion, since sequential loops
+  // naturally produce monotonically increasing indices.
+  const boundaries: number[] = [];
   let inString: string | null = null; // Either null, "'", '"', or '`'
 
   for (let i = 0; i < sql.length; i++) {
@@ -280,7 +283,7 @@ function _boundarySemicolons(
           i = dEnd - 1; // Advance loop to end of dollar quote
         }
       } else if (c === ";") {
-        boundaries.add(i);
+        boundaries.push(i);
       }
     }
   }
@@ -303,14 +306,12 @@ function _boundarySemicolons(
 function _splitStatements(sql: string, dialect: SqlDialect = "generic"): string[] {
   const cleaned = Policy._stripComments(sql, dialect);
 
-  const b1 = _boundarySemicolons(cleaned, false, dialect);
-  const b2 = _boundarySemicolons(cleaned, true, dialect);
+  const b1Array = _boundarySemicolons(cleaned, false, dialect);
+  const b2Array = _boundarySemicolons(cleaned, true, dialect);
 
-  if (b1.size !== b2.size) {
+  if (b1Array.length !== b2Array.length) {
     throw new Error("Ambiguous SQL statement boundaries");
   }
-  const b1Array = Array.from(b1).sort((a, b) => a - b);
-  const b2Array = Array.from(b2).sort((a, b) => a - b);
   for (let i = 0; i < b1Array.length; i++) {
     if (b1Array[i] !== b2Array[i]) {
       throw new Error("Ambiguous SQL statement boundaries");


### PR DESCRIPTION
💡 What: Replaced `Set<number>` with a standard `number[]` for tracking semicolon boundaries in `_boundarySemicolons`, and removed the subsequent `Array.from(...).sort(...)` call.
🎯 Why: The sequential loop over the SQL string naturally produces monotonically increasing indices. Storing these in a Set only to immediately convert and sort them introduces unnecessary O(N log N) overhead for what is inherently an O(N) operation.
📊 Impact: Eliminates redundant sorting and Set-to-Array conversions in the hot path of the SQL policy parsing engine, improving the performance of `_splitStatements`.
🔬 Measurement: Verified by running `pnpm test tests/connectors/db/policy.test.ts`. All 59 tests continue to pass with the optimization in place.

---
*PR created automatically by Jules for task [9816159023107403100](https://jules.google.com/task/9816159023107403100) started by @rfv-code*