### PR TITLE
⚡ Bolt: Replace Set with Array for O(N) boundary tracking

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,6 @@
 ## 2024-06-25 - Avoid array sort for Top-K in hot paths
 **Learning:** V8 engine sorting (`[...arr].sort()`) is surprisingly slow and blocks the event loop for thousands of records when fetching Top-K elements (e.g. usage statistics). It scales at O(N log N) when O(N) is sufficient for a fixed K.
 **Action:** When gathering top elements from a large data array in this codebase, manually track the top items in a single O(N) pass rather than sorting a full copy.
+## 2024-05-18 - Avoid Set and sorting for monotonically increasing boundary tracking
+**Learning:** In SQL parsing (`src/connectors/db/lib/policy.ts`), `_boundarySemicolons` used a `Set<number>` to track semicolon indices, which were then converted to an array and sorted via `Array.from(set).sort((a,b) => a-b)`. Since the loop iterates over the string sequentially (`for let i=0...`), the indices are naturally monotonically increasing and unique.
+**Action:** Always use an array (`number[]`) with `push()` instead of a `Set` when tracking positions during sequential string/array iteration. This eliminates unnecessary Set allocation and subsequent $O(N \log N)$ sorting overhead, reducing it to $O(N)$.

--- a/src/connectors/db/lib/policy.ts
+++ b/src/connectors/db/lib/policy.ts
@@ -251,8 +251,8 @@ function _boundarySemicolons(
   sql: string,
   treatBackslashAsEscape: boolean,
   dialect: SqlDialect = "generic",
-): Set<number> {
-  const boundaries = new Set<number>();
+): number[] {
+  const boundaries: number[] = [];
   let inString: string | null = null; // Either null, "'", '"', or '`'
 
   for (let i = 0; i < sql.length; i++) {
@@ -280,7 +280,7 @@ function _boundarySemicolons(
           i = dEnd - 1; // Advance loop to end of dollar quote
         }
       } else if (c === ";") {
-        boundaries.add(i);
+        boundaries.push(i);
       }
     }
   }
@@ -306,18 +306,16 @@ function _splitStatements(sql: string, dialect: SqlDialect = "generic"): string[
   const b1 = _boundarySemicolons(cleaned, false, dialect);
   const b2 = _boundarySemicolons(cleaned, true, dialect);
 
-  if (b1.size !== b2.size) {
+  if (b1.length !== b2.length) {
     throw new Error("Ambiguous SQL statement boundaries");
   }
-  const b1Array = Array.from(b1).sort((a, b) => a - b);
-  const b2Array = Array.from(b2).sort((a, b) => a - b);
-  for (let i = 0; i < b1Array.length; i++) {
-    if (b1Array[i] !== b2Array[i]) {
+  for (let i = 0; i < b1.length; i++) {
+    if (b1[i] !== b2[i]) {
       throw new Error("Ambiguous SQL statement boundaries");
     }
   }
 
-  const boundaries = b1Array;
+  const boundaries = b1;
 
   const out: string[] = [];
   let start = 0;


### PR DESCRIPTION
💡 What: Replaced a `Set<number>` with a `number[]` array in `_boundarySemicolons` (SQL policy parser) and removed the subsequent `Array.from(...).sort()` conversion.
🎯 Why: Because the string is parsed strictly left-to-right (`i = 0` to `sql.length`), any boundary indices encountered are naturally sorted and unique. Allocating a Set and sorting it afterwards introduced unnecessary $O(N \log N)$ overhead that blocks the Node event loop on large queries.
📊 Impact: Changes O(N log N) Set conversion and sorting to O(N) array pushes. Reduces CPU time spent parsing compound SQL statements.
🔬 Measurement: Verify changes in `src/connectors/db/lib/policy.ts` and ensure `tests/connectors/db/policy.test.ts` passes.

---
*PR created automatically by Jules for task [17597187335611243452](https://jules.google.com/task/17597187335611243452) started by @rfv-code*