### PR TITLE
⚡ Bolt: Replace Set sorting with O(N) array tracking for SQL statement parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,6 @@
 ## 2024-06-25 - Avoid array sort for Top-K in hot paths
 **Learning:** V8 engine sorting (`[...arr].sort()`) is surprisingly slow and blocks the event loop for thousands of records when fetching Top-K elements (e.g. usage statistics). It scales at O(N log N) when O(N) is sufficient for a fixed K.
 **Action:** When gathering top elements from a large data array in this codebase, manually track the top items in a single O(N) pass rather than sorting a full copy.
+## 2024-05-18 - Sequential string loop sets vs arrays
+**Learning:** When collecting match/boundary indices by iterating over a string sequentially, accumulating into a `Set` and then converting to an Array and sorting it (`Array.from(b1).sort()`) introduces unnecessary O(N log N) performance overhead. Because the string index only moves forward, an `Array` using `.push()` naturally produces a deduplicated, strictly monotonically increasing sequence of indices.
+**Action:** When tracking index positions during string or array iteration, use standard arrays (`number[]`) populated sequentially rather than `Set`s that require subsequent conversion and sorting.

--- a/src/connectors/db/lib/policy.ts
+++ b/src/connectors/db/lib/policy.ts
@@ -251,8 +251,8 @@ function _boundarySemicolons(
   sql: string,
   treatBackslashAsEscape: boolean,
   dialect: SqlDialect = "generic",
-): Set<number> {
-  const boundaries = new Set<number>();
+): number[] {
+  const boundaries: number[] = [];
   let inString: string | null = null; // Either null, "'", '"', or '`'
 
   for (let i = 0; i < sql.length; i++) {
@@ -280,7 +280,7 @@ function _boundarySemicolons(
           i = dEnd - 1; // Advance loop to end of dollar quote
         }
       } else if (c === ";") {
-        boundaries.add(i);
+        boundaries.push(i);
       }
     }
   }
@@ -306,18 +306,19 @@ function _splitStatements(sql: string, dialect: SqlDialect = "generic"): string[
   const b1 = _boundarySemicolons(cleaned, false, dialect);
   const b2 = _boundarySemicolons(cleaned, true, dialect);
 
-  if (b1.size !== b2.size) {
+  if (b1.length !== b2.length) {
     throw new Error("Ambiguous SQL statement boundaries");
   }
-  const b1Array = Array.from(b1).sort((a, b) => a - b);
-  const b2Array = Array.from(b2).sort((a, b) => a - b);
-  for (let i = 0; i < b1Array.length; i++) {
-    if (b1Array[i] !== b2Array[i]) {
+
+  // ⚡ Bolt: No sorting needed. Array indices from sequential string iteration
+  // are guaranteed to be monotonically increasing.
+  for (let i = 0; i < b1.length; i++) {
+    if (b1[i] !== b2[i]) {
       throw new Error("Ambiguous SQL statement boundaries");
     }
   }
 
-  const boundaries = b1Array;
+  const boundaries = b1;
 
   const out: string[] = [];
   let start = 0;


### PR DESCRIPTION
💡 What:
Replaced the `Set<number>` used in `_boundarySemicolons` with a `number[]` array using `.push()`. In `_splitStatements`, removed the `Array.from(set).sort()` calls.

🎯 Why:
The string parsing loop's index `i` inherently only advances forward. Therefore, indices added to the collection are naturally deduplicated and already perfectly sorted in strictly increasing order. The use of a Set, followed by array conversion and sorting, introduced unnecessary O(N log N) performance overhead for an operation that is inherently O(N).

📊 Impact:
Removes redundant O(N log N) sorting steps and the overhead of Set tracking in a hot path related to SQL policy classification, converting it to an exact O(N) operation.

🔬 Measurement:
Run the test suite `pnpm test tests/connectors/db/policy.test.ts` to ensure that statement boundaries continue to be accurately parsed. Test suite passes successfully, proving semantic parity with improved execution efficiency.

---
*PR created automatically by Jules for task [244505090937722012](https://jules.google.com/task/244505090937722012) started by @rfv-code*