### PR TITLE
⚡ Bolt: Replace Set with Array for sequential boundary tracking

### DIFF
--- a/src/connectors/db/lib/policy.ts
+++ b/src/connectors/db/lib/policy.ts
@@ -251,8 +251,11 @@ function _boundarySemicolons(
   sql: string,
   treatBackslashAsEscape: boolean,
   dialect: SqlDialect = "generic",
-): Set<number> {
-  const boundaries = new Set<number>();
+): number[] {
+  // ⚡ Bolt: Replace Set<number> with number[] for sequential loop parsing.
+  // Pushing sequentially inherently keeps the array sorted and avoids an
+  // unnecessary O(N log N) sorting step later in _splitStatements.
+  const boundaries: number[] = [];
   let inString: string | null = null; // Either null, "'", '"', or '`'
 
   for (let i = 0; i < sql.length; i++) {
@@ -280,7 +283,7 @@ function _boundarySemicolons(
           i = dEnd - 1; // Advance loop to end of dollar quote
         }
       } else if (c === ";") {
-        boundaries.add(i);
+        boundaries.push(i);
       }
     }
   }
@@ -303,14 +306,12 @@ function _boundarySemicolons(
 function _splitStatements(sql: string, dialect: SqlDialect = "generic"): string[] {
   const cleaned = Policy._stripComments(sql, dialect);
 
-  const b1 = _boundarySemicolons(cleaned, false, dialect);
-  const b2 = _boundarySemicolons(cleaned, true, dialect);
+  const b1Array = _boundarySemicolons(cleaned, false, dialect);
+  const b2Array = _boundarySemicolons(cleaned, true, dialect);
 
-  if (b1.size !== b2.size) {
+  if (b1Array.length !== b2Array.length) {
     throw new Error("Ambiguous SQL statement boundaries");
   }
-  const b1Array = Array.from(b1).sort((a, b) => a - b);
-  const b2Array = Array.from(b2).sort((a, b) => a - b);
   for (let i = 0; i < b1Array.length; i++) {
     if (b1Array[i] !== b2Array[i]) {
       throw new Error("Ambiguous SQL statement boundaries");


### PR DESCRIPTION
💡 **What:** Replaced the use of `Set<number>` with `number[]` in `_boundarySemicolons` and eliminated the subsequent `Array.from(...).sort(...)` calls in `_splitStatements`.

🎯 **Why:** The parsing loop in `_boundarySemicolons` processes the SQL string strictly sequentially from left to right. Any semicolon boundary discovered is inherently greater than the last. Accumulating these in a Set and then sorting them is redundant and introduces an unnecessary `O(N log N)` computational overhead to a critical, frequently-called parsing path. 

📊 **Impact:** Reduces memory allocation overhead (Arrays vs Sets) and changes the statement-splitting time complexity for boundary sorting from `O(N log N)` to strict `O(N)`.

🔬 **Measurement:** Code logic confirmed by existing test suite. `pnpm test tests/connectors/db/policy.test.ts` passes successfully, validating that statement boundaries are still parsed accurately across all dialects.

---
*PR created automatically by Jules for task [1706588776754965364](https://jules.google.com/task/1706588776754965364) started by @rfv-code*