### PR TITLE
⚡ Bolt: Optimize SQL statement boundary tracking by replacing Set with Array

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,6 @@
 ## 2024-06-25 - Avoid array sort for Top-K in hot paths
 **Learning:** V8 engine sorting (`[...arr].sort()`) is surprisingly slow and blocks the event loop for thousands of records when fetching Top-K elements (e.g. usage statistics). It scales at O(N log N) when O(N) is sufficient for a fixed K.
 **Action:** When gathering top elements from a large data array in this codebase, manually track the top items in a single O(N) pass rather than sorting a full copy.
+## 2024-05-30 - Replace Set with Array for Sequential Index Collection
+**Learning:** In string parsing functions tracking boundary indices (like semicolons in SQL), using `Set<number>` for uniqueness causes overhead during conversion `Array.from(set)` and redundant `sort()` calls. Because parsing loops are sequential (increasing `i`), a regular `number[]` array populated via `.push(i)` naturally produces monotonically increasing, unique indices without O(N log N) sorting overhead.
+**Action:** When tracking index positions during sequential iteration, use standard arrays (`number[]`) populated via `.push()` instead of `Set`s that require subsequent conversion and sorting.

--- a/src/connectors/db/lib/policy.ts
+++ b/src/connectors/db/lib/policy.ts
@@ -251,8 +251,8 @@ function _boundarySemicolons(
   sql: string,
   treatBackslashAsEscape: boolean,
   dialect: SqlDialect = "generic",
-): Set<number> {
-  const boundaries = new Set<number>();
+): number[] {
+  const boundaries: number[] = [];
   let inString: string | null = null; // Either null, "'", '"', or '`'
 
   for (let i = 0; i < sql.length; i++) {
@@ -280,7 +280,7 @@ function _boundarySemicolons(
           i = dEnd - 1; // Advance loop to end of dollar quote
         }
       } else if (c === ";") {
-        boundaries.add(i);
+        boundaries.push(i);
       }
     }
   }
@@ -306,18 +306,16 @@ function _splitStatements(sql: string, dialect: SqlDialect = "generic"): string[
   const b1 = _boundarySemicolons(cleaned, false, dialect);
   const b2 = _boundarySemicolons(cleaned, true, dialect);
 
-  if (b1.size !== b2.size) {
+  if (b1.length !== b2.length) {
     throw new Error("Ambiguous SQL statement boundaries");
   }
-  const b1Array = Array.from(b1).sort((a, b) => a - b);
-  const b2Array = Array.from(b2).sort((a, b) => a - b);
-  for (let i = 0; i < b1Array.length; i++) {
-    if (b1Array[i] !== b2Array[i]) {
+  for (let i = 0; i < b1.length; i++) {
+    if (b1[i] !== b2[i]) {
       throw new Error("Ambiguous SQL statement boundaries");
     }
   }
 
-  const boundaries = b1Array;
+  const boundaries = b1;
 
   const out: string[] = [];
   let start = 0;


### PR DESCRIPTION
💡 What: Modified `_boundarySemicolons` in `src/connectors/db/lib/policy.ts` to return a `number[]` array instead of a `Set<number>`, appending to it using `.push()`. Updated `_splitStatements` to rely on the arrays directly, removing the `Array.from()` conversion and `.sort()` operations.
🎯 Why: Because the `for` loop iteration index `i` is strictly increasing during string parsing, the tracking of semicolon boundaries naturally produces a monotonically increasing set of indices. Allocating a `Set`, hashing each insertion, converting back to an Array, and calling `.sort()` introduces unnecessary O(N log N) overhead on an array that is inherently sorted.
📊 Impact: Eliminates O(N log N) overhead and memory allocations from `Set` initialization and conversion in the SQL policy evaluation hot-path, making statement splitting measurably more efficient on larger SQL scripts.
🔬 Measurement: Verify changes manually via `pnpm test tests/connectors/db/policy.test.ts` and standard suite execution.

---
*PR created automatically by Jules for task [7526801084259754452](https://jules.google.com/task/7526801084259754452) started by @rfv-code*